### PR TITLE
Allow organisation admins to add users to organisation

### DIFF
--- a/opencodelists/forms.py
+++ b/opencodelists/forms.py
@@ -149,10 +149,11 @@ class RegisterForm(forms.ModelForm):
 
 
 class MembershipCreateForm(forms.Form):
-    email = forms.EmailField(
-        help_text="Enter an email address for an existing user",
+    user_idenitfier = forms.CharField(
+        max_length=255,
+        help_text="Enter a username or email address for an existing user",
         widget=forms.TextInput(
-            attrs={"class": "form-control", "placeholder": "Email address"}
+            attrs={"class": "form-control", "placeholder": "Username/Email"}
         ),
     )
 
@@ -161,21 +162,26 @@ class MembershipCreateForm(forms.Form):
         self.user = None
         super().__init__(*args, **kwargs)
 
-        if "email" in self.errors:
-            self.fields["email"].widget.attrs.update(
+        if "user_idenitfier" in self.errors:
+            self.fields["user_idenitfier"].widget.attrs.update(
                 {"class": "form-control border-danger"}
             )
 
-    def clean_email(self):
-        email = self.cleaned_data["email"]
+    def clean_user_idenitfier(self):
+        user_idenitfier = self.cleaned_data["user_idenitfier"]
         try:
-            self.user = User.objects.get(email=email)
+            self.user = User.objects.get(username=user_idenitfier)
         except User.DoesNotExist:
-            self.add_error("email", f"User with email address {email} does not exist")
+            try:
+                self.user = User.objects.get(email=user_idenitfier)
+            except User.DoesNotExist:
+                self.add_error(
+                    "user_idenitfier", f"User {user_idenitfier} does not exist"
+                )
 
         if self.user and self.user.is_member(self.organisation):
             self.add_error(
-                "email", f"User with email address {email} is already a member"
+                "user_idenitfier", f"User {user_idenitfier} is already a member"
             )
         else:
-            return email
+            return user_idenitfier

--- a/opencodelists/models.py
+++ b/opencodelists/models.py
@@ -1,5 +1,3 @@
-from datetime import datetime
-
 from django.conf import settings
 from django.contrib.auth.models import AbstractBaseUser, BaseUserManager
 from django.core.exceptions import ObjectDoesNotExist
@@ -27,20 +25,10 @@ class UserManager(BaseUserManager):
         if not email:
             raise ValueError("The Email must be set")
 
-        org = Organisation.objects.first()
-        if not org:
-            org = Organisation.objects.create(
-                name="DataLab", slug="datalab", url="https://ebmdatalab.net/"
-            )
-
         email = self.normalize_email(email)
         user = self.model(username=username, email=email, **extra_fields)
         user.set_password(password)
         user.save()
-        user.memberships.create(
-            organisation=org, date_joined=datetime.today(), is_admin=False
-        )
-
         return user
 
     def create_superuser(self, username, email, password, **extra_fields):

--- a/opencodelists/models.py
+++ b/opencodelists/models.py
@@ -1,3 +1,5 @@
+from datetime import datetime
+
 from django.conf import settings
 from django.contrib.auth.models import AbstractBaseUser, BaseUserManager
 from django.core.exceptions import ObjectDoesNotExist
@@ -32,11 +34,12 @@ class UserManager(BaseUserManager):
             )
 
         email = self.normalize_email(email)
-        user = self.model(
-            username=username, email=email, organisation=org, **extra_fields
-        )
+        user = self.model(username=username, email=email, **extra_fields)
         user.set_password(password)
         user.save()
+        user.memberships.create(
+            organisation=org, date_joined=datetime.today(), is_admin=False
+        )
 
         return user
 
@@ -199,3 +202,6 @@ class Membership(models.Model):
 
     class Meta:
         unique_together = ("user", "organisation")
+
+    def get_absolute_url(self):
+        return reverse("organisation", args=(self.organisation.slug,))

--- a/opencodelists/tests/test_forms.py
+++ b/opencodelists/tests/test_forms.py
@@ -21,28 +21,30 @@ def test_userpasswordform_different_passwords():
 
 def test_membership_create_form(organisation, user_without_organisation):
     form = MembershipCreateForm(
-        {"email": user_without_organisation.email}, organisation=organisation
+        {"user_idenitfier": user_without_organisation.email}, organisation=organisation
+    )
+    assert form.is_valid()
+
+    form = MembershipCreateForm(
+        {"user_idenitfier": user_without_organisation.username},
+        organisation=organisation,
     )
     assert form.is_valid()
 
 
 def test_membership_create_form_already_member(organisation, organisation_user):
     form = MembershipCreateForm(
-        {"email": organisation_user.email}, organisation=organisation
+        {"user_idenitfier": organisation_user.email}, organisation=organisation
     )
     assert form.is_valid() is False
     assert form.errors == {
-        "email": [
-            f"User with email address {organisation_user.email} is already a member"
-        ]
+        "user_idenitfier": [f"User {organisation_user.email} is already a member"]
     }
 
 
 def test_membership_create_form_no_user(organisation):
     form = MembershipCreateForm(
-        {"email": "unknown@test.com"}, organisation=organisation
+        {"user_idenitfier": "unknown@test.com"}, organisation=organisation
     )
     assert form.is_valid() is False
-    assert form.errors == {
-        "email": ["User with email address unknown@test.com does not exist"]
-    }
+    assert form.errors == {"user_idenitfier": ["User unknown@test.com does not exist"]}

--- a/opencodelists/tests/test_forms.py
+++ b/opencodelists/tests/test_forms.py
@@ -1,7 +1,7 @@
 import pytest
 from django.core.exceptions import ValidationError
 
-from ..forms import UserPasswordForm
+from ..forms import MembershipCreateForm, UserPasswordForm
 
 
 def test_userpasswordform_different_passwords():
@@ -17,3 +17,32 @@ def test_userpasswordform_different_passwords():
 
     assert len(e.value.messages) == 1
     assert e.value.messages[0] == "The two password fields don't match."
+
+
+def test_membership_create_form(organisation, user_without_organisation):
+    form = MembershipCreateForm(
+        {"email": user_without_organisation.email}, organisation=organisation
+    )
+    assert form.is_valid()
+
+
+def test_membership_create_form_already_member(organisation, organisation_user):
+    form = MembershipCreateForm(
+        {"email": organisation_user.email}, organisation=organisation
+    )
+    assert form.is_valid() is False
+    assert form.errors == {
+        "email": [
+            f"User with email address {organisation_user.email} is already a member"
+        ]
+    }
+
+
+def test_membership_create_form_no_user(organisation):
+    form = MembershipCreateForm(
+        {"email": "unknown@test.com"}, organisation=organisation
+    )
+    assert form.is_valid() is False
+    assert form.errors == {
+        "email": ["User with email address unknown@test.com does not exist"]
+    }

--- a/opencodelists/tests/views/test_organisations.py
+++ b/opencodelists/tests/views/test_organisations.py
@@ -1,0 +1,92 @@
+from django.urls import reverse
+
+
+def test_organisations_nav(client, user_without_organisation, organisation_user):
+    response = client.get("/")
+    assert "My organisations" not in response.content.decode()
+
+    client.force_login(user_without_organisation)
+    response = client.get("/")
+    assert "My organisations" not in response.content.decode()
+
+    client.force_login(organisation_user)
+    response = client.get("/")
+    assert "My organisations" in response.content.decode()
+
+
+def test_get_organisations(client, user_without_organisation, organisation_user):
+    response = client.get("/organisations/")
+    assert response.status_code == 302
+
+    client.force_login(user_without_organisation)
+    response = client.get("/organisations/")
+    assert response.status_code == 200
+
+    assert not response.context["organisations"]
+
+    client.force_login(organisation_user)
+    response = client.get("/organisations/")
+    assert list(response.context["organisations"]) == [
+        organisation_user.organisations.first()
+    ]
+
+
+def test_get_organisation_members(
+    client,
+    organisation,
+    organisation_admin,
+    user_without_organisation,
+    organisation_user,
+):
+    # not logged in
+    organisation_members_url = reverse(
+        "organisation_members", args=(organisation.slug,)
+    )
+    response = client.get(organisation_members_url)
+    assert response.status_code == 302
+    assert response.url == f"{reverse('login')}?next={organisation_members_url}"
+
+    # not a member
+    client.force_login(user_without_organisation)
+    response = client.get(organisation_members_url)
+    assert response.status_code == 302
+    assert response.url == reverse("organisations")
+
+    # member
+    client.force_login(organisation_user)
+    response = client.get(organisation_members_url)
+    assert response.status_code == 302
+    assert response.url == reverse("organisations")
+
+    # admin
+    client.force_login(organisation_admin)
+    response = client.get(organisation_members_url)
+    assert response.status_code == 200
+
+
+def test_add_member(
+    client,
+    organisation,
+    organisation_admin,
+    organisation_user,
+    user_without_organisation,
+):
+    organisation_members_url = reverse(
+        "organisation_members", args=(organisation.slug,)
+    )
+    client.force_login(organisation_admin)
+
+    response = client.post(organisation_members_url, data={"email": "unknown@test.com"})
+    assert response.context["form"].is_valid() is False
+
+    response = client.post(
+        organisation_members_url, data={"email": organisation_user.email}
+    )
+    assert response.context["form"].is_valid() is False
+
+    assert user_without_organisation.organisations.exists() is False
+    response = client.post(
+        organisation_members_url, data={"email": user_without_organisation.email}
+    )
+    assert user_without_organisation.organisations.exists() is True
+    assert user_without_organisation.organisations.first() == organisation

--- a/opencodelists/tests/views/test_organisations.py
+++ b/opencodelists/tests/views/test_organisations.py
@@ -76,17 +76,31 @@ def test_add_member(
     )
     client.force_login(organisation_admin)
 
-    response = client.post(organisation_members_url, data={"email": "unknown@test.com"})
-    assert response.context["form"].is_valid() is False
-
     response = client.post(
-        organisation_members_url, data={"email": organisation_user.email}
+        organisation_members_url, data={"user_idenitfier": "unknown@test.com"}
     )
     assert response.context["form"].is_valid() is False
 
+    response = client.post(
+        organisation_members_url, data={"user_idenitfier": organisation_user.email}
+    )
+    assert response.context["form"].is_valid() is False
+
+    # add user by email address
     assert user_without_organisation.organisations.exists() is False
     response = client.post(
-        organisation_members_url, data={"email": user_without_organisation.email}
+        organisation_members_url,
+        data={"user_idenitfier": user_without_organisation.email},
+    )
+    assert user_without_organisation.organisations.exists() is True
+    assert user_without_organisation.organisations.first() == organisation
+
+    # add user by username
+    user_without_organisation.memberships.all().delete()
+    assert user_without_organisation.organisations.exists() is False
+    response = client.post(
+        organisation_members_url,
+        data={"user_idenitfier": user_without_organisation.username},
     )
     assert user_without_organisation.organisations.exists() is True
     assert user_without_organisation.organisations.first() == organisation

--- a/opencodelists/urls.py
+++ b/opencodelists/urls.py
@@ -15,10 +15,21 @@ users_patterns = [
     ),
 ]
 
+organisations_patterns = [
+    # list users for an organisation (admins only)
+    path(
+        "<organisation_slug>/users",
+        views.organisation_members,
+        name="organisation_members",
+    ),
+    path("", views.organisations, name="organisations"),
+]
+
 urlpatterns = [
     path("", include("codelists.urls")),
     path("api/v1/", include("codelists.api_urls")),
     path("users/", include(users_patterns)),
+    path("organisations/", include(organisations_patterns)),
     path("admin/", admin.site.urls),
     path("accounts/", include("django.contrib.auth.urls")),
     path("accounts/register/", views.register, name="register"),

--- a/opencodelists/views/__init__.py
+++ b/opencodelists/views/__init__.py
@@ -1,3 +1,4 @@
+from .organisations import organisation_members, organisations
 from .register import register
 from .user import user
 from .user_activation_url import user_activation_url

--- a/opencodelists/views/decorators.py
+++ b/opencodelists/views/decorators.py
@@ -1,0 +1,32 @@
+from functools import wraps
+
+from django.shortcuts import get_object_or_404, redirect
+from django.urls import reverse
+
+from ..models import Organisation
+
+
+def load_organisation(view_fn):
+    """Load an Organisation (or raise 404) and pass it to view function."""
+
+    @wraps(view_fn)
+    def wrapped_view(request, organisation_slug):
+        organisation = get_object_or_404(Organisation, slug=organisation_slug)
+        return view_fn(request, organisation)
+
+    return wrapped_view
+
+
+def require_admin_permission(view_fn):
+    """Ensure the user is an admin member"""
+
+    @wraps(view_fn)
+    def wrapped_view(request, organisation, *args, **kwargs):
+        test = lambda user: user.is_admin_member(organisation)  # noqa
+
+        if test(request.user):
+            return view_fn(request, organisation, *args, **kwargs)
+        else:
+            return redirect(reverse("organisations"))
+
+    return wrapped_view

--- a/opencodelists/views/organisations.py
+++ b/opencodelists/views/organisations.py
@@ -1,0 +1,52 @@
+from datetime import datetime
+
+from django.contrib.auth.decorators import login_required
+from django.shortcuts import render
+
+from ..actions import add_user_to_organisation
+from ..forms import MembershipCreateForm
+from .decorators import load_organisation, require_admin_permission
+
+
+@login_required
+def organisations(request):
+    """List organisations that the user is a member of"""
+    ctx = {
+        "organisations": request.user.organisations.all(),
+        "admin_organisations": request.user.memberships.filter(
+            is_admin=True
+        ).values_list("organisation", flat=True),
+    }
+    return render(request, "opencodelists/user_organisations.html", ctx)
+
+
+@login_required
+@load_organisation
+@require_admin_permission
+def organisation_members(request, organisation):
+    """List members of an organisation and allow admin user to add new users"""
+    organisation_users = organisation.users.all().order_by("name")
+    ctx = {
+        "organisation": organisation,
+        "organisation_members": organisation_users,
+        "form": MembershipCreateForm(organisation=organisation),
+    }
+
+    if request.method == "POST":
+        form = MembershipCreateForm(request.POST, organisation=organisation)
+        if form.is_valid():
+            add_user_to_organisation(
+                user=form.user, organisation=organisation, date_joined=datetime.today()
+            )
+            ctx.update(
+                {
+                    "just_added": form.user,
+                    "organisation_members": organisation_users.exclude(
+                        username=form.user.username
+                    ),
+                }
+            )
+        else:
+            ctx["form"] = form
+
+    return render(request, "opencodelists/organisation_members.html", ctx)

--- a/templates/base.html
+++ b/templates/base.html
@@ -135,6 +135,11 @@
             <li class="navbar-nav nav-item">
               <a class="nav-link text-white" href="{% url 'user' user.username %}">My codelists</a>
             </li>
+            {% if user.memberships.exists %}
+            <li class="navbar-nav nav-item">
+              <a class="nav-link text-white" href="{% url 'organisations' %}">My organisations</a>
+            </li>
+            {% endif %}
             <li class="navbar-nav nav-item">
               <a class="nav-link text-white" href="{% url 'logout' %}">Sign out</a>
             </li>

--- a/templates/opencodelists/organisation_members.html
+++ b/templates/opencodelists/organisation_members.html
@@ -13,14 +13,14 @@
 <form method='POST'>
     {% csrf_token %}
     <div class="form-group">
-        {{ form.email }}
-        <small id="email_help" class="form-text text-muted">
-            {{ form.email.help_text|safe }}
+        {{ form.user_idenitfier }}
+        <small id="user_idenitfier_help" class="form-text text-muted">
+            {{ form.user_idenitfier.help_text|safe }}
         </small>
 
-        {% if form.email.errors %}
+        {% if form.user_idenitfier.errors %}
           <ul class="list-unstyled my-2">
-            {% for error in form.email.errors %}
+            {% for error in form.user_idenitfier.errors %}
             <li class="text-danger">{{ error }}</li>
             {% endfor %}
           </ul>
@@ -35,6 +35,7 @@
     <thead>
       <tr>
         <th scope="col">Name</th>
+        <th scope="col">Username</th>
         <th scope="col">Email</th>
       </tr>
     </thead>
@@ -42,6 +43,7 @@
         {% if just_added %}
         <tr class="table-success">
             <td>{{ just_added.name }}</td>
+            <td>{{ just_added.username }}</td>
             <td>{{ just_added.email }}</td>
         </tr>
         {% endif %}
@@ -49,6 +51,7 @@
         {% for member in organisation_members %}
             <tr>
                 <td>{{ member.name }}</td>
+                <td>{{ member.username }}</td>
                 <td>{{ member.email }}</td>
             </tr>
         {% endfor %}

--- a/templates/opencodelists/organisation_members.html
+++ b/templates/opencodelists/organisation_members.html
@@ -1,0 +1,60 @@
+{% extends 'base.html' %}
+
+{% load crispy_forms_tags %}
+
+{% block title_extra %}: {{ organisation.name }}{% endblock %}
+
+{% block content %}
+<br />
+<h3>{{ organisation.name }} Users</h3>
+<br />
+
+<h5>Add a user</h5>
+<form method='POST'>
+    {% csrf_token %}
+    <div class="form-group">
+        {{ form.email }}
+        <small id="email_help" class="form-text text-muted">
+            {{ form.email.help_text|safe }}
+        </small>
+
+        {% if form.email.errors %}
+          <ul class="list-unstyled my-2">
+            {% for error in form.email.errors %}
+            <li class="text-danger">{{ error }}</li>
+            {% endfor %}
+          </ul>
+        {% endif %}
+    </div>
+    <button type="submit" class="btn btn-primary">Add user</button>
+</form>
+<br />
+
+<br />
+<table class="table table-sm pt-4">
+    <thead>
+      <tr>
+        <th scope="col">Name</th>
+        <th scope="col">Email</th>
+      </tr>
+    </thead>
+    <tbody>
+        {% if just_added %}
+        <tr class="table-success">
+            <td>{{ just_added.name }}</td>
+            <td>{{ just_added.email }}</td>
+        </tr>
+        {% endif %}
+
+        {% for member in organisation_members %}
+            <tr>
+                <td>{{ member.name }}</td>
+                <td>{{ member.email }}</td>
+            </tr>
+        {% endfor %}
+
+
+    </tbody>
+</table>
+
+{% endblock %}

--- a/templates/opencodelists/user_organisations.html
+++ b/templates/opencodelists/user_organisations.html
@@ -1,0 +1,25 @@
+{% extends 'base.html' %}
+
+{% load crispy_forms_tags %}
+
+{% block title_extra %}: {{ user.name }} organisations{% endblock %}
+
+{% block content %}
+<br />
+<h3>Hello, {{ user.name }}</h3>
+<br />
+
+<h4>Your organisations</h4>
+<br />
+{% for organisation in organisations %}
+    <h5>{{ organisation.name }}</h5>
+
+    <ul>
+        <li><a href="{% url 'codelists:organisation_index' organisation.slug %}">Codelists owned by {{ organisation.name }}</a></li>
+        {% if organisation.slug in admin_organisations %}
+        <li><a href="{% url 'organisation_members' organisation.slug %}">{{ organisation.name }} Users</a></li>
+        {% endif %}
+    </ul>
+{% endfor %}
+
+{% endblock %}


### PR DESCRIPTION
Fixes #1048 

If a user is a member of one or more organisations, there's now a navbar link to a view that shows a list of the users orgs, with links to the org's codelists and (if the user is an admin for that org) the org's users.

![Screenshot from 2022-02-24 09-53-30](https://user-images.githubusercontent.com/6770950/155502490-434423d6-5cf3-40d6-a948-3eb7d8e5bc38.png)

The organisation users page shows a list of users and a minimal form to add a user by email.  It assumes an admin will only add a user who's already signed up to opencodelists.

![Screenshot from 2022-02-24 09-54-12](https://user-images.githubusercontent.com/6770950/155502687-4711b5c5-52b7-4ef9-8d35-a7ee57131ed1.png)

Error messages are shown if you try to add a user that doesn't exist or is already a member

![Screenshot from 2022-02-24 09-54-31](https://user-images.githubusercontent.com/6770950/155503095-5f7ea16e-f38e-4dec-9f58-ee9cce166303.png)
![Screenshot from 2022-02-24 09-54-51](https://user-images.githubusercontent.com/6770950/155503112-263d5541-69b6-4151-8211-52fbd857ba59.png)

When a user is successfully added, they're highlighted green in the user table and shown first:

![Screenshot from 2022-02-24 10-20-08](https://user-images.githubusercontent.com/6770950/155505624-f8a101b7-4d36-4e36-a810-3774fd272d96.png)







