### PR TITLE
Fix bug in icd10.code_to_term

### DIFF
--- a/coding_systems/icd10/fixtures/README
+++ b/coding_systems/icd10/fixtures/README
@@ -1,0 +1,7 @@
+This directory contains the JSON fixture containing a slice of the ICD-10 hierarchy.
+
+It was generated with:
+
+./manage.py generate_icd10_hierarchy_fixture A77 M77 --path coding_systems/icd10/fixtures/icd10.json
+
+using data from icdClaML2019en.xml.

--- a/coding_systems/icd10/fixtures/icd10.json
+++ b/coding_systems/icd10/fixtures/icd10.json
@@ -1,0 +1,191 @@
+[
+  {
+    "model": "icd10.concept",
+    "pk": "A75-A79",
+    "fields": {
+      "kind": "block",
+      "term": "Rickettsioses",
+      "parent": "I"
+    }
+  },
+  {
+    "model": "icd10.concept",
+    "pk": "A77",
+    "fields": {
+      "kind": "category",
+      "term": "Spotted fever [tick-borne rickettsioses]",
+      "parent": "A75-A79"
+    }
+  },
+  {
+    "model": "icd10.concept",
+    "pk": "A770",
+    "fields": {
+      "kind": "category",
+      "term": "Spotted fever due to Rickettsia rickettsii",
+      "parent": "A77"
+    }
+  },
+  {
+    "model": "icd10.concept",
+    "pk": "A771",
+    "fields": {
+      "kind": "category",
+      "term": "Spotted fever due to Rickettsia conorii",
+      "parent": "A77"
+    }
+  },
+  {
+    "model": "icd10.concept",
+    "pk": "A772",
+    "fields": {
+      "kind": "category",
+      "term": "Spotted fever due to Rickettsia sibirica",
+      "parent": "A77"
+    }
+  },
+  {
+    "model": "icd10.concept",
+    "pk": "A773",
+    "fields": {
+      "kind": "category",
+      "term": "Spotted fever due to Rickettsia australis",
+      "parent": "A77"
+    }
+  },
+  {
+    "model": "icd10.concept",
+    "pk": "A778",
+    "fields": {
+      "kind": "category",
+      "term": "Other spotted fevers",
+      "parent": "A77"
+    }
+  },
+  {
+    "model": "icd10.concept",
+    "pk": "A779",
+    "fields": {
+      "kind": "category",
+      "term": "Spotted fever, unspecified",
+      "parent": "A77"
+    }
+  },
+  {
+    "model": "icd10.concept",
+    "pk": "I",
+    "fields": {
+      "kind": "chapter",
+      "term": "Certain infectious and parasitic diseases",
+      "parent": null
+    }
+  },
+  {
+    "model": "icd10.concept",
+    "pk": "M60-M79",
+    "fields": {
+      "kind": "block",
+      "term": "Soft tissue disorders",
+      "parent": "XIII"
+    }
+  },
+  {
+    "model": "icd10.concept",
+    "pk": "M70-M79",
+    "fields": {
+      "kind": "block",
+      "term": "Other soft tissue disorders",
+      "parent": "M60-M79"
+    }
+  },
+  {
+    "model": "icd10.concept",
+    "pk": "M77",
+    "fields": {
+      "kind": "category",
+      "term": "Other enthesopathies",
+      "parent": "M70-M79"
+    }
+  },
+  {
+    "model": "icd10.concept",
+    "pk": "M770",
+    "fields": {
+      "kind": "category",
+      "term": "Medial epicondylitis",
+      "parent": "M77"
+    }
+  },
+  {
+    "model": "icd10.concept",
+    "pk": "M771",
+    "fields": {
+      "kind": "category",
+      "term": "Lateral epicondylitis",
+      "parent": "M77"
+    }
+  },
+  {
+    "model": "icd10.concept",
+    "pk": "M772",
+    "fields": {
+      "kind": "category",
+      "term": "Periarthritis of wrist",
+      "parent": "M77"
+    }
+  },
+  {
+    "model": "icd10.concept",
+    "pk": "M773",
+    "fields": {
+      "kind": "category",
+      "term": "Calcaneal spur",
+      "parent": "M77"
+    }
+  },
+  {
+    "model": "icd10.concept",
+    "pk": "M774",
+    "fields": {
+      "kind": "category",
+      "term": "Metatarsalgia",
+      "parent": "M77"
+    }
+  },
+  {
+    "model": "icd10.concept",
+    "pk": "M775",
+    "fields": {
+      "kind": "category",
+      "term": "Other enthesopathy of foot",
+      "parent": "M77"
+    }
+  },
+  {
+    "model": "icd10.concept",
+    "pk": "M778",
+    "fields": {
+      "kind": "category",
+      "term": "Other enthesopathies, not elsewhere classified",
+      "parent": "M77"
+    }
+  },
+  {
+    "model": "icd10.concept",
+    "pk": "M779",
+    "fields": {
+      "kind": "category",
+      "term": "Enthesopathy, unspecified",
+      "parent": "M77"
+    }
+  },
+  {
+    "model": "icd10.concept",
+    "pk": "XIII",
+    "fields": {
+      "kind": "chapter",
+      "term": "Diseases of the musculoskeletal system and connective tissue",
+      "parent": null
+    }
+  }
+]

--- a/coding_systems/icd10/management/commands/generate_icd10_hierarchy_fixture.py
+++ b/coding_systems/icd10/management/commands/generate_icd10_hierarchy_fixture.py
@@ -1,0 +1,50 @@
+"""
+Generate a JSON fixture containing every Concept related to Concepts with given codes.
+
+The generated fixture can be loaded with `loaddata`.
+"""
+from operator import attrgetter
+
+from django.core import serializers
+from django.core.management import BaseCommand
+
+from ...models import Concept
+
+
+class Command(BaseCommand):
+    help = __doc__
+
+    def add_arguments(self, parser):
+        parser.add_argument("codes", nargs="+", help="Codes of concepts to start from")
+        parser.add_argument("--path", help="Path to write fixture to")
+
+    def handle(self, path, codes, **kwargs):
+        starting_concepts = Concept.objects.filter(pk__in=codes)
+        assert len(codes) == starting_concepts.count()
+        concepts = set()
+
+        # Walk up the hierarchy
+        todo = list(starting_concepts)
+
+        while todo:
+            concept = todo.pop()
+            print(concept.code, concept.term)
+            concepts.add(concept)
+
+            if concept.parent is not None:
+                todo.append(concept.parent)
+
+        # Walk down the hierarchy
+        todo = list(starting_concepts)
+
+        while todo:
+            concept = todo.pop()
+            print(concept.code, concept.term)
+            concepts.add(concept)
+
+            todo.extend(concept.children.all())
+
+        concepts = sorted(concepts, key=attrgetter("pk"))
+
+        with open(path, "w") as f:
+            serializers.serialize("json", concepts, stream=f, indent=2)

--- a/coding_systems/icd10/tests.py
+++ b/coding_systems/icd10/tests.py
@@ -1,0 +1,12 @@
+from coding_systems.icd10.coding_system import codes_by_type
+
+
+def test_codes_by_type(icd10_data):
+    assert codes_by_type(["A771", "M77", "M770", "M779"], None) == {
+        "I: Certain infectious and parasitic diseases": ["A771"],
+        "XIII: Diseases of the musculoskeletal system and connective tissue": [
+            "M77",
+            "M770",
+            "M779",
+        ],
+    }


### PR DESCRIPTION
Previously, codes at the end of a block (eg M779 in block M75-M77) were
not captured correctly.