### PR TITLE
Refactor slow dictionary comprehension in version view

### DIFF
--- a/codelists/views/version.py
+++ b/codelists/views/version.py
@@ -20,12 +20,13 @@ def version(request, clv):
         parent_map = {p: list(cc) for p, cc in hierarchy.parent_map.items()}
         child_map = {c: list(pp) for c, pp in hierarchy.child_map.items()}
         code_to_term = coding_system.code_to_term(hierarchy.nodes)
+        included = set(clv.codes) & hierarchy.nodes
+        excluded = hierarchy.nodes - included
         code_to_status = {
-            code: "+" if code in clv.codes else "-" for code in hierarchy.nodes
+            **{code: "+" for code in included},
+            **{code: "-" for code in excluded},
         }
-        ancestor_codes = hierarchy.filter_to_ultimate_ancestors(
-            set(clv.codes) & hierarchy.nodes
-        )
+        ancestor_codes = hierarchy.filter_to_ultimate_ancestors(included)
         tree_tables = sorted(
             (type.title(), sorted(codes, key=code_to_term.__getitem__))
             for type, codes in coding_system.codes_by_type(


### PR DESCRIPTION
Large codelists take a really long time to load in the version view; e.g. [this one ](https://www.opencodelists.org/codelist/user/rebkwok/test-large-csv/2227f362/) will load, but it takes about 1.5 mins (after some fiddling with gunicorn settings to let it wait longer before timing out).  @Jongmassey attempted to upload the [same codelist](https://www.opencodelists.org/codelist/user/jon_massey/ali_test_non-ab/3b376697/) and that one runs into a cloudflare timeout.

The slowest part of this view turned out to be a dictionary comprehension; with the version in this PR, that codelist takes about 5s to load for me locally, vs 1.5 mins.  This is just an interim fix to get it to load though - displaying the full list or the tree works, but is still very slow, and doesn't show any sort of helpful loading icon while it renders.  