### PR TITLE
Display only codelists with a published version

### DIFF
--- a/codelists/models.py
+++ b/codelists/models.py
@@ -157,6 +157,9 @@ class Codelist(models.Model):
 
         return self.visible_versions(user).first()
 
+    def has_published_versions(self):
+        return self.versions.filter(status="published").exists()
+
 
 class Handle(models.Model):
     codelist = models.ForeignKey(

--- a/codelists/tests/test_models.py
+++ b/codelists/tests/test_models.py
@@ -224,3 +224,15 @@ def test_get_by_hash(new_style_version):
     assert (
         CodelistVersion.objects.get_by_hash(new_style_version.hash) == new_style_version
     )
+
+
+def test_codelist_has_published_versions_returns_true_when_published(
+    new_style_codelist,
+):
+    assert new_style_codelist.has_published_versions()
+
+
+def test_codelist_has_published_versions_returns_false_when_not_published(
+    old_style_codelist,
+):
+    assert not old_style_codelist.has_published_versions()

--- a/codelists/tests/views/test_index.py
+++ b/codelists/tests/views/test_index.py
@@ -1,0 +1,20 @@
+def test_search_only_returns_codelists_with_published_versions(
+    client, organisation, old_style_codelist, new_style_codelist
+):
+    # The organisation has two codelists whose name matches "style" ("New-style
+    # codelist" and "Old-style codelist").  However, "Old-style codelist" does not have
+    # any published versions, and so should not appear in search results.
+
+    # Validate our assumptions about the fixtures.
+    assert old_style_codelist.organisation == organisation
+    assert old_style_codelist.versions.filter(status="published").count() == 0
+    assert new_style_codelist.organisation == organisation
+    assert new_style_codelist.versions.filter(status="published").count() > 0
+
+    # Do a search.
+    rsp = client.get(f"/codelist/{organisation.slug}/?q=style")
+
+    # Assert that only one codelist is returned.
+    assert len(rsp.context["codelists"]) == 1
+    codelist = rsp.context["codelists"][0]
+    assert codelist.slug == "new-style-codelist"

--- a/codelists/views/index.py
+++ b/codelists/views/index.py
@@ -27,6 +27,14 @@ def index(request, organisation_slug=None):
         )
 
     handles = handles.order_by("name")
-    codelists = [handle.codelist for handle in handles]
+    codelists = _all_published_codelists(handles)
     ctx = {"codelists": codelists, "organisation": organisation, "q": q}
     return render(request, "codelists/index.html", ctx)
+
+
+def _all_published_codelists(handles):
+    return [
+        handle.codelist
+        for handle in handles
+        if handle.codelist.has_published_versions()
+    ]


### PR DESCRIPTION
Codelists with no published versions are currently being returned in
search results, but these are not accessible to anyone outside of the
OpenSafely organisation.

An example is given in [Github Issue #1111](https://github.com/opensafely-core/opencodelists/issues/1111)