### PR TITLE
Paginate index pages

### DIFF
--- a/codelists/tests/views/test_index.py
+++ b/codelists/tests/views/test_index.py
@@ -1,4 +1,6 @@
 from codelists.actions import publish_version
+from codelists.models import Handle, Status
+from opencodelists.list_utils import flatten
 
 
 def test_search_only_returns_codelists_with_published_versions(
@@ -18,9 +20,29 @@ def test_search_only_returns_codelists_with_published_versions(
     rsp = client.get(f"/codelist/{organisation.slug}/?q=style")
 
     # Assert that only one codelist is returned.
-    assert len(rsp.context["codelists"]) == 1
-    codelist = rsp.context["codelists"][0]
+    assert len(rsp.context["codelists_page"].object_list) == 1
+    codelist = rsp.context["codelists_page"].object_list[0]
     assert codelist.slug == "new-style-codelist"
+
+
+def test_paginate_codelists(client, organisation, create_codelists):
+    # Create enough published codelists to paginate (codelist index page is paginated by 15)
+    create_codelists(30, owner=organisation, status=Status.PUBLISHED)
+    published_for_organisation = [
+        handle.codelist
+        for handle in Handle.objects.filter(is_current=True, organisation=organisation)
+        if handle.codelist.has_published_versions()
+    ]
+    assert len(published_for_organisation) > 30
+
+    rsp = client.get(f"/codelist/{organisation.slug}/")
+    codelist_page_obj = rsp.context["codelists_page"]
+    assert len(codelist_page_obj.object_list) == 15
+    assert codelist_page_obj.number == 1
+
+    rsp = client.get(f"/codelist/{organisation.slug}/?page=3")
+    codelist_page_obj = rsp.context["codelists_page"]
+    assert len(codelist_page_obj.object_list) == len(published_for_organisation) - 30
 
 
 def test_under_review_index(
@@ -46,10 +68,33 @@ def test_under_review_index(
     # Get the under-review index.
     rsp = client.get(f"/codelist/{organisation.slug}/under-review/")
     # Assert that only under-review versions are returned
-    versions = rsp.context["versions"]
+    versions = rsp.context["versions_page"].object_list
     assert len(versions) == under_review_count + old_style_under_review_count
     for version in versions:
         assert version.status == "under review"
+
+
+def test_paginate_under_review_versions(client, organisation, create_codelists):
+    # Create enough published codelists to paginate (under-review index page is paginated by 30)
+    create_codelists(40, status=Status.UNDER_REVIEW, owner=organisation)
+    under_review_for_organisation = flatten(
+        [
+            list(handle.codelist.versions.filter(status=Status.UNDER_REVIEW))
+            for handle in Handle.objects.filter(
+                is_current=True, organisation=organisation
+            )
+        ]
+    )
+    assert len(under_review_for_organisation) > 40
+
+    rsp = client.get(f"/codelist/{organisation.slug}/under-review/")
+    codelist_page_obj = rsp.context["versions_page"]
+    assert len(codelist_page_obj.object_list) == 30
+    assert codelist_page_obj.number == 1
+
+    rsp = client.get(f"/codelist/{organisation.slug}/under-review/?page=2")
+    codelist_page_obj = rsp.context["versions_page"]
+    assert len(codelist_page_obj.object_list) == len(under_review_for_organisation) - 30
 
 
 def test_search_only_returns_codelists_with_under_review_versions(
@@ -78,7 +123,7 @@ def test_search_only_returns_codelists_with_under_review_versions(
     # Do a search.
     rsp = client.get(f"/codelist/{organisation.slug}/under-review/?q=style")
     # Assert that only versions related to one codelist are returned
-    versions = rsp.context["versions"]
+    versions = rsp.context["versions_page"].object_list
     assert len(versions) == under_review_count
     assert version_under_review.id in [version.id for version in versions]
     for version in versions:

--- a/opencodelists/tests/fixtures.py
+++ b/opencodelists/tests/fixtures.py
@@ -118,6 +118,7 @@ from codelists.actions import (
     export_to_builder,
 )
 from codelists.coding_systems import CODING_SYSTEMS
+from codelists.models import Status
 from codelists.search import do_search
 from opencodelists.actions import (
     add_user_to_organisation,
@@ -635,6 +636,27 @@ def draft(draft_with_complete_searches):
 def new_style_version(universe, request):
     version = universe[request.param]
     return type(version).objects.get(pk=version.pk)
+
+
+@pytest.fixture
+def create_codelists(organisation):
+    """Fixture to create a batch of codelists with a specific status"""
+
+    def _create_codelist(i, owner, status):
+        new_codelist = create_codelist_from_scratch(
+            owner=owner, name=f"Codelist {i}", coding_system_id="snomedct", author=None
+        )
+        version = new_codelist.versions.last()
+        version.status = status
+        version.save()
+        return new_codelist
+
+    def make_codelist(number, owner=None, status=Status.PUBLISHED):
+        return [
+            _create_codelist(i, owner or organisation, status) for i in range(number)
+        ]
+
+    return make_codelist
 
 
 @pytest.fixture

--- a/templates/codelists/_pagination.html
+++ b/templates/codelists/_pagination.html
@@ -1,0 +1,53 @@
+{% if page_obj.paginator.num_pages > 1 %}
+    {% with current_plus_3=page_obj.number|add:'3' current_minus_3=page_obj.number|add:'-3' %}
+    <nav aria-label="Page navigation">
+        <ul class="pagination">
+            {% if page_obj.has_previous %}
+                {% if current_minus_3 >= 1 %}
+                <li class="page-item">
+                    <a class="page-link" href="?page=1&q={{ request.GET.q }}" aria-label="First">
+                        <span aria-hidden="true">1</span>
+                        <span class="sr-only">first</span>
+                    </a>
+                </li>
+                {% endif %}
+                {% if current_minus_3 > 1 %}
+                    <li class="page-item disabled">
+                        <span class="page-link">...</span>
+                    </li>
+                {% endif %}
+            {% endif %}
+
+            {% for page_number in page_obj.paginator.page_range %}
+                {% if page_obj.number == page_number %}
+                    <li class="page-item active">
+                        <span class="page-link">{{ page_number }}
+                            <span class="sr-only">(current)</span>
+                        </span>
+                    </li>
+                {% elif page_number > page_obj.number|add:'-3' and page_number < page_obj.number|add:'3' %}
+                    <li class="page-item">
+                        <a class="page-link" href="?page={{ page_number }}&q={{ request.GET.q }}">{{ page_number }}</a>
+                    </li>
+                {% endif %}
+            {% endfor %}
+
+            {% if page_obj.has_next %}
+                {% if current_plus_3 < page_obj.paginator.num_pages %}
+                    <li class="page-item disabled">
+                        <span class="page-link">...</span>
+                    </li>
+                {% endif %}
+                {% if current_plus_3 <= page_obj.paginator.num_pages %}
+                    <li class="page-item">
+                        <a class="page-link" href="?page={{ page_obj.paginator.num_pages }}&q={{ request.GET.q }}" aria-label="Last">
+                        <span aria-hidden="true">{{ page_obj.paginator.num_pages }}</span>
+                        <span class="sr-only">last</span>
+                        </a>
+                    </li>
+                {% endif %}
+            {% endif %}
+        </ul>
+    </nav>
+    {% endwith %}
+{% endif %}

--- a/templates/codelists/index.html
+++ b/templates/codelists/index.html
@@ -64,23 +64,26 @@
 <div class="row">
   <div class="col-12">
     <dl class="home-codelists">
-      {% for cl in codelists %}
-      <dt>
-        <a href="{{ cl.get_absolute_url }}">{{ cl.name }}</a>
-	<span class="badge badge-secondary">{{ cl.coding_system.short_name }}</span>
-      </dt>
-      <dd>
+      {% for cl in codelists_page %}
+        <dt>
+          <a href="{{ cl.get_absolute_url }}">{{ cl.name }}</a>
+          <span class="badge badge-secondary">{{ cl.coding_system.short_name }}</span>
+        </dt>
+        <dd>
 
-      {% if cl.description %}
-      <div>{{ cl.description|markdown_filter|safe }}</div>
-      {% endif %}
+        {% if cl.description %}
+        <div>{{ cl.description|markdown_filter|safe }}</div>
+        {% endif %}
 
-      {% if not organisation %}
-      <div>Published by <a href="{% url 'codelists:organisation_index' cl.organisation_id %}">{{ cl.organisation.name }}</a></div>
-      {% endif %}
-      </dd>
+        {% if not organisation %}
+        <div>Published by <a href="{% url 'codelists:organisation_index' cl.organisation_id %}">{{ cl.organisation.name }}</a></div>
+        {% endif %}
+        </dd>
       {% endfor %}
     </dl>
   </div>
+
+  {% include "./_pagination.html" with page_obj=codelists_page %}
+
 </div>
 {% endblock %}

--- a/templates/codelists/under_review_index.html
+++ b/templates/codelists/under_review_index.html
@@ -11,7 +11,7 @@
 <div class="row">
   <div class="col-12">
     <dl class="home-codelists">
-      {% for version in versions %}
+      {% for version in versions_page %}
       <dt>
         <a href="{{ version.get_absolute_url }}">{{ version.codelist.name }} - version {{ version.tag_or_hash }}</a>
       </dt>
@@ -19,5 +19,8 @@
       {% endfor %}
     </dl>
   </div>
+
+  {% include "./_pagination.html" with page_obj=versions_page %}
+
 </div>
 {% endblock %}


### PR DESCRIPTION
We have over 2000 published codelists now, and they all get loaded on the main index page.  This adds pagination for the home page, organisation codelists page, and organisation under-review page.

Numbers are arbitrary; 30 for under-review pages and 15 for codelist pages, because under-review pages only show the codelist name, and codelist pages have a bit of descriptive text that makes them take up more space on the page.

![Screenshot from 2022-04-07 14-28-44](https://user-images.githubusercontent.com/6770950/162244942-6e50ae0e-07ea-421f-8eeb-38580b7d59fc.png)
