### PR TITLE
Wrap long codelist IDs

### DIFF
--- a/static/src/js/builder/codelistbuilder.jsx
+++ b/static/src/js/builder/codelistbuilder.jsx
@@ -182,7 +182,9 @@ class CodelistBuilder extends React.Component {
               ) : null}
 
               <dt>Codelist ID</dt>
-              <dd>{this.props.metadata.codelist_full_slug}</dd>
+              <dd className="text-break">
+                {this.props.metadata.codelist_full_slug}
+              </dd>
 
               <dt>ID</dt>
               <dd>{this.props.metadata.hash}</dd>

--- a/templates/codelists/version.html
+++ b/templates/codelists/version.html
@@ -52,7 +52,7 @@
       {% endif %}
 
       <dt>Codelist ID</dt>
-      <dd>{{ codelist.full_slug }}</dd>
+      <dd class="text-break">{{ codelist.full_slug }}</dd>
 
       {% if clv.tag %}
       <dt>Tag</dt>


### PR DESCRIPTION
Fixes #1038 

Wrap long codelist IDs and allow words to break if they need to, on both builder and codelist pages