### PR TITLE
Fix bugs with discarding drafts

### DIFF
--- a/builder/decorators.py
+++ b/builder/decorators.py
@@ -16,7 +16,8 @@ def load_draft(view_fn):
         version = get_object_or_404(CodelistVersion, id=id)
         if version.is_draft:
             rsp = view_fn(request, version, **kwargs)
-            if version.hierarchy.dirty:
+            # make sure the draft version has not just been discarded
+            if version.exists() and version.hierarchy.dirty:
                 cache_hierarchy(version=version)
             return rsp
         else:

--- a/builder/tests/test_views.py
+++ b/builder/tests/test_views.py
@@ -1,3 +1,4 @@
+from codelists.actions import create_codelist_from_scratch
 from codelists.tests.views.assertions import (
     assert_post_unauthenticated,
     assert_post_unauthorised,
@@ -140,3 +141,27 @@ def test_new_search_no_results(client, draft):
 
     assert rsp.status_code == 200
     assert b"bananas" in rsp.content
+
+
+def test_discard_only_draft_version(client, organisation_user):
+    new_codelist = create_codelist_from_scratch(
+        owner=organisation_user,
+        author=organisation_user,
+        name="foo",
+        coding_system_id="snomedct",
+    )
+    assert new_codelist.versions.count() == 1
+    draft = new_codelist.versions.first()
+
+    client.force_login(organisation_user)
+
+    rsp = client.post(draft.get_builder_draft_url(), {"action": "discard"}, follow=True)
+    assert rsp.status_code == 200
+
+
+def test_discard_one_draft_version(client, draft):
+    assert draft.codelist.versions.count() > 1
+    client.force_login(draft.author)
+
+    rsp = client.post(draft.get_builder_draft_url(), {"action": "discard"}, follow=True)
+    assert rsp.status_code == 200

--- a/builder/views.py
+++ b/builder/views.py
@@ -4,6 +4,7 @@ from django.contrib import messages
 from django.contrib.auth.decorators import login_required
 from django.http import HttpResponse, JsonResponse
 from django.shortcuts import get_object_or_404, redirect, render
+from django.urls import reverse
 from django.views.decorators.http import require_http_methods
 
 from codelists.search import do_search
@@ -45,7 +46,10 @@ def _handle_post(request, draft):
     elif action == "discard":
         messages.add_message(request, messages.INFO, "Your changes have been discarded")
         actions.discard_draft(draft=draft)
-        return redirect(draft.codelist)
+        # check if the discarded draft's codelist still exists (i.e. this was not the only version)
+        if draft.codelist.id is not None:
+            return redirect(draft.codelist)
+        return redirect(reverse("user", args=(request.user.username,)))
     else:
         return HttpResponse(status=400)
 

--- a/codelists/models.py
+++ b/codelists/models.py
@@ -313,6 +313,13 @@ class CodelistVersion(models.Model):
         kwargs["other_tag_or_hash"] = other_clv.tag_or_hash
         return reverse(f"codelists:{self.codelist_type}_version_diff", kwargs=kwargs)
 
+    def exists(self):
+        """
+        Check that a CodelistVersion exists.  It may not, in the event that it's just
+        been discarded
+        """
+        return CodelistVersion.objects.filter(id=self.id).exists()
+
     @property
     def url_kwargs(self):
         kwargs = self.codelist.url_kwargs


### PR DESCRIPTION
Discarding a draft was resulting in a 500 error to the user, although the draft was successfully deleted.

In the case where a draft was the sole version for a codelist, the codelist itself was also deleted, and the error was caused by an attempt to redirect to the non-existed codelist URL (`Handle.DoesNotExist` error)
Fixes #867 

In the case where there were multiple drafts, the error was caused by an attempt to cache the hierarchy on a discarded version (`CodelistVersion.cached_hierarchy.RelatedObjectDoesNotExist`)
Fixes #868
Fixes #922