### PR TITLE
Reject search terms that result in empty slugs

### DIFF
--- a/builder/tests/test_views.py
+++ b/builder/tests/test_views.py
@@ -175,7 +175,7 @@ def test_new_search_check_slugified_terms(client, draft, term, valid, slug):
     if valid:
         assert rsp.url == draft.get_builder_search_url(slug)
     else:
-        assert rsp.url == draft.get_absolute_url()
+        assert rsp.url == draft.get_builder_draft_url()
 
 
 def test_discard_only_draft_version(client, organisation_user):

--- a/builder/views.py
+++ b/builder/views.py
@@ -5,6 +5,7 @@ from django.contrib.auth.decorators import login_required
 from django.http import HttpResponse, JsonResponse
 from django.shortcuts import get_object_or_404, redirect, render
 from django.urls import reverse
+from django.utils.text import slugify
 from django.views.decorators.http import require_http_methods
 
 from codelists.search import do_search
@@ -197,6 +198,11 @@ def update(request, draft):
 @require_permission
 def new_search(request, draft):
     term = request.POST["search"].strip()
+    # Ensure that the term is not an empty string after slugifying
+    # (e.g. if the user entered "*" as a search term)
+    if not slugify(term):
+        messages.info(request, f'"{term}" is not a valid search term')
+        return redirect(draft)
     if term.startswith("code:"):
         code = term[5:].strip()
         term = None

--- a/builder/views.py
+++ b/builder/views.py
@@ -202,7 +202,7 @@ def new_search(request, draft):
     # (e.g. if the user entered "*" as a search term)
     if not slugify(term):
         messages.info(request, f'"{term}" is not a valid search term')
-        return redirect(draft)
+        return redirect(draft.get_builder_draft_url())
     if term.startswith("code:"):
         code = term[5:].strip()
         term = None


### PR DESCRIPTION
A (non "code:"-prefixed) search term is converted to a slug using django's `slugify` method, and forms part of the URL for the search.  If a user searches for a term that results in an empty slug after conversion, this ends up with a Search that has an invalid URL.  The search view attempts to redirect to the invalid URL, and after that the entire codelist page is broken, because the template tries to render the invalid URL.

Mostly, we'd expect that users aren't going to search for random strings of punctuation that result in empty slugs.  However, they could enter a single character and hit search by mistake, or as @Jongmassey found out, try to return all codes by entering `*` (instead of `code:*`)