### PR TITLE
Handle duplicate searches

### DIFF
--- a/builder/actions.py
+++ b/builder/actions.py
@@ -17,7 +17,10 @@ def create_search(*, draft, term=None, code=None, codes):
         slug = slugify(term)
     else:
         slug = f"code:{code}"
-    search = draft.searches.create(term=term, code=code, slug=slug)
+    search, new = draft.searches.get_or_create(term=term, code=code, slug=slug)
+    if not new:
+        logger.info("Returned existing Search", search_pk=search.pk)
+        return search
 
     # Ensure that there is a CodeObj object linked to this draft for each code.
     codes_with_existing_code_objs = set(

--- a/builder/tests/test_actions.py
+++ b/builder/tests/test_actions.py
@@ -48,6 +48,48 @@ def test_create_search(version_from_scratch):
     assert draft.code_objs.count() == 2
 
 
+def test_duplicate_search(version_from_scratch):
+    # Test that a user can search for the same term again without error
+
+    draft = version_from_scratch
+
+    # Act: create a term search
+    s = actions.create_search(
+        draft=draft,
+        term="epicondylitis",
+        codes={"73583000", "202855006"},
+    )
+
+    # Assert...
+    # that the search's attributes have been set
+    assert s.version == draft
+    assert s.term == "epicondylitis"
+    assert s.code is None
+    assert s.slug == "epicondylitis"
+
+    # that the newly created search has 2 results
+    assert s.results.count() == 2
+    # that the draft has 1 search
+    assert draft.searches.count() == 1
+    # that the draft has 2 codes
+    assert draft.code_objs.count() == 2
+
+    # try to repeat the same search
+    s1 = actions.create_search(
+        draft=draft,
+        term="epicondylitis",
+        codes={"73583000", "202855006"},
+    )
+
+    # Assert...
+    # that the initally created search was returned
+    assert s1.id == s.id
+
+    # that the draft still has the same search and code counts
+    assert draft.searches.count() == 1
+    assert draft.code_objs.count() == 2
+
+
 @pytest.mark.xfail
 def test_delete_search():
     pass


### PR DESCRIPTION
Fixes #786 #870 #668 (all duplicates)

Duplicate searches were previously attempting to recreate the search, and raising an IntegrityError.  If a user searches for the same term again, we now return the previously created search.