### PR TITLE
Fix export_to_builder

### DIFF
--- a/codelists/actions.py
+++ b/codelists/actions.py
@@ -322,9 +322,12 @@ def export_to_builder(*, version, owner):
     # In future, we should be able to short-circuit this by keeping track of the release
     # that version was created with.
     for search in version.searches.all():
-        term = search.term
-        codes = do_search(version.coding_system, term)["all_codes"]
-        builder_actions.create_search(draft=draft, term=term, codes=codes)
+        codes = do_search(version.coding_system, term=search.term, code=search.code)[
+            "all_codes"
+        ]
+        builder_actions.create_search(
+            draft=draft, term=search.term, code=search.code, codes=codes
+        )
 
     # Update each code status.
     code_to_status = dict(version.code_objs.values_list("code", "status"))

--- a/opencodelists/tests/fixtures.py
+++ b/opencodelists/tests/fixtures.py
@@ -328,6 +328,13 @@ def build_fixtures():
         draft=version_with_complete_searches,
         updates=[("156659008", "+")],  # include "(Epicondylitis &/or tennis elbow) ..."
     )
+    # This search does not find any new codes, but we need a search with a code for
+    # tests.
+    create_search(
+        draft=version_with_complete_searches,
+        code="439656005",
+        codes=codes_for_search_code("439656005"),
+    )
     save(draft=version_with_complete_searches)
 
     # Check that all code_objs are linked to searches
@@ -412,7 +419,14 @@ def codes_for_search_term(term):
     """Return codes matching search term."""
 
     coding_system = CODING_SYSTEMS["snomedct"]
-    return do_search(coding_system, term)["all_codes"]
+    return do_search(coding_system, term=term)["all_codes"]
+
+
+def codes_for_search_code(code):
+    """Return codes matching search code."""
+
+    coding_system = CODING_SYSTEMS["snomedct"]
+    return do_search(coding_system, code=code)["all_codes"]
 
 
 def check_expected_codes(version, codes):


### PR DESCRIPTION
When exporting a codelist with code searches, the codes weren't being
passed correctly, triggering the assert in codelists.search.do_search.