### PR TITLE
Don't redirect from codelist to builder

### DIFF
--- a/codelists/models.py
+++ b/codelists/models.py
@@ -123,6 +123,12 @@ class Codelist(models.Model):
         else:
             return user.is_member(self.organisation)
 
+    def latest_version(self):
+        """Return latest version that's not being edited, or None if no such version
+        exists."""
+
+        return self.versions.filter(draft_owner__isnull=True).order_by("id").last()
+
 
 class CodelistVersion(models.Model):
     codelist = models.ForeignKey(

--- a/codelists/tests/test_models.py
+++ b/codelists/tests/test_models.py
@@ -1,6 +1,7 @@
 import pytest
 from django.db.utils import IntegrityError
 
+from codelists.actions import export_to_builder
 from codelists.models import Codelist, CodelistVersion
 from opencodelists.tests.factories import OrganisationFactory, UserFactory
 
@@ -100,6 +101,23 @@ def test_old_style_is_new_style(old_style_codelist):
 
 def test_new_style_is_new_style(new_style_codelist):
     assert new_style_codelist.is_new_style()
+
+
+def test_latest_version(
+    new_style_codelist, version_with_complete_searches, organisation_user
+):
+    # Check that the latest version is the last created version
+    assert new_style_codelist.latest_version() == version_with_complete_searches
+
+    # Create a new draft version
+    export_to_builder(version=version_with_complete_searches, owner=organisation_user)
+
+    # Check that the latest version is unchanged
+    assert new_style_codelist.latest_version() == version_with_complete_searches
+
+
+def test_latest_version_for_new_codelist(codelist_from_scratch, organisation_user):
+    assert codelist_from_scratch.latest_version() is None
 
 
 def test_get_by_hash(new_style_version):

--- a/codelists/tests/views/test_codelist.py
+++ b/codelists/tests/views/test_codelist.py
@@ -1,23 +1,18 @@
-from ..factories import create_published_version, create_published_version_for_user
-
-
-def test_get_for_organisation(client):
-    clv = create_published_version()
-    cl = clv.codelist
-
-    response = client.get(cl.get_absolute_url())
-
-    # check redirect to the correct version page
+def test_get_for_organisation_owned_codelist(
+    client, new_style_codelist, version_with_complete_searches
+):
+    response = client.get(new_style_codelist.get_absolute_url())
     assert response.status_code == 302
-    assert response.url == clv.get_absolute_url()
+    assert response.url == version_with_complete_searches.get_absolute_url()
 
 
-def test_get_for_user(client):
-    clv = create_published_version_for_user()
-    cl = clv.codelist
-
-    response = client.get(cl.get_absolute_url())
-
-    # check redirect to the correct version page
+def test_get_for_user_owned_codelist(client, user_codelist, user_version):
+    response = client.get(user_codelist.get_absolute_url())
     assert response.status_code == 302
-    assert response.url == clv.get_absolute_url()
+    assert response.url == user_version.get_absolute_url()
+
+
+def test_get_for_new_codelist(client, codelist_from_scratch):
+    response = client.get(codelist_from_scratch.get_absolute_url())
+    assert response.status_code == 302
+    assert response.url == "/"

--- a/codelists/views/codelist.py
+++ b/codelists/views/codelist.py
@@ -1,3 +1,4 @@
+from django.contrib import messages
 from django.shortcuts import redirect
 
 from .decorators import load_codelist
@@ -5,5 +6,11 @@ from .decorators import load_codelist
 
 @load_codelist
 def codelist(request, codelist):
-    clv = codelist.versions.order_by("created_at").last()
-    return redirect(clv)
+    clv = codelist.latest_version()
+    if clv is not None:
+        return redirect(clv)
+    else:
+        messages.add_message(
+            request, messages.INFO, "This codelist has not been published"
+        )
+        return redirect("/")

--- a/opencodelists/views/user_create_codelist.py
+++ b/opencodelists/views/user_create_codelist.py
@@ -83,7 +83,7 @@ def handle_post_valid(request, form, user, owner_choices):
         )
         return handle_post_invalid(request, form, user)
 
-    return redirect(codelist)
+    return redirect(codelist.versions.get())
 
 
 def handle_post_invalid(request, form, user):


### PR DESCRIPTION
Previously, the codelist page would redirect to the codelist's latest
version.  However, we don't want to redirect to a version that's
currently being edited.