### PR TITLE
Fix 'My codelists' link to always refer to  current user's codelists

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -133,7 +133,7 @@
           </li>
           {% if request.user.is_authenticated %}
             <li class="navbar-nav nav-item">
-              <a class="nav-link text-white" href="{% url 'user' user.username %}">My codelists</a>
+              <a class="nav-link text-white" href="{% url 'user' request.user.username %}">My codelists</a>
             </li>
             {% if user.memberships.exists %}
             <li class="navbar-nav nav-item">


### PR DESCRIPTION
Some views provide a `user` in the context, which may not be the same user as `request.user` (e.g. opencodelists/views/user.py, builder/views.py).  The base template was using `user` in the url for "My codelists", which can be a shortcut for `request.user` in a template, but in these views it was being overridden, so a user who went to a draft codelist for another user would be taken to the other user's codelist if they clicked on "My codelists", not their own