### PR TITLE
Don't try to cache a hierarchy that doesn't exist

### DIFF
--- a/codelists/actions.py
+++ b/codelists/actions.py
@@ -436,6 +436,8 @@ def cache_hierarchy(*, version, hierarchy=None):
     hierarchy.
     """
 
+    if not version.has_hierarchy:
+        return
     if hierarchy is None:
         hierarchy = version.calculate_hierarchy()
     cached_hierarchy, _ = CachedHierarchy.objects.get_or_create(version=version)


### PR DESCRIPTION
This should all be better tested, but doing so requires setting up quite
a bit of extra test data