### PR TITLE
Show versions on builder page, and latest published version on user codelists page

### DIFF
--- a/codelists/tests/test_models.py
+++ b/codelists/tests/test_models.py
@@ -236,3 +236,27 @@ def test_codelist_has_published_versions_returns_false_when_not_published(
     old_style_codelist,
 ):
     assert not old_style_codelist.has_published_versions()
+
+
+def test_latest_published_version_no_versions_published(codelist_from_scratch):
+    assert codelist_from_scratch.latest_published_version() is None
+
+
+def test_latest_published_version_with_version_published(
+    new_style_codelist, latest_published_version
+):
+    assert new_style_codelist.latest_published_version() == latest_published_version
+
+
+def test_get_latest_published_url(new_style_codelist, latest_published_version):
+    assert (
+        new_style_codelist.get_latest_published_url()
+        == latest_published_version.get_absolute_url()
+    )
+
+
+def test_get_latest_published_url_no_published_version(codelist_from_scratch):
+    assert (
+        codelist_from_scratch.get_latest_published_url()
+        == codelist_from_scratch.get_absolute_url()
+    )

--- a/static/src/js/builder/codelistbuilder.jsx
+++ b/static/src/js/builder/codelistbuilder.jsx
@@ -189,16 +189,12 @@ class CodelistBuilder extends React.Component {
             </dl>
             <hr />
 
-            {this.props.searches.length > 0 && (
-              <>
-                <h6>Versions</h6>
-                <ul className="pl-3">
-                  {this.props.versions.map((version) => (
-                    <Version key={version.hash} version={version} />
-                  ))}
-                </ul>
-              </>
-            )}
+            <h6>Versions</h6>
+            <ul className="pl-3">
+              {this.props.versions.map((version) => (
+                <Version key={version.hash} version={version} />
+              ))}
+            </ul>
           </div>
 
           <div className="col-9 pl-5">

--- a/templates/opencodelists/this_user.html
+++ b/templates/opencodelists/this_user.html
@@ -21,7 +21,7 @@
 
 <ul>
         {% for codelist in codelists %}
-        <li><a href="{{ codelist.get_absolute_url }}">{{ codelist.name }}</a></li>
+        <li><a href="{{ codelist.get_latest_published_url }}">{{ codelist.name }}</a></li>
         {% endfor %}
 </ul>
 {% endif %}
@@ -32,7 +32,7 @@
 
 <ul>
         {% for codelist in authored_for_organisation %}
-        <li><a href="{{ codelist.get_absolute_url }}">{{ codelist.name }} (owned by {{ codelist.owner }})</a></li>
+        <li><a href="{{ codelist.get_latest_published_url }}">{{ codelist.name }} (owned by {{ codelist.owner }})</a></li>
         {% endfor %}
 </ul>
 {% endif %}


### PR DESCRIPTION
Fixes #1127 

- Show versions on the builder page
The code for this was there already, but was only showing up if a draft had searches.

- Use latest published version URLs on user's codelists page
The `Codelist.get_absolute_url` returns the latest visible version for that user, but when a codelist has both a published version and a version in draft or under review, we expect the link under "My codelists" to show the latest published version, and the link under "My codelists under review/My drafts" to show the relevant unpublished version.