### PR TITLE
Add notes on uploading OPCS-4 codelists

### DIFF
--- a/userdocs/creating-a-codelist-from-a-csv-file.md
+++ b/userdocs/creating-a-codelist-from-a-csv-file.md
@@ -4,23 +4,51 @@ As well as creating a codelist from scratch, you can create one by uploading a C
 
 From the _My codelists_ page, click _Create a codelist_.
 
-Choose a name for the codelist, select a coding system from the dropdown,
-and choose a file to upload from your hard drive.  If you wish to create an OPCS-4 codelist, please see the notes at the bottom of this page. If you are a member of an organisation, you can also choose an owner for the codelist (your own account or an organisation account).
+Choose a name for the codelist, select a coding system from the dropdown, and choose a file to upload from your hard drive.  
+
+To create an OPCS-4 codelist, please see the notes at the bottom of this page.
+	
+If you are a member of an organisation, you can also choose an owner for the codelist (your own account or an organisation account).
 
         create-a-codelist-1.png
 
-The final codelist must be stored in CSV format to be imported 
-into [OpenCodelists](https://www.opencodelists.org). The codes must be stored in exactly one column.
-There is currently a soft requirement that the first column must contain codes in the chosen coding system, preferably named according to the CSV column names provided in the table above (this limitation will be lifted). The second column is typically a text description of the code. Before uploading a codelist CSV under your OpenSAFELY codelist profile, you should remove the header row as these will be automatically added in a standardised manner.
+### Requirements for uploading codelists to OpenCodelists
+	
+* Store the final codelist in CSV format.
+* Store codes in exactly one column.
+* Remove the header row. Standardised headers will automatically be added for you.
+* There is currently a soft requirement that the first column must contain codes in the chosen coding system. These should preferably be named according to the CSV column names provided in the table above. (We plan to eventually remove this requirement.) The second column is typically a text description of the code.
 
-The codelist page will allow you to upload two columns (a code, and a text description of the code), however, some codelists may require a 'classification' or 'type' column, which classifies the codes into subcategories. For example, when using a codelist for venous thromboemobolism you may wish to classify these codes into deep vein thromboses and pulmonary embolisms, and keep this within a single codelist rather than uploading separate lists for each subcategory of the clinical condition. You can access subcategories of a codelist by using the `filter_codes_by_category` functionality when calling `with_these_clinical_events` as part of your `study_definition`. Uploading more than two columns is currently only possible for the OpenSAFELY core team, so in case this is required for your study please get in touch.
+### More about codelist columns
+	
+The codelist page allow you to upload two columns:
 
-Finally, please avoid filtering on an include or exclude column in Excel when finalising a codelist. Any filters applied will be lost when converted to CSV, and you will end up with all of the codes being uploaded. Please also avoid opening any SNOMED-CT codelists in Excel, as the codes get rounded.
+* a code
+* a text description of the code
+
+However, some codelists may require a 'classification' or 'type' column, which classifies the codes into subcategories. For example, when using a codelist for venous thromboembolism, you may wish to classify these codes into deep vein thromboses and pulmonary embolisms. By using subcategories, you can keep all the codes in a single codelist, rather than uploading separate lists for each clinical subcategory. In your study definition, the `filter_codes_by_category` functionality allows access to the subcategories of a codelist.
+        
+**Uploading more than two columns is currently only possible for the OpenSAFELY core team. If your study requires this feature, [please get in touch](https://www.opensafely.org/contact/).**
+
+### Potential issues when editing codelists in spreadsheet software, such as Excel
+
+Avoid:
+
+* filtering on an include or exclude column when finalising a codelist. Applied filters are lost in CSV conversion: *all* of the codes will be uploaded.
+* editing SNOMED-CT codelists. The codes get rounded.
 
 When you click _Create_ the codelist will be created and you will be taken to the codelist homepage.
 
 From here, you can edit any metadata.
 You can also edit the codelist.
 
-Note:OPCS-4 codelists can not currently be created using the form described above. To add an OPCS-4 codelist, you can navigate to https://www.opencodelists.org/codelist/user/{ACCOUNT}/add/, replacing {ACCOUNT} with your OpenCodelists username to add it to your personal account or with the name of the organisation your account is associated with if you would like to add it under the organisation. Note that the OPCS-4 codes you upload should **NOT** include the decimal point.
+### Adding an OPCS-4 codelist
+	
+Note: OPCS-4 codelists can not currently be created using the form described above.
 
+To add an OPCS-4 codelist, navigate to `https://www.opencodelists.org/codelist/user/{ACCOUNT}/add/` — where `{ACCOUNT}` in the URL is substituted with one of the following options:
+
+* Either your OpenCodelists username, to add the codelist to your personal account
+* Or the name of the organisation your account is associated with, to add the codelist under the organisation.
+
+**The OPCS-4 codes you upload should NOT include the decimal point.**

--- a/userdocs/creating-a-codelist-from-a-csv-file.md
+++ b/userdocs/creating-a-codelist-from-a-csv-file.md
@@ -22,5 +22,5 @@ When you click _Create_ the codelist will be created and you will be taken to th
 From here, you can edit any metadata.
 You can also edit the codelist.
 
-Note:OPCS-4 codelists can not currently be created using the form described above. To add an OPCS-4 codelist, you can navigate to https://www.opencodelists.org/codelist/user/{USERNAME}/add/, replacing {USERNAME} with your OpenCodelists username. Note that the decimal point in the OPCS-4 codes you upload should be excluded.
+Note:OPCS-4 codelists can not currently be created using the form described above. To add an OPCS-4 codelist, you can navigate to https://www.opencodelists.org/codelist/user/{ACCOUNT}/add/, replacing {ACCOUNT} with your OpenCodelists username to add it to your personal account or with the name of the organisation your account is associated with if you would like to add it under the organisation. Note that the OPCS-4 codes you upload should **NOT** include the decimal point.
 

--- a/userdocs/creating-a-codelist-from-a-csv-file.md
+++ b/userdocs/creating-a-codelist-from-a-csv-file.md
@@ -22,5 +22,5 @@ When you click _Create_ the codelist will be created and you will be taken to th
 From here, you can edit any metadata.
 You can also edit the codelist.
 
-**OPCS-4 codelists**:OPCS-4 codelists can not currently be created using the form described above. To add an OPCS-4 codelist, you can navigate to https://www.opencodelists.org/codelist/user/{USERNAME}/add/, replacing {USERNAME} with your OpenCodelists username. Note that the decimal point in the OPCS-4 codes you upload should be excluded.
+Note:OPCS-4 codelists can not currently be created using the form described above. To add an OPCS-4 codelist, you can navigate to https://www.opencodelists.org/codelist/user/{USERNAME}/add/, replacing {USERNAME} with your OpenCodelists username. Note that the decimal point in the OPCS-4 codes you upload should be excluded.
 

--- a/userdocs/creating-a-codelist-from-a-csv-file.md
+++ b/userdocs/creating-a-codelist-from-a-csv-file.md
@@ -5,7 +5,7 @@ As well as creating a codelist from scratch, you can create one by uploading a C
 From the _My codelists_ page, click _Create a codelist_.
 
 Choose a name for the codelist, select a coding system from the dropdown,
-and choose a file to upload from your hard drive.  If you are a member of an organisation, you can also choose an owner for the codelist (your own account or an organisation account).
+and choose a file to upload from your hard drive.  If you wish to create an OPCS-4 codelist, please see the notes at the bottom of this page. If you are a member of an organisation, you can also choose an owner for the codelist (your own account or an organisation account).
 
         create-a-codelist-1.png
 

--- a/userdocs/creating-a-codelist-from-a-csv-file.md
+++ b/userdocs/creating-a-codelist-from-a-csv-file.md
@@ -15,7 +15,7 @@ There is currently a soft requirement that the first column must contain codes i
 
 The codelist page will allow you to upload two columns (a code, and a text description of the code), however, some codelists may require a 'classification' or 'type' column, which classifies the codes into subcategories. For example, when using a codelist for venous thromboemobolism you may wish to classify these codes into deep vein thromboses and pulmonary embolisms, and keep this within a single codelist rather than uploading separate lists for each subcategory of the clinical condition. You can access subcategories of a codelist by using the `filter_codes_by_category` functionality when calling `with_these_clinical_events` as part of your `study_definition`. Uploading more than two columns is currently only possible for the OpenSAFELY core team, so in case this is required for your study please get in touch.
 
-Finally, please avoid filtering on an include or exclude column in Excel when finalising a codelist. Any filters applied will be lost when converted to CSV, and you will end up with all of the codes being uploaded.
+Finally, please avoid filtering on an include or exclude column in Excel when finalising a codelist. Any filters applied will be lost when converted to CSV, and you will end up with all of the codes being uploaded. Please also avoid opening any SNOMED-CT codelists in Excel, as the codes get rounded.
 
 When you click _Create_ the codelist will be created and you will be taken to the codelist homepage.
 

--- a/userdocs/creating-a-codelist-from-a-csv-file.md
+++ b/userdocs/creating-a-codelist-from-a-csv-file.md
@@ -22,4 +22,7 @@ When you click _Create_ the codelist will be created and you will be taken to th
 From here, you can edit any metadata.
 You can also edit the codelist.
 
+### OPCS-4 codelists
+
+OPCS-4 codelists can not currently be created using the form described above. To add an OPCS-4 codelist, you can navigate to https://www.opencodelists.org/codelist/user/{USERNAME}/add/, replacing {USERNAME} with your OpenCodelists username. Note that the decimal point in the OPCS-4 codes you upload should be excluded.
 

--- a/userdocs/creating-a-codelist-from-a-csv-file.md
+++ b/userdocs/creating-a-codelist-from-a-csv-file.md
@@ -9,11 +9,17 @@ and choose a file to upload from your hard drive.  If you are a member of an org
 
         create-a-codelist-1.png
 
-Note that the CSV file should not have a header,
-and its first column must contain valid codes in the chosen coding system.
-(This limitation will be lifted.)
+The final codelist must be stored in CSV format to be imported 
+into [OpenCodelists](https://www.opencodelists.org). The codes must be stored in exactly one column.
+There is currently a soft requirement that the first column must contain codes in the chosen coding system, preferably named according to the CSV column names provided in the table above (this limitation will be lifted). The second column is typically a text description of the code. Before uploading a codelist CSV under your OpenSAFELY codelist profile, you should remove the header row as these will be automatically added in a standardised manner.
+
+The codelist page will allow you to upload two columns (a code, and a text description of the code), however, some codelists may require a 'classification' or 'type' column, which classifies the codes into subcategories. For example, when using a codelist for venous thromboemobolism you may wish to classify these codes into deep vein thromboses and pulmonary embolisms, and keep this within a single codelist rather than uploading separate lists for each subcategory of the clinical condition. You can access subcategories of a codelist by using the `filter_codes_by_category` functionality when calling `with_these_clinical_events` as part of your `study_definition`. Uploading more than two columns is currently only possible for the OpenSAFELY core team, so in case this is required for your study please get in touch.
+
+Finally, please avoid filtering on an include or exclude column in Excel when finalising a codelist. Any filters applied will be lost when converted to CSV, and you will end up with all of the codes being uploaded.
 
 When you click _Create_ the codelist will be created and you will be taken to the codelist homepage.
 
 From here, you can edit any metadata.
 You can also edit the codelist.
+
+

--- a/userdocs/creating-a-codelist-from-a-csv-file.md
+++ b/userdocs/creating-a-codelist-from-a-csv-file.md
@@ -22,7 +22,5 @@ When you click _Create_ the codelist will be created and you will be taken to th
 From here, you can edit any metadata.
 You can also edit the codelist.
 
-### OPCS-4 codelists
-
-OPCS-4 codelists can not currently be created using the form described above. To add an OPCS-4 codelist, you can navigate to https://www.opencodelists.org/codelist/user/{USERNAME}/add/, replacing {USERNAME} with your OpenCodelists username. Note that the decimal point in the OPCS-4 codes you upload should be excluded.
+**OPCS-4 codelists**:OPCS-4 codelists can not currently be created using the form described above. To add an OPCS-4 codelist, you can navigate to https://www.opencodelists.org/codelist/user/{USERNAME}/add/, replacing {USERNAME} with your OpenCodelists username. Note that the decimal point in the OPCS-4 codes you upload should be excluded.
 


### PR DESCRIPTION
Adds instructions for uploading an opcs-4 codelist and moves some existing info from main documentation. This accompanies opensafely/documentation#592.