### PR TITLE
Delete searches

### DIFF
--- a/builder/actions.py
+++ b/builder/actions.py
@@ -68,17 +68,12 @@ def delete_search(*, search):
     hierarchy = search.version.hierarchy
     codes_to_keep = set()
 
+    codes_to_keep = []
     for code_obj in search_only_code_objs:
-        # Keep a code if it is explicitly included or a descendant of an explicitly included code
-        if code_obj.code in all_included_codes:
-            codes_to_keep.add(code_obj.code)
-            codes_to_keep = codes_to_keep | hierarchy.descendants(code_obj.code)
-        else:
-            # if it's not explicitly included, we still need to keep it if any of its parents are included
-            ancestors = hierarchy.ancestors(code_obj.code)
-            ancestors_in_included = ancestors & all_included_codes
-            if ancestors_in_included:
-                codes_to_keep.add(code_obj.code)
+        ancestors = hierarchy.ancestors(code_obj.code)
+        ancestors_in_included = ancestors & all_included_codes
+        if ancestors_in_included or code_obj.code in all_included_codes:
+            codes_to_keep.append(code_obj.code)
 
     # Delete any code objs that belong to this search only, and are not in the codes_to_keep set
     search_only_code_objs.exclude(code__in=codes_to_keep).delete()

--- a/builder/decorators.py
+++ b/builder/decorators.py
@@ -31,9 +31,9 @@ def require_permission(view_fn):
     """Ensure the user has permission to edit the draft codelist."""
 
     @wraps(view_fn)
-    def wrapped_view(request, draft):
+    def wrapped_view(request, draft, **kwargs):
         if request.user == draft.author:
-            return view_fn(request, draft)
+            return view_fn(request, draft, **kwargs)
         else:
             return redirect("/")
 

--- a/builder/management/commands/generate_builder_fixture.py
+++ b/builder/management/commands/generate_builder_fixture.py
@@ -9,6 +9,7 @@ from pathlib import Path
 from django.conf import settings
 from django.core.management import BaseCommand, CommandError, call_command
 from django.db import connections
+from django.test import override_settings
 from django.test.client import Client
 
 from codelists.actions import export_to_builder
@@ -44,7 +45,8 @@ class Command(BaseCommand):
             if version_key != "version_from_scratch":
                 draft = export_to_builder(version=version, author=organisation_user)
 
-            rsp = client.get(draft.get_builder_draft_url())
+            with override_settings(ALLOWED_HOSTS="*"):
+                rsp = client.get(draft.get_builder_draft_url())
             data = {
                 context_key: rsp.context[context_key]
                 for context_key in [

--- a/builder/tests/test_actions.py
+++ b/builder/tests/test_actions.py
@@ -119,27 +119,37 @@ def test_delete_search(version_from_scratch):
     s2 = actions.create_search(
         draft=draft, term="Soft tissue lesion", codes={"239964003"}
     )
+    # This search also returns the codes from s1
+    s3 = actions.create_search(
+        draft=draft,
+        term="Enthesopathy of elbow region",
+        codes={"35185008", "73583000", "202855006"},
+    )
 
     # Act: delete the search for "Soft tissue lesion"
     actions.delete_search(search=s2)
 
     # Assert...
-    # that the codelist has only 1 search
-    assert draft.searches.count() == 1
-    # that the codelist has 2 codes
-    assert draft.code_objs.count() == 2
+    # that the codelist has 2 searches
+    assert draft.searches.count() == 2
+    # that the codelist has 3 codes
+    assert draft.code_objs.count() == 3
 
-    # Arrange: recreate the search for "Soft tissue lesion"
-    actions.create_search(draft=draft, term="Soft tissue lesion", codes=["239964003"])
-
-    # Act: delete the search for "epicondylitis"
-    actions.delete_search(search=s1)
+    # Act: delete the search for "Enthesopathy of elbow region"
+    actions.delete_search(search=s3)
 
     # Assert...
     # that the codelist has only 1 search
     assert draft.searches.count() == 1
-    # that the codelist now has only 1 code
-    assert draft.code_objs.count() == 1
+    # that the codelist now has 2 codes; although codes 73583000 and 202855006 are
+    # in the search for "Enthesopathy of elbow region", they are not deleted because
+    # the are also in the search for "epicondylitis"
+    assert draft.code_objs.count() == 2
+
+    # Act: delete the remainng search for "epicondylitis"
+    actions.delete_search(search=s1)
+    assert draft.searches.count() == 0
+    assert draft.code_objs.count() == 0
 
 
 def test_delete_search_codelist_with_codes(version_with_no_searches):

--- a/builder/urls.py
+++ b/builder/urls.py
@@ -7,6 +7,9 @@ app_name = "builder"
 urlpatterns = [
     path("<hash>/", views.draft, name="draft"),
     path("<hash>/search/<search_slug>/", views.search, name="search"),
+    path(
+        "<hash>/search/<search_slug>/delete/", views.delete_search, name="delete-search"
+    ),
     path("<hash>/no-search-term/", views.no_search_term, name="no-search-term"),
     path("<hash>/update/", views.update, name="update"),
     path("<hash>/search/", views.new_search, name="new-search"),

--- a/builder/views.py
+++ b/builder/views.py
@@ -230,6 +230,7 @@ def delete_search(request, draft, search_slug):
     actions.delete_search(search=search)
     messages.info(
         request,
-        f'Search for "{search_slug}" deleted.  Any included codes and their descendants have been maintained.',
+        f'Search for "{search_slug}" deleted. Any codes matching "{search_slug}" that '
+        "do not match any other search term and which are not included in the codelist have been removed",
     )
     return redirect(draft.get_builder_draft_url())

--- a/builder/views.py
+++ b/builder/views.py
@@ -8,6 +8,7 @@ from django.urls import reverse
 from django.utils.text import slugify
 from django.views.decorators.http import require_http_methods
 
+from codelists.models import Search
 from codelists.search import do_search
 
 from . import actions
@@ -80,6 +81,7 @@ def _draft(request, draft, search_slug):
         {
             "term_or_code": s.term_or_code,
             "url": draft.get_builder_search_url(s.slug),
+            "delete_url": draft.get_builder_delete_search_url(s.slug),
             "active": s == search,
         }
         for s in draft.searches.order_by("term")
@@ -88,7 +90,7 @@ def _draft(request, draft, search_slug):
     if searches and draft.code_objs.filter(results=None).exists():
         searches.append(
             {
-                "term": "[no search term]",
+                "term_or_code": "[no search term]",
                 "url": draft.get_builder_no_search_term_url(),
                 "active": search_slug == NO_SEARCH_TERM,
             }
@@ -217,3 +219,14 @@ def new_search(request, draft):
         messages.info(request, f'There are no results for "{term}"')
 
     return redirect(draft.get_builder_search_url(search.slug))
+
+
+@login_required
+@require_http_methods(["POST"])
+@load_draft
+@require_permission
+def delete_search(request, draft, search_slug):
+    search = get_object_or_404(Search, version=draft, slug=search_slug)
+    actions.delete_search(search=search)
+    messages.info(request, f'Search for "{search_slug}" (and associated codes) deleted')
+    return redirect(draft.get_builder_draft_url())

--- a/builder/views.py
+++ b/builder/views.py
@@ -228,5 +228,8 @@ def new_search(request, draft):
 def delete_search(request, draft, search_slug):
     search = get_object_or_404(Search, version=draft, slug=search_slug)
     actions.delete_search(search=search)
-    messages.info(request, f'Search for "{search_slug}" (and associated codes) deleted')
+    messages.info(
+        request,
+        f'Search for "{search_slug}" deleted.  Any included codes and their descendants have been maintained.',
+    )
     return redirect(draft.get_builder_draft_url())

--- a/codelists/models.py
+++ b/codelists/models.py
@@ -522,6 +522,9 @@ class CodeObj(models.Model):
     def is_excluded(self):
         return self.status in ["-", "(-)"]
 
+    def __str__(self):
+        return f"{self.code} {self.status}"
+
 
 class Search(models.Model):
     version = models.ForeignKey(

--- a/codelists/models.py
+++ b/codelists/models.py
@@ -305,6 +305,9 @@ class CodelistVersion(models.Model):
     def get_builder_search_url(self, search_slug):
         return reverse("builder:search", args=[self.hash, search_slug])
 
+    def get_builder_delete_search_url(self, search_slug):
+        return reverse("builder:delete-search", args=[self.hash, search_slug])
+
     def get_builder_no_search_term_url(self):
         return reverse("builder:no-search-term", args=[self.hash])
 

--- a/static/src/js/builder/codelistbuilder.jsx
+++ b/static/src/js/builder/codelistbuilder.jsx
@@ -319,13 +319,40 @@ function Filter(props) {
 function Search(props) {
   const { search } = props;
 
-  return (
+  return search.delete_url ? (
+    <form method="post" action={search.delete_url} className="mt-0 pt-0">
+      <input
+        type="hidden"
+        name="csrfmiddlewaretoken"
+        value={getCookie("csrftoken")}
+      />
+
+      <a
+        href={search.url}
+        className={
+          search.active
+            ? "list-group-item list-group-item-action active py-1 px-2"
+            : "list-group-item list-group-item-action py-1 px-2 "
+        }
+      >
+        {search.term_or_code}
+
+        <button
+          type="submit"
+          name="delete-search"
+          className="btn badge badge-secondary float-right"
+        >
+          x
+        </button>
+      </a>
+    </form>
+  ) : (
     <a
       href={search.url}
       className={
         search.active
-          ? "list-group-item list-group-item-action active py-1"
-          : "list-group-item list-group-item-action py-1"
+          ? "list-group-item list-group-item-action active py-1 px-2"
+          : "list-group-item list-group-item-action py-1 px-2 "
       }
     >
       {search.term_or_code}

--- a/static/test/js/fixtures/version_from_scratch.json
+++ b/static/test/js/fixtures/version_from_scratch.json
@@ -2,22 +2,26 @@
   "searches": [
     {
       "term_or_code": "code: 439656005",
-      "url": "/builder/05657fec/search/code:439656005/",
+      "url": "/builder/6c560cb6/search/code:439656005/",
+      "delete_url": "/builder/6c560cb6/search/code:439656005/delete/",
       "active": false
     },
     {
       "term_or_code": "arthritis",
-      "url": "/builder/05657fec/search/arthritis/",
+      "url": "/builder/6c560cb6/search/arthritis/",
+      "delete_url": "/builder/6c560cb6/search/arthritis/delete/",
       "active": false
     },
     {
       "term_or_code": "elbow",
-      "url": "/builder/05657fec/search/elbow/",
+      "url": "/builder/6c560cb6/search/elbow/",
+      "delete_url": "/builder/6c560cb6/search/elbow/delete/",
       "active": false
     },
     {
       "term_or_code": "tennis",
-      "url": "/builder/05657fec/search/tennis/",
+      "url": "/builder/6c560cb6/search/tennis/",
+      "delete_url": "/builder/6c560cb6/search/tennis/delete/",
       "active": false
     }
   ],
@@ -504,24 +508,24 @@
     "73583000": "(+)"
   },
   "is_editable": true,
-  "update_url": "/builder/05657fec/update/",
-  "search_url": "/builder/05657fec/search/",
+  "update_url": "/builder/6c560cb6/update/",
+  "search_url": "/builder/6c560cb6/search/",
   "versions": [
     {
-      "tag_or_hash": "05657fec",
-      "url": "/codelist/test-university/new-style-codelist/05657fec/",
+      "tag_or_hash": "6c560cb6",
+      "url": "/codelist/test-university/new-style-codelist/6c560cb6/",
       "status": "draft",
       "current": true
     },
     {
-      "tag_or_hash": "1e74f321",
-      "url": "/codelist/test-university/new-style-codelist/1e74f321/",
+      "tag_or_hash": "05657fec",
+      "url": "/codelist/test-university/new-style-codelist/05657fec/",
       "status": "draft",
       "current": false
     },
     {
-      "tag_or_hash": "37846656",
-      "url": "/codelist/test-university/new-style-codelist/37846656/",
+      "tag_or_hash": "1e74f321",
+      "url": "/codelist/test-university/new-style-codelist/1e74f321/",
       "status": "draft",
       "current": false
     },
@@ -548,6 +552,6 @@
     "coding_system_name": "SNOMED CT",
     "organisation_name": "Test University",
     "codelist_full_slug": "test-university/new-style-codelist",
-    "hash": "05657fec"
+    "hash": "6c560cb6"
   }
 }

--- a/static/test/js/fixtures/version_with_complete_searches.json
+++ b/static/test/js/fixtures/version_with_complete_searches.json
@@ -2,22 +2,26 @@
   "searches": [
     {
       "term_or_code": "code: 439656005",
-      "url": "/builder/05657fec/search/code:439656005/",
+      "url": "/builder/6c560cb6/search/code:439656005/",
+      "delete_url": "/builder/6c560cb6/search/code:439656005/delete/",
       "active": false
     },
     {
       "term_or_code": "arthritis",
-      "url": "/builder/05657fec/search/arthritis/",
+      "url": "/builder/6c560cb6/search/arthritis/",
+      "delete_url": "/builder/6c560cb6/search/arthritis/delete/",
       "active": false
     },
     {
       "term_or_code": "elbow",
-      "url": "/builder/05657fec/search/elbow/",
+      "url": "/builder/6c560cb6/search/elbow/",
+      "delete_url": "/builder/6c560cb6/search/elbow/delete/",
       "active": false
     },
     {
       "term_or_code": "tennis",
-      "url": "/builder/05657fec/search/tennis/",
+      "url": "/builder/6c560cb6/search/tennis/",
+      "delete_url": "/builder/6c560cb6/search/tennis/delete/",
       "active": false
     }
   ],
@@ -504,24 +508,24 @@
     "73583000": "(+)"
   },
   "is_editable": true,
-  "update_url": "/builder/05657fec/update/",
-  "search_url": "/builder/05657fec/search/",
+  "update_url": "/builder/6c560cb6/update/",
+  "search_url": "/builder/6c560cb6/search/",
   "versions": [
     {
-      "tag_or_hash": "05657fec",
-      "url": "/codelist/test-university/new-style-codelist/05657fec/",
+      "tag_or_hash": "6c560cb6",
+      "url": "/codelist/test-university/new-style-codelist/6c560cb6/",
       "status": "draft",
       "current": true
     },
     {
-      "tag_or_hash": "1e74f321",
-      "url": "/codelist/test-university/new-style-codelist/1e74f321/",
+      "tag_or_hash": "05657fec",
+      "url": "/codelist/test-university/new-style-codelist/05657fec/",
       "status": "draft",
       "current": false
     },
     {
-      "tag_or_hash": "37846656",
-      "url": "/codelist/test-university/new-style-codelist/37846656/",
+      "tag_or_hash": "1e74f321",
+      "url": "/codelist/test-university/new-style-codelist/1e74f321/",
       "status": "draft",
       "current": false
     },
@@ -548,6 +552,6 @@
     "coding_system_name": "SNOMED CT",
     "organisation_name": "Test University",
     "codelist_full_slug": "test-university/new-style-codelist",
-    "hash": "05657fec"
+    "hash": "6c560cb6"
   }
 }

--- a/static/test/js/fixtures/version_with_no_searches.json
+++ b/static/test/js/fixtures/version_with_no_searches.json
@@ -463,12 +463,12 @@
     "73583000": "(+)"
   },
   "is_editable": true,
-  "update_url": "/builder/37846656/update/",
-  "search_url": "/builder/37846656/search/",
+  "update_url": "/builder/1e74f321/update/",
+  "search_url": "/builder/1e74f321/search/",
   "versions": [
     {
-      "tag_or_hash": "37846656",
-      "url": "/codelist/test-university/new-style-codelist/37846656/",
+      "tag_or_hash": "1e74f321",
+      "url": "/codelist/test-university/new-style-codelist/1e74f321/",
       "status": "draft",
       "current": true
     },
@@ -495,6 +495,6 @@
     "coding_system_name": "SNOMED CT",
     "organisation_name": "Test University",
     "codelist_full_slug": "test-university/new-style-codelist",
-    "hash": "37846656"
+    "hash": "1e74f321"
   }
 }

--- a/static/test/js/fixtures/version_with_some_searches.json
+++ b/static/test/js/fixtures/version_with_some_searches.json
@@ -2,12 +2,13 @@
   "searches": [
     {
       "term_or_code": "arthritis",
-      "url": "/builder/1e74f321/search/arthritis/",
+      "url": "/builder/05657fec/search/arthritis/",
+      "delete_url": "/builder/05657fec/search/arthritis/delete/",
       "active": false
     },
     {
-      "term": "[no search term]",
-      "url": "/builder/1e74f321/no-search-term/",
+      "term_or_code": "[no search term]",
+      "url": "/builder/05657fec/no-search-term/",
       "active": false
     }
   ],
@@ -479,18 +480,18 @@
     "73583000": "(+)"
   },
   "is_editable": true,
-  "update_url": "/builder/1e74f321/update/",
-  "search_url": "/builder/1e74f321/search/",
+  "update_url": "/builder/05657fec/update/",
+  "search_url": "/builder/05657fec/search/",
   "versions": [
     {
-      "tag_or_hash": "1e74f321",
-      "url": "/codelist/test-university/new-style-codelist/1e74f321/",
+      "tag_or_hash": "05657fec",
+      "url": "/codelist/test-university/new-style-codelist/05657fec/",
       "status": "draft",
       "current": true
     },
     {
-      "tag_or_hash": "37846656",
-      "url": "/codelist/test-university/new-style-codelist/37846656/",
+      "tag_or_hash": "1e74f321",
+      "url": "/codelist/test-university/new-style-codelist/1e74f321/",
       "status": "draft",
       "current": false
     },
@@ -517,6 +518,6 @@
     "coding_system_name": "SNOMED CT",
     "organisation_name": "Test University",
     "codelist_full_slug": "test-university/new-style-codelist",
-    "hash": "1e74f321"
+    "hash": "05657fec"
   }
 }


### PR DESCRIPTION
Makes searches deletable.

Code are deleted from the codelist along with the search only if:
1) they only belong to this search (i.e. they aren't returned by any other searches)
2) they are not included
3) they do not have any ancestors that are included

Fixes #358 