### PR TITLE
Organisation members can see organisation-owned under-review codelists

### DIFF
--- a/codelists/list_utils.py
+++ b/codelists/list_utils.py
@@ -1,0 +1,2 @@
+def flatten(nested_list):
+    return sum(nested_list, [])

--- a/codelists/tests/views/test_index.py
+++ b/codelists/tests/views/test_index.py
@@ -1,3 +1,6 @@
+from codelists.actions import publish_version
+
+
 def test_search_only_returns_codelists_with_published_versions(
     client, organisation, old_style_codelist, new_style_codelist
 ):
@@ -18,3 +21,65 @@ def test_search_only_returns_codelists_with_published_versions(
     assert len(rsp.context["codelists"]) == 1
     codelist = rsp.context["codelists"][0]
     assert codelist.slug == "new-style-codelist"
+
+
+def test_under_review_index(
+    client, organisation, version_under_review, old_style_codelist
+):
+    # The organisation has two codelists whose name matches "style", and both
+    # have under review versions
+
+    # Validate our assumptions about the fixtures.
+    assert version_under_review.codelist.organisation == organisation
+    assert version_under_review.status == "under review"
+    under_review_count = version_under_review.codelist.versions.filter(
+        status="under review"
+    ).count()
+    assert under_review_count > 0
+
+    assert old_style_codelist.organisation == organisation
+    old_style_under_review_count = old_style_codelist.versions.filter(
+        status="under review"
+    ).count()
+    assert old_style_under_review_count > 0
+
+    # Get the under-review index.
+    rsp = client.get(f"/codelist/{organisation.slug}/under-review/")
+    # Assert that only under-review versions are returned
+    versions = rsp.context["versions"]
+    assert len(versions) == under_review_count + old_style_under_review_count
+    for version in versions:
+        assert version.status == "under review"
+
+
+def test_search_only_returns_codelists_with_under_review_versions(
+    client, organisation, version_under_review, old_style_codelist
+):
+    # The organisation has two codelists whose name matches "style" ("New-style
+    # codelist" and "Old-style codelist").  However, only "New-style codelist" has
+    # under review versions, and so only these should appear in search results.
+
+    # Validate our assumptions about the fixtures.
+    assert version_under_review.codelist.organisation == organisation
+    assert version_under_review.status == "under review"
+    under_review_count = version_under_review.codelist.versions.filter(
+        status="under review"
+    ).count()
+    assert under_review_count > 0
+
+    # publish the old-style-codelist
+    old_style_under_review_version = old_style_codelist.versions.filter(
+        status="under review"
+    ).first()
+    publish_version(version=old_style_under_review_version)
+    assert old_style_codelist.organisation == organisation
+    assert old_style_codelist.versions.filter(status="under review").count() == 0
+
+    # Do a search.
+    rsp = client.get(f"/codelist/{organisation.slug}/under-review/?q=style")
+    # Assert that only versions related to one codelist are returned
+    versions = rsp.context["versions"]
+    assert len(versions) == under_review_count
+    assert version_under_review.id in [version.id for version in versions]
+    for version in versions:
+        assert version.codelist == version_under_review.codelist

--- a/codelists/urls.py
+++ b/codelists/urls.py
@@ -2,6 +2,7 @@ from django.urls import path
 from django.views.generic import RedirectView
 
 from . import views
+from .models import Status
 
 app_name = "codelists"
 
@@ -37,6 +38,12 @@ urlpatterns = [
     # ~~~
     path("", views.index, name="index"),
     path("codelist/<organisation_slug>/", views.index, name="organisation_index"),
+    path(
+        "codelist/<organisation_slug>/under-review/",
+        views.index,
+        {"status": Status.UNDER_REVIEW},
+        name="organisation_under_review_index",
+    ),
 ]
 
 for subpath, view in [

--- a/codelists/views/index.py
+++ b/codelists/views/index.py
@@ -3,10 +3,10 @@ from django.shortcuts import get_object_or_404, render
 
 from opencodelists.models import Organisation
 
-from ..models import Handle
+from ..models import Handle, Status
 
 
-def index(request, organisation_slug=None):
+def index(request, organisation_slug=None, status=Status.PUBLISHED):
     handles = Handle.objects.filter(is_current=True)
 
     q = request.GET.get("q")
@@ -27,9 +27,15 @@ def index(request, organisation_slug=None):
         )
 
     handles = handles.order_by("name")
-    codelists = _all_published_codelists(handles)
-    ctx = {"codelists": codelists, "organisation": organisation, "q": q}
-    return render(request, "codelists/index.html", ctx)
+    if status == Status.PUBLISHED:
+        codelists = _all_published_codelists(handles)
+        ctx = {"codelists": codelists, "organisation": organisation, "q": q}
+        return render(request, "codelists/index.html", ctx)
+    else:
+        assert status == Status.UNDER_REVIEW
+        codelists = _all_under_review_codelist_versions(handles)
+        ctx = {"versions": codelists, "organisation": organisation, "q": q}
+        return render(request, "codelists/under_review_index.html", ctx)
 
 
 def _all_published_codelists(handles):
@@ -38,3 +44,13 @@ def _all_published_codelists(handles):
         for handle in handles
         if handle.codelist.has_published_versions()
     ]
+
+
+def _all_under_review_codelist_versions(handles):
+    return sum(
+        [
+            list(handle.codelist.versions.filter(status=Status.UNDER_REVIEW))
+            for handle in handles
+        ],
+        [],
+    )

--- a/codelists/views/index.py
+++ b/codelists/views/index.py
@@ -3,6 +3,7 @@ from django.shortcuts import get_object_or_404, render
 
 from opencodelists.models import Organisation
 
+from ..list_utils import flatten
 from ..models import Handle, Status
 
 
@@ -33,8 +34,8 @@ def index(request, organisation_slug=None, status=Status.PUBLISHED):
         return render(request, "codelists/index.html", ctx)
     else:
         assert status == Status.UNDER_REVIEW
-        codelists = _all_under_review_codelist_versions(handles)
-        ctx = {"versions": codelists, "organisation": organisation, "q": q}
+        versions = _all_under_review_codelist_versions(handles)
+        ctx = {"versions": versions, "organisation": organisation, "q": q}
         return render(request, "codelists/under_review_index.html", ctx)
 
 
@@ -47,10 +48,9 @@ def _all_published_codelists(handles):
 
 
 def _all_under_review_codelist_versions(handles):
-    return sum(
+    return flatten(
         [
             list(handle.codelist.versions.filter(status=Status.UNDER_REVIEW))
             for handle in handles
-        ],
-        [],
+        ]
     )

--- a/templates/codelists/_search_form.html
+++ b/templates/codelists/_search_form.html
@@ -1,0 +1,14 @@
+<form class="form-inline mb-4">
+    <label class="sr-only" for="search-codelists">Query</label>
+    <input
+      name="q"
+      type="text"
+      id="search-codelists"
+      class="form-control mb-2 mr-2"
+      placeholder="Search codelists"
+      {% if q %}value="{{ q }}"{% endif %}
+    />
+
+    <button type="submit" class="btn btn-primary mb-2 mr-2">Search</button>
+    <a href="{{ request.path }}" role="button" class="btn btn-primary mb-2">Reset</a>
+  </form>

--- a/templates/codelists/index.html
+++ b/templates/codelists/index.html
@@ -59,20 +59,7 @@
 {% endif %}
 <br />
 
-<form class="form-inline mb-4">
-  <label class="sr-only" for="search-codelists">Query</label>
-  <input
-    name="q"
-    type="text"
-    id="search-codelists"
-    class="form-control mb-2 mr-2"
-    placeholder="Search codelists"
-    {% if q %}value="{{ q }}"{% endif %}
-  />
-
-  <button type="submit" class="btn btn-primary mb-2 mr-2">Search</button>
-  <a href="/" role="button" class="btn btn-primary mb-2">Reset</a>
-</form>
+{% include "codelists/_search_form.html" %}
 
 <div class="row">
   <div class="col-12">

--- a/templates/codelists/under_review_index.html
+++ b/templates/codelists/under_review_index.html
@@ -6,20 +6,7 @@
 <h3>{{ organisation.name }}: codelists under review</h3>
 <br />
 
-<form class="form-inline mb-4">
-  <label class="sr-only" for="search-codelists">Query</label>
-  <input
-    name="q"
-    type="text"
-    id="search-codelists"
-    class="form-control mb-2 mr-2"
-    placeholder="Search codelists"
-    {% if q %}value="{{ q }}"{% endif %}
-  />
-
-  <button type="submit" class="btn btn-primary mb-2 mr-2">Search</button>
-  <a href="/" role="button" class="btn btn-primary mb-2">Reset</a>
-</form>
+{% include "codelists/_search_form.html" %}
 
 <div class="row">
   <div class="col-12">

--- a/templates/codelists/under_review_index.html
+++ b/templates/codelists/under_review_index.html
@@ -1,0 +1,36 @@
+{% extends 'codelists/index.html' %}
+
+
+{% block content %}
+
+<h3>{{ organisation.name }}: codelists under review</h3>
+<br />
+
+<form class="form-inline mb-4">
+  <label class="sr-only" for="search-codelists">Query</label>
+  <input
+    name="q"
+    type="text"
+    id="search-codelists"
+    class="form-control mb-2 mr-2"
+    placeholder="Search codelists"
+    {% if q %}value="{{ q }}"{% endif %}
+  />
+
+  <button type="submit" class="btn btn-primary mb-2 mr-2">Search</button>
+  <a href="/" role="button" class="btn btn-primary mb-2">Reset</a>
+</form>
+
+<div class="row">
+  <div class="col-12">
+    <dl class="home-codelists">
+      {% for version in versions %}
+      <dt>
+        <a href="{{ version.get_absolute_url }}">{{ version.codelist.name }} - version {{ version.tag_or_hash }}</a>
+      </dt>
+      <dd>
+      {% endfor %}
+    </dl>
+  </div>
+</div>
+{% endblock %}

--- a/templates/opencodelists/user_organisations.html
+++ b/templates/opencodelists/user_organisations.html
@@ -15,7 +15,8 @@
     <h5>{{ organisation.name }}</h5>
 
     <ul>
-        <li><a href="{% url 'codelists:organisation_index' organisation.slug %}">Codelists owned by {{ organisation.name }}</a></li>
+        <li><a href="{% url 'codelists:organisation_index' organisation.slug %}">Published codelists owned by {{ organisation.name }}</a></li>
+        <li><a href="{% url 'codelists:organisation_under_review_index' organisation.slug %}">Codelists under review</a></li>
         {% if organisation.slug in admin_organisations %}
         <li><a href="{% url 'organisation_members' organisation.slug %}">{{ organisation.name }} Users</a></li>
         {% endif %}


### PR DESCRIPTION
Now that organisation members have a "My organisations" page, we can give them a list of both published and under-review codelists.  This means that any organisation-owned under-review codelists that don't have authors (either because they predate the author field, or because they were uploaded via the API) can be accessed easily by members of that organisation.