### PR TITLE
Allow versions to be deleted

### DIFF
--- a/codelists/actions.py
+++ b/codelists/actions.py
@@ -435,6 +435,27 @@ def publish_version(*, version):
 
 
 @transaction.atomic
+def delete_version(*, version):
+    """Delete a version.
+
+    If this is the only version, the codelist will also be deleted.
+    """
+
+    assert version.is_under_review
+    codelist = version.codelist
+    if codelist.versions.count() == 1:
+        codelist.delete()
+        logger.info(
+            "Deleted Version and Codelist",
+            codelist_pk=codelist.pk,
+            version_pk=version.pk,
+        )
+    else:
+        version.delete()
+        logger.info("Deleted Version", version_pk=version.pk)
+
+
+@transaction.atomic
 def convert_codelist_to_new_style(*, codelist):
     """Convert codelist to new style.
 

--- a/codelists/actions.py
+++ b/codelists/actions.py
@@ -439,6 +439,8 @@ def delete_version(*, version):
     """Delete a version.
 
     If this is the only version, the codelist will also be deleted.
+
+    Returns a boolean indicating whether the codelist was deleted.
     """
 
     assert version.is_under_review
@@ -450,9 +452,14 @@ def delete_version(*, version):
             codelist_pk=codelist.pk,
             version_pk=version.pk,
         )
+        # We clear the pk so that we can check (eg in the load_version decorator)
+        # whether the version is still in the database.
+        version.pk = None
+        return True
     else:
         version.delete()
         logger.info("Deleted Version", version_pk=version.pk)
+        return False
 
 
 @transaction.atomic

--- a/codelists/models.py
+++ b/codelists/models.py
@@ -261,6 +261,11 @@ class CodelistVersion(models.Model):
             f"codelists:{self.codelist_type}_version_publish", kwargs=self.url_kwargs
         )
 
+    def get_delete_url(self):
+        return reverse(
+            f"codelists:{self.codelist_type}_version_delete", kwargs=self.url_kwargs
+        )
+
     def get_download_url(self):
         return reverse(
             f"codelists:{self.codelist_type}_version_download", kwargs=self.url_kwargs

--- a/codelists/tests/test_actions.py
+++ b/codelists/tests/test_actions.py
@@ -392,10 +392,12 @@ def test_delete_version(old_style_codelist):
     codelist_pk = codelist.pk
     version1, version2 = codelist.versions.order_by("id")
 
-    actions.delete_version(version=version2)
+    codelist_was_deleted = actions.delete_version(version=version2)
+    assert not codelist_was_deleted
     assert codelist.versions.count() == 1
 
-    actions.delete_version(version=version1)
+    codelist_was_deleted = actions.delete_version(version=version1)
+    assert codelist_was_deleted
     assert not CodelistVersion.objects.filter(codelist_id=codelist_pk).exists()
     assert not Codelist.objects.filter(pk=codelist_pk).exists()
 

--- a/codelists/tests/test_models.py
+++ b/codelists/tests/test_models.py
@@ -195,23 +195,20 @@ def test_visible_versions_user_doesnt_have_edit_permissions(
 
 def test_latest_visible_version_user_has_edit_permissions(
     new_style_codelist,
-    new_style_codelist_latest_version,
+    latest_version,
     user,
 ):
-    assert (
-        new_style_codelist.latest_visible_version(user)
-        == new_style_codelist_latest_version
-    )
+    assert new_style_codelist.latest_visible_version(user) == latest_version
 
 
 def test_latest_visible_version_user_doesnt_have_edit_permissions(
     new_style_codelist,
-    new_style_codelist_latest_published_version,
+    latest_published_version,
     user_without_organisation,
 ):
     assert (
         new_style_codelist.latest_visible_version(user_without_organisation)
-        == new_style_codelist_latest_published_version
+        == latest_published_version
     )
 
 

--- a/codelists/tests/views/test_codelist.py
+++ b/codelists/tests/views/test_codelist.py
@@ -1,24 +1,16 @@
-def test_get_user_has_edit_permissions(
-    client, user, new_style_codelist, new_style_codelist_latest_version
-):
+def test_get_user_has_edit_permissions(client, user, codelist, latest_version):
     client.force_login(user)
-    rsp = client.get(new_style_codelist.get_absolute_url(), follow=True)
+    rsp = client.get(codelist.get_absolute_url(), follow=True)
     assert rsp.status_code == 200
-    assert (
-        rsp.redirect_chain[-1][0]
-        == new_style_codelist_latest_version.get_absolute_url()
-    )
+    assert rsp.redirect_chain[-1][0] == latest_version.get_absolute_url()
 
 
 def test_get_user_doesnt_have_edit_permissions(
-    client, new_style_codelist, new_style_codelist_latest_published_version
+    client, codelist, latest_published_version
 ):
-    rsp = client.get(new_style_codelist.get_absolute_url(), follow=True)
+    rsp = client.get(codelist.get_absolute_url(), follow=True)
     assert rsp.status_code == 200
-    assert (
-        rsp.redirect_chain[-1][0]
-        == new_style_codelist_latest_published_version.get_absolute_url()
-    )
+    assert rsp.redirect_chain[-1][0] == latest_published_version.get_absolute_url()
 
 
 def test_get_no_versions_available(client, codelist_from_scratch):

--- a/codelists/tests/views/test_version_delete.py
+++ b/codelists/tests/views/test_version_delete.py
@@ -1,0 +1,24 @@
+from .assertions import assert_post_unauthenticated, assert_post_unauthorised
+from .helpers import force_login
+
+
+def test_post_unauthenticated(client, version):
+    assert_post_unauthenticated(client, version.get_publish_url())
+
+
+def test_post_unauthorised(client, version):
+    assert_post_unauthorised(client, version.get_publish_url())
+
+
+def test_post_success(client, old_style_codelist):
+    codelist = old_style_codelist
+    version1, version2 = codelist.versions.order_by("id")
+    force_login(codelist, client)
+
+    response = client.post(version2.get_delete_url())
+    assert response.status_code == 302
+    assert response.url == codelist.get_absolute_url()
+
+    response = client.post(version1.get_delete_url())
+    assert response.status_code == 302
+    assert response.url == "/"

--- a/codelists/urls.py
+++ b/codelists/urls.py
@@ -47,6 +47,7 @@ for subpath, view in [
     ("<codelist_slug>/<tag_or_hash>/", views.version),
     ("<codelist_slug>/<tag_or_hash>/create-new-version/", views.version_create),
     ("<codelist_slug>/<tag_or_hash>/publish/", views.version_publish),
+    ("<codelist_slug>/<tag_or_hash>/delete/", views.version_delete),
     ("<codelist_slug>/<tag_or_hash>/diff/<other_tag_or_hash>/", views.version_diff),
     ("<codelist_slug>/<tag_or_hash>/download.csv", views.version_download),
     ("<codelist_slug>/<tag_or_hash>/definition.csv", views.version_download_definition),

--- a/codelists/views/__init__.py
+++ b/codelists/views/__init__.py
@@ -4,6 +4,7 @@ from .codelist_update import codelist_update
 from .index import index
 from .version import version
 from .version_create import version_create
+from .version_delete import version_delete
 from .version_diff import version_diff
 from .version_dmd_download import version_dmd_download
 from .version_download import version_download

--- a/codelists/views/decorators.py
+++ b/codelists/views/decorators.py
@@ -65,7 +65,7 @@ def load_version(view_fn):
             return redirect(version.get_builder_draft_url())
         else:
             rsp = view_fn(request, version, **view_kwargs)
-            if version.has_hierarchy and version.hierarchy.dirty:
+            if version.pk and version.has_hierarchy and version.hierarchy.dirty:
                 cache_hierarchy(version=version)
             return rsp
 

--- a/codelists/views/version_delete.py
+++ b/codelists/views/version_delete.py
@@ -1,0 +1,18 @@
+from django.contrib.auth.decorators import login_required
+from django.shortcuts import redirect
+from django.views.decorators.http import require_POST
+
+from .. import actions
+from .decorators import load_version, require_permission
+
+
+@require_POST
+@login_required
+@load_version
+@require_permission
+def version_delete(request, version):
+    codelist_was_deleted = actions.delete_version(version=version)
+    if codelist_was_deleted:
+        return redirect("/")
+    else:
+        return redirect(version.codelist)

--- a/opencodelists/tests/fixtures.py
+++ b/opencodelists/tests/fixtures.py
@@ -322,9 +322,10 @@ def build_fixtures():
         version_with_no_searches, disorder_of_elbow_excl_arthritis_codes
     )
 
-    # new_style_codelist_latest_published_version
+    # latest_published_version
     # - an alias for version_with_no_searches
-    new_style_codelist_latest_published_version = version_with_no_searches
+    latest_published_version = version_with_no_searches
+    assert latest_published_version.is_published
 
     # version_with_excluded_codes
     # - an alias for version_with_no_searches
@@ -417,9 +418,9 @@ def build_fixtures():
     # - an alias for version_with_complete_searches
     version_under_review = version_with_complete_searches
 
-    # new_style_codelist_latest_version
+    # latest_version
     # - an alias for version_with_complete_searches
-    new_style_codelist_latest_version = version_with_complete_searches
+    latest_version = version_with_complete_searches
 
     # codelist_with_collaborator
     # - an alias for new_style_codelist
@@ -540,10 +541,8 @@ version_with_no_searches = build_fixture("version_with_no_searches")
 version_with_some_searches = build_fixture("version_with_some_searches")
 version_with_complete_searches = build_fixture("version_with_complete_searches")
 version_with_excluded_codes = build_fixture("version_with_excluded_codes")
-new_style_codelist_latest_published_version = build_fixture(
-    "new_style_codelist_latest_published_version"
-)
-new_style_codelist_latest_version = build_fixture("new_style_codelist_latest_version")
+latest_published_version = build_fixture("latest_published_version")
+latest_version = build_fixture("latest_version")
 version = build_fixture("version")
 version_under_review = build_fixture("version_under_review")
 codelist_with_collaborator = build_fixture("codelist_with_collaborator")

--- a/templates/codelists/_are_you_sure_modal.html
+++ b/templates/codelists/_are_you_sure_modal.html
@@ -1,0 +1,46 @@
+<div
+  class="modal fade"
+  id="js-{{ action }}-version-form"
+  tabindex="-1"
+  role="dialog"
+  aria-labelledby="{{ action }}-version-label"
+  aria-hidden="true"
+>
+  <div class="modal-dialog" role="document">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h5 class="modal-title" id="{{ action }}-version-label">{{ title }}</h5>
+        <button
+          type="button"
+          class="close"
+          data-dismiss="modal"
+          aria-label="Close"
+        >
+          <span aria-hidden="true">&times;</span>
+        </button>
+      </div>
+
+      <div class="modal-body">
+        <form method="POST" action="{{ url }}">
+          {% csrf_token %}
+
+          <p>{{ message }}</p>
+          <p>Are you sure you want to continue?</p>
+
+          <div class="d-flex justify-content-between">
+            <button
+              type="button"
+              class="btn btn-secondary"
+              data-dismiss="modal"
+            >
+              Cancel
+            </button>
+            <button type="submit" class="btn btn-primary">
+              {{ submit_text }}
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  </div>
+</div>

--- a/templates/codelists/version.html
+++ b/templates/codelists/version.html
@@ -112,6 +112,13 @@
               data-target="#js-publish-version-form">
               Publish version
             </button>
+            <button
+              type="button"
+              class="btn btn-outline-primary btn-block"
+              data-toggle="modal"
+              data-target="#js-delete-version-form">
+              Delete version
+            </button>
           {% else %}
             <button
               type="button"
@@ -120,6 +127,14 @@
               data-toggle="tooltip"
               title="This version has already been published">
               Publish version
+            </button>
+            <button
+              type="button"
+              class="disabled btn btn-outline-secondary btn-block"
+              aria-disabled="true"
+              data-toggle="tooltip"
+              title="This version has already been published, so cannot be deleted">
+              Delete version
             </button>
           {% endif %}
         </div>
@@ -179,6 +194,8 @@
 </div>
 
 {% include "./_are_you_sure_modal.html" with action="publish" title="Publish Version" url=clv.get_publish_url message="Publishing a version is irreversible, and will delete any other draft versions or versions under review." submit_text="Publish" %}
+
+{% include "./_are_you_sure_modal.html" with action="delete" title="Delete Version" url=clv.get_delete_url message="Deleting a version is irreversible." submit_text="Delete" %}
 
 {% endblock %}
 

--- a/templates/codelists/version.html
+++ b/templates/codelists/version.html
@@ -178,36 +178,7 @@
   </div>
 </div>
 
-<div class="modal fade" id="js-publish-version-form" tabindex="-1" role="dialog" aria-labelledby="publish-version-label" aria-hidden="true">
-  <div class="modal-dialog" role="document">
-    <div class="modal-content">
-      <div class="modal-header">
-
-        <h5 class="modal-title" id="publish-version-label">Publish Version</h5>
-        <button type="button" class="close" data-dismiss="modal" aria-label="Close">
-          <span aria-hidden="true">&times;</span>
-        </button>
-
-      </div>
-      <div class="modal-body">
-
-        <form method="POST" action="{{ clv.get_publish_url }}">
-          {% csrf_token %}
-
-          <p>Publishing a version is irreversible, and will delete any other draft versions or versions under review.</p>
-          <p>Are you sure you want to continue?</p>
-
-          <div class="d-flex justify-content-between">
-            <button type="button" class="btn btn-secondary" data-dismiss="modal">Cancel</button>
-            <button type="submit" class="btn btn-primary">Publish</button>
-          </div>
-
-        </form>
-
-      </div>
-    </div>
-  </div>
-</div>
+{% include "./_are_you_sure_modal.html" with action="publish" title="Publish Version" url=clv.get_publish_url message="Publishing a version is irreversible, and will delete any other draft versions or versions under review." submit_text="Publish" %}
 
 {% endblock %}
 


### PR DESCRIPTION
This PR adds a new "Delete version" button for users who can edit a codelist.

![image](https://user-images.githubusercontent.com/28734/139832934-7a30e6bb-4289-406f-9706-15af12ddb63a.png)

When clicked, the user sees an "are you sure?" modal:

![image](https://user-images.githubusercontent.com/28734/139832891-1a74578d-d17b-4e6c-ac25-c69546482663.png)

The button is greyed out if the version has already been published, since we do not allow a published version to be changed.