### PR TITLE
Support codesets for old-style versions

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -35,7 +35,7 @@ repos:
     - id: detect-private-key
 
   - repo: https://github.com/jumanjihouse/pre-commit-hooks
-    rev: 2.1.4
+    rev: 2.1.5
     hooks:
     - id: shellcheck
 

--- a/codelists/models.py
+++ b/codelists/models.py
@@ -247,9 +247,15 @@ class CodelistVersion(models.Model):
         """Return Codeset for the codes related to this CodelistVersion."""
 
         if self.csv_data:
-            # We don't need a Codeset for an old-style codelist
-            return None
+            return self._old_style_codeset()
+        else:
+            return self._new_style_codeset()
 
+    def _old_style_codeset(self):
+        hierarchy = Hierarchy.from_codes(self.coding_system, self.codes)
+        return Codeset.from_codes(set(self.codes), hierarchy)
+
+    def _new_style_codeset(self):
         code_to_status = dict(self.code_objs.values_list("code", "status"))
         hierarchy = Hierarchy.from_codes(self.coding_system, list(code_to_status))
         return Codeset(code_to_status, hierarchy)

--- a/codelists/tests/test_models.py
+++ b/codelists/tests/test_models.py
@@ -57,6 +57,10 @@ def test_old_style_table(old_style_version):
     ]
 
 
+def test_old_style_codeset(old_style_version):
+    assert old_style_version.codeset.codes() == set(old_style_version.codes)
+
+
 def test_new_style_codes(version_with_some_searches):
     assert version_with_some_searches.codes == (
         "128133004",
@@ -82,6 +86,12 @@ def test_new_style_table(version_with_some_searches):
         ["439656005", "Arthritis of elbow"],
         ["73583000", "Epicondylitis"],
     ]
+
+
+def test_new_style_codeset(version_with_some_searches):
+    assert version_with_some_searches.codeset.codes() == set(
+        version_with_some_searches.codes
+    )
 
 
 def test_old_style_is_new_style(old_style_codelist):


### PR DESCRIPTION
This fixes the broken "Download Definition" link for old-style versions.