### PR TITLE
Add a manage command to fix a draft version after a coding system update

### DIFF
--- a/codelists/codeset.py
+++ b/codelists/codeset.py
@@ -150,6 +150,22 @@ class Codeset:
 
         yield from helper(self.defining_tree())
 
+    def reapply_statuses(self):
+        """
+        Build a new Codeset by reapplying the directly included and excluded status, and
+        recalculating inherited statuses
+        """
+        # Find all explicitly included/excluded codes
+        explicitly_included_or_excluded = {(code, "+") for code in self.codes("+")} | {
+            (code, "-") for code in self.codes("-")
+        }
+
+        # Reset the code_to_status dict so all codes are now unresolved
+        self.code_to_status = {code: "?" for code in self.code_to_status}
+
+        # Update with the directly included/excludes statuses
+        return self.update(explicitly_included_or_excluded)
+
     def update(self, updates):
         """Build new Codeset with given updates applied in turn to self's code_to_status.
 

--- a/codelists/management/commands/update_draft.py
+++ b/codelists/management/commands/update_draft.py
@@ -1,0 +1,197 @@
+from collections import defaultdict
+
+import structlog
+from django.core.management import BaseCommand
+from django.db import transaction
+from django.utils.text import slugify
+
+from ...actions import cache_hierarchy
+from ...models import CodelistVersion, CodeObj, SearchResult
+from ...search import do_search
+
+logger = structlog.get_logger()
+
+
+class Command(BaseCommand):
+
+    """
+    Update a draft's codeset; required if a coding system has changed since the draft was created.
+
+    It reruns the draft's searches, then checks for new matching concepts and ensures the codeset
+    is up to date so the builder frontend can display it
+
+    The recreated search will have added any new concepts that are returned by a search.
+    The builder frontend can't deal with new concepts (with unresolved status) if they have
+    a parent that is included/excluded.
+
+    Update all code statuses with the known statuses that are explicitly included
+    or excluded.  This will assign statuses to unresolved codes that have included/excluded
+    parents.  It will also update any previously implicitly included/excluded status that
+    are no longer applicable.
+
+    e.g. On the initial draft, B inherited from A;
+     - A was explicitly included, so B was implicitly included
+    After a coding system update, now A and B have swapped, so A inherits from B
+     - A is still explicitly included
+     - B is now unresolved as it has no parents that are explicitly included or
+       excluded (the fronted can deal with that)
+    """
+
+    def add_arguments(self, parser):
+        parser.add_argument("version_hash")
+
+    def handle(self, version_hash, **kwargs):
+        draft = next(
+            (
+                version
+                for version in CodelistVersion.objects.all()
+                if version.hash == version_hash
+            ),
+            None,
+        )
+        if draft is None:
+            self.stderr.write(f"No CodelistVersion found with hash '{version_hash}'")
+        elif not draft.is_draft:
+            self.stderr.write(
+                f"CodelistVersion '{version_hash}' is not a draft ({draft.status})"
+            )
+        else:
+            original_codeset = draft.codeset
+            logger.info("Updating draft", hash=version_hash)
+            logger.info(
+                "Original codeset", code_to_status=original_codeset.code_to_status
+            )
+            self.update_searches(draft)
+            self.delete_removed_codes(draft)
+            self.update_code_statuses(draft)
+            updates = self.diff(draft.codeset, original_codeset)
+            cache_hierarchy(version=draft)
+
+            if any(updates.values()):
+                self.stdout.write(f"CodelistVersion {version_hash} updated:")
+                if updates["added"]:
+                    for code, status in updates["added"]:
+                        self.stdout.write(f"{code} - {status} (new)")
+                if updates["changed"]:
+                    for code, status in updates["changed"]:
+                        self.stdout.write(f"{code} - {status} (changed)")
+                if updates["removed"]:
+                    for code in updates["removed"]:
+                        self.stdout.write(f"{code} (removed)")
+            else:
+                self.stdout.write(
+                    f"CodelistVersion {version_hash}: no changes required"
+                )
+
+    def update_searches(self, draft):
+        for search in draft.searches.all():
+            codes = do_search(draft.coding_system, term=search.term, code=search.code)[
+                "all_codes"
+            ]
+            self.update_search(
+                draft=draft, term=search.term, code=search.code, codes=codes
+            )
+
+    @transaction.atomic
+    def update_search(self, *, draft, term=None, code=None, codes):
+        """
+        Note: this is more or less a copy of builder.actions.create_search, modifed to
+        update searches on an existing draft
+        """
+        assert bool(term) != bool(code)
+        if term is not None:
+            slug = slugify(term)
+        else:
+            slug = f"code:{code}"
+
+        search = draft.searches.get(term=term, code=code, slug=slug)
+        # Ensure that there is a CodeObj object linked to this draft for each code.
+        codes_with_existing_code_objs = set(
+            draft.code_objs.filter(code__in=codes).values_list("code", flat=True)
+        )
+        codes_without_existing_code_objs = set(codes) - codes_with_existing_code_objs
+        CodeObj.objects.bulk_create(
+            CodeObj(version=draft, code=code)
+            for code in codes_without_existing_code_objs
+        )
+
+        # Create a SearchResult for each new code which doesn't already have one.
+        code_obj_ids = draft.code_objs.filter(code__in=codes).values_list(
+            "id", flat=True
+        )
+        existing_results = SearchResult.objects.filter(
+            search=search, code_obj_id__in=code_obj_ids
+        ).values_list("code_obj_id", flat=True)
+        # find the set of code_obj_ids that don't already exist in the search results
+        to_create = set(code_obj_ids) - set(existing_results)
+        # find code_objs that no longer match a search
+        to_delete = set(existing_results) - set(code_obj_ids)
+
+        SearchResult.objects.bulk_create(
+            SearchResult(search=search, code_obj_id=id) for id in to_create
+        )
+        SearchResult.objects.filter(search=search, code_obj_id__in=to_delete).delete()
+
+        logger.info("Updated Search", search_pk=search.pk)
+
+    def delete_removed_codes(self, draft):
+        """
+        Identify any code objs on the draft that are no longer in the coding system,
+        and delete them
+        """
+        codes_in_coding_system = set(
+            draft.coding_system.code_to_term(draft.codeset.all_codes())
+        )
+        old_codes = draft.codeset.all_codes() - codes_in_coding_system
+        if old_codes:
+            CodeObj.objects.filter(version=draft, code__in=old_codes).delete()
+            logger.info(
+                "Old codes no longer in coding system removed from draft",
+                draft=draft,
+                coding_system=draft.coding_system,
+                removed_codes=old_codes,
+            )
+
+    @transaction.atomic
+    def update_code_statuses(self, draft):
+        """
+        Update a draft's a codeset that may be out of date following a coding system update,
+        by clearing all code statuses and reapplying any explicitly included/excluded codes
+
+        Note: this is more or less a copy of builder.actions.update_code_statuses,
+        except that it creates the new codeset by reapplying the draft's current directly
+        included/excluded codes
+        """
+        new_codeset = draft.codeset.reapply_statuses()
+        status_to_new_code = defaultdict(list)
+        for code, status in new_codeset.code_to_status.items():
+            status_to_new_code[status].append(code)
+
+        for status, codes in status_to_new_code.items():
+            draft.code_objs.filter(code__in=codes).update(status=status)
+
+    def diff(self, updated_codeset, original_codeset):
+        """
+        Compare the updated codeset to the original codeset, and return a dict of codes that
+        have been added, changed and removed in the updated one
+        """
+        removed_codes = set(original_codeset.code_to_status) - set(
+            updated_codeset.code_to_status
+        )
+        new_codes = set(updated_codeset.code_to_status) - set(
+            original_codeset.code_to_status
+        )
+        all_changes = set(updated_codeset.code_to_status.items()) - set(
+            original_codeset.code_to_status.items()
+        )
+        new_code_statuses = {
+            (code, status)
+            for code, status in updated_codeset.code_to_status.items()
+            if code in new_codes
+        }
+
+        return {
+            "added": new_code_statuses,
+            "changed": all_changes - new_code_statuses,
+            "removed": removed_codes,
+        }

--- a/codelists/management/commands/update_draft.py
+++ b/codelists/management/commands/update_draft.py
@@ -40,6 +40,7 @@ class Command(BaseCommand):
     def add_arguments(self, parser):
         parser.add_argument("version_hash")
 
+    @transaction.atomic
     def handle(self, version_hash, **kwargs):
         draft = next(
             (
@@ -92,7 +93,6 @@ class Command(BaseCommand):
                 draft=draft, term=search.term, code=search.code, codes=codes
             )
 
-    @transaction.atomic
     def update_search(self, *, draft, term=None, code=None, codes):
         """
         Note: this is more or less a copy of builder.actions.create_search, modifed to
@@ -152,7 +152,6 @@ class Command(BaseCommand):
                 removed_codes=old_codes,
             )
 
-    @transaction.atomic
     def update_code_statuses(self, draft):
         """
         Update a draft's a codeset that may be out of date following a coding system update,

--- a/codelists/tests/test_api.py
+++ b/codelists/tests/test_api.py
@@ -24,6 +24,27 @@ def test_codelists_get(client, organisation):
             ],
         },
         {
+            "full_slug": "test-university/minimal-codelist",
+            "slug": "minimal-codelist",
+            "name": "Minimal Codelist",
+            "organisation": "Test University",
+            "coding_system_id": "snomedct",
+            "versions": [
+                {
+                    "hash": "1e74f321",
+                    "tag": None,
+                    "full_slug": "test-university/minimal-codelist/1e74f321",
+                    "status": "published",
+                },
+                {
+                    "hash": "05657fec",
+                    "tag": None,
+                    "full_slug": "test-university/minimal-codelist/05657fec",
+                    "status": "draft",
+                },
+            ],
+        },
+        {
             "full_slug": "test-university/new-style-codelist",
             "slug": "new-style-codelist",
             "name": "New-style Codelist",
@@ -77,11 +98,11 @@ def test_codelists_get(client, organisation):
 def test_codelists_get_with_coding_system_id(client, organisation):
     rsp = client.get(f"/api/v1/codelist/{organisation.slug}/?coding_system_id=snomedct")
     data = json.loads(rsp.content)
-    assert len(data["codelists"]) == 3
+    assert len(data["codelists"]) == 4
 
     rsp = client.get(f"/api/v1/codelist/{organisation.slug}/?coding_system_id=")
     data = json.loads(rsp.content)
-    assert len(data["codelists"]) == 3
+    assert len(data["codelists"]) == 4
 
     rsp = client.get(f"/api/v1/codelist/{organisation.slug}/?coding_system_id=bnf")
     data = json.loads(rsp.content)

--- a/codelists/tests/test_commands.py
+++ b/codelists/tests/test_commands.py
@@ -1,0 +1,227 @@
+from io import StringIO
+
+from django.core.management import call_command
+
+from codelists.models import CodeObj
+
+
+def output_from_call_command(command, *args):
+    out = StringIO()
+    err = StringIO()
+    call_command(
+        command,
+        *args,
+        stdout=out,
+        stderr=err,
+    )
+    return out.getvalue().strip(), err.getvalue().strip()
+
+
+def test_update_draft_no_matching_version():
+    out, err = output_from_call_command("update_draft", "foo")
+    assert out == ""
+    assert err == "No CodelistVersion found with hash 'foo'"
+
+
+def test_update_draft_version_not_draft(version_with_some_searches):
+    assert version_with_some_searches.status == "under review"
+    out, err = output_from_call_command("update_draft", version_with_some_searches.hash)
+    assert out == ""
+    assert (
+        err
+        == f"CodelistVersion '{version_with_some_searches.hash}' is not a draft (under review)"
+    )
+
+
+def test_update_draft_version_no_changes_needed(draft_with_some_searches):
+    out, err = output_from_call_command("update_draft", draft_with_some_searches.hash)
+    assert (
+        out == f"CodelistVersion {draft_with_some_searches.hash}: no changes required"
+    )
+    assert err == ""
+
+
+def test_update_draft_output(draft_with_complete_searches):
+    # Test that a draft that requires an update outputs the expected message
+
+    # delete a CodeObj that's included by a parent from the draft to simulate a new concept on the
+    # coding system
+    missing_implicit_concept = draft_with_complete_searches.code_objs.filter(
+        status="(+)"
+    ).first()
+    missing_code = missing_implicit_concept.code
+    missing_implicit_concept.delete()
+
+    out, err = output_from_call_command(
+        "update_draft", draft_with_complete_searches.hash
+    )
+    assert (
+        out
+        == f"CodelistVersion {draft_with_complete_searches.hash} updated:\n{missing_code} - (+) (new)"
+    )
+    assert err == ""
+
+
+def test_update_draft_codeset_new_code(minimal_draft):
+    """
+    There are 4 codes on minimal_draft:
+    2 directly included and 2 implicitly included, as the result of searches for
+    "tennis toe" and "Enthesopathy of elbow"
+    Note 202855006 is a descendant of both 3723001/439656005 (not included) and 35185008/73583000 (included)
+
+    ..  3723001         Arthritis
+    ..  439656005       └ Arthritis of elbow
+    (+) 202855006         └ Lateral epicondylitis
+    ..  116309007       Finding of elbow region
+    ..  128133004       ├ Disorder of elbow
+    ..  429554009       │ ├ Arthropathy of elbow
+    ..  439656005       │ │ └ Arthritis of elbow
+    ..  202855006       │ │   └ Lateral epicondylitis
+    +   35185008        │ ├ Enthesopathy of elbow region
+    (+) 73583000        │ │ └ Epicondylitis
+    (+) 202855006       │ │   └ Lateral epicondylitis
+    ..  239964003       │ └ Soft tissue lesion of elbow region
+    ..  298869002       └ Finding of elbow joint
+    ..  429554009         ├ Arthropathy of elbow
+    ..  439656005         │ └ Arthritis of elbow
+    ..  202855006         │   └ Lateral epicondylitis
+    ..  298163003         └ Elbow joint infla
+    ..  439656005           └ Arthritis of elbow
+    ..  202855006             └ Lateral epicondylitis
+    ..  238484001       Tennis toe
+    +   156659008       (Epicondylitis &/or tennis elbow) or (golfers' elbow) [inactive]
+    """
+
+    # Searches for "tennis toe" and "Enthesopathy of elbow" will return these 4 codes
+    initial_code_to_status = {
+        "238484001": "+",
+        "73583000": "(+)",
+        "202855006": "(+)",
+        "35185008": "+",
+    }
+    assert minimal_draft.codeset.code_to_status == initial_code_to_status
+
+    # Set up the test scenarios
+    # Manipulate the code objs to represent a previous state of the coding system
+
+    # 1) 202855006 is a new code that will be returned when the searches are re-run
+    # i.e. in previous version
+    # +   73583000        │ ├ Epicondylitis
+    # (+) 35185008        │ │ └ Enthesopathy of elbow region
+    # in new version
+    # +   35185008        │ ├ Enthesopathy of elbow region
+    # (+) 73583000        │ │ └ Epicondylitis
+    # (+) 202855006       │ │   └ Lateral epicondylitis
+
+    # SET UP: Delete 202855006 from the version
+    CodeObj.objects.get(version=minimal_draft, code="202855006").delete()
+    # This is the state of the codeset's code_to_status based on searches
+    # that did NOT return 202855006
+    assert minimal_draft.codeset.code_to_status == {
+        "238484001": "+",
+        "73583000": "(+)",
+        "35185008": "+",
+    }
+
+    # update the draft to recreate its searches and derived statuses
+    call_command("update_draft", minimal_draft.hash)
+
+    # the "new" code has been set to its expected inherited status
+    assert minimal_draft.codeset.code_to_status == initial_code_to_status
+
+
+def test_update_draft_codeset_swapped_codes(minimal_draft):
+    # Searches for "tennis toe" and "Enthesopathy of elbow" will return these 4 codes
+    initial_code_to_status = {
+        "238484001": "+",
+        "73583000": "(+)",
+        "202855006": "(+)",
+        "35185008": "+",
+    }
+    assert minimal_draft.codeset.code_to_status == initial_code_to_status
+
+    # Set up the test scenarios
+    # Manipulate the code objs to represent a previous state of the coding system
+
+    # Assume that 73583000 (Epicondylitis) and 35185008 (Enthesopathy of elbow region)
+    # have swapped places - ie. 73583000 used to be the parent of 35185008 and 202855006,
+    # and was explicitly included, with 35185008 implicitly included
+
+    # i.e. in previous version
+    # +   73583000        │ ├ Epicondylitis
+    # (+) 35185008        │ │ └ Enthesopathy of elbow region
+    # (+) 202855006       │ │   └ Lateral epicondylitis
+    # in new version 73583000 is still included, and 202855006 is implicitly included by it
+    # but the new parent 35185008 is now unresolved
+    # ?   35185008        │ ├ Enthesopathy of elbow region
+    # +   73583000        │ │ └ Epicondylitis
+    # (+) 202855006       │ │   └ Lateral epicondylitis
+
+    # SET UP: Update the status of the two codes
+    code_35185008 = CodeObj.objects.get(version=minimal_draft, code="35185008")
+    code_35185008.status = "(+)"
+    code_35185008.save()
+    code_73583000 = CodeObj.objects.get(version=minimal_draft, code="73583000")
+    code_73583000.status = "+"
+    code_73583000.save()
+    assert minimal_draft.codeset.code_to_status == {
+        "238484001": "+",
+        "73583000": "+",
+        "202855006": "(+)",
+        "35185008": "(+)",
+    }
+    # update the draft to recreate its searches and derived statuses
+    call_command("update_draft", minimal_draft.hash)
+    # 35185008 was implicitly included by inclusion of 73583000, but now it is the
+    # parent of 73583000.  Its status has been updated to '?'; this is OK for the
+    # frontend, because it has no ancestors that are included/excluded
+    # 202855006 is still a child of the explicity included 73583000, so it remains
+    # implicitly included
+    assert minimal_draft.codeset.code_to_status == {
+        "35185008": "?",
+        "73583000": "+",
+        "238484001": "+",
+        "202855006": "(+)",
+    }
+
+
+def test_update_draft_codeset_replaced_code(minimal_draft):
+    # Searches for "tennis toe" and "Enthesopathy of elbow" will return these 4 codes
+    initial_code_to_status = {
+        "238484001": "+",
+        "73583000": "(+)",
+        "202855006": "(+)",
+        "35185008": "+",
+    }
+    assert minimal_draft.codeset.code_to_status == initial_code_to_status
+
+    # Set up the test scenarios
+    # Manipulate the code objs to represent a previous state of the coding system
+
+    # Assume that the hierarchy has changed so 73583000 is a replacement for another
+    # code 99999999 which no longer exists
+
+    # i.e. in previous version
+    # +   35185008        │ ├ Enthesopathy of elbow region
+    # (+) 99999999        │ │ └ Epicondylitis
+    # (+) 202855006       │ │   └ Lateral epicondylitis
+    # in new version
+    # +   35185008        │ ├ Enthesopathy of elbow region
+    # (+) 73583000        │ │ └ Epicondylitis
+    # (+) 202855006       │ │   └ Lateral epicondylitis
+
+    # SETUP: delete 73583000 and create 99999999
+    CodeObj.objects.get(version=minimal_draft, code="73583000").delete()
+    CodeObj.objects.create(version=minimal_draft, code="99999999", status="(+)")
+    assert minimal_draft.codeset.code_to_status == {
+        "35185008": "+",
+        "99999999": "(+)",
+        "238484001": "+",
+        "202855006": "(+)",
+    }
+    # update the draft to recreate its searches and derived statuses
+    call_command("update_draft", minimal_draft.hash)
+    # 99999999 has been replaced by 73583000, and is now implicitly included by inclusion
+    # of its parent 35185008
+
+    assert minimal_draft.codeset.code_to_status == initial_code_to_status

--- a/coding_systems/snomedct/fixtures/enthesopathy-of-elbow-region-plus-tennis-toe.csv
+++ b/coding_systems/snomedct/fixtures/enthesopathy-of-elbow-region-plus-tennis-toe.csv
@@ -1,0 +1,5 @@
+code,term
+238484001,Tennis toe
+202855006,Lateral epicondylitis
+35185008,Enthesopathy of elbow region
+73583000,Epicondylitis

--- a/opencodelists/tests/fixtures.py
+++ b/opencodelists/tests/fixtures.py
@@ -211,6 +211,11 @@ def build_fixtures():
         "disorder-of-elbow-excl-arthritis.csv"
     )
 
+    # enthesopathy_of_elbow_region_plus_tennis_toe
+    enthesopathy_of_elbow_region_plus_tennis_toe = load_codes_from_csv(
+        "enthesopathy-of-elbow-region-plus-tennis-toe.csv"
+    )
+
     # organisation
     # - has two users:
     #   - organisation_admin
@@ -509,6 +514,33 @@ def build_fixtures():
     # - belongs to user_codelist
     user_version = user_codelist.versions.get()
 
+    # minimal codelist with codes
+    # - belongs to organisation
+    # - has 4 codes matching searches
+    # - has one version
+    #   - minimal_version_with_codes
+    minimal_codelist = create_codelist_with_codes(
+        owner=organisation,
+        name="Minimal Codelist",
+        coding_system_id="snomedct",
+        codes=enthesopathy_of_elbow_region_plus_tennis_toe,
+    )
+    # minimal_version
+    # - belongs to minimal_codelist
+    minimal_version = minimal_codelist.versions.get()
+    minimal_draft = export_to_builder(version=minimal_version, author=organisation_user)
+    create_search(
+        draft=minimal_draft,
+        term="enthesopathy of elbow",
+        codes=codes_for_search_term("enthesopathy of elbow"),
+    )
+    create_search(
+        draft=minimal_draft,
+        term="tennis toe",
+        codes=codes_for_search_term("tennis toe"),
+    )
+    # Check that all code_objs are linked to searches
+    assert not minimal_draft.code_objs.filter(results__isnull=True).exists()
     return locals()
 
 
@@ -599,6 +631,7 @@ user_codelist_from_scratch = build_fixture("user_codelist_from_scratch")
 version_from_scratch = build_fixture("version_from_scratch")
 user_codelist = build_fixture("user_codelist")
 user_version = build_fixture("user_version")
+minimal_draft = build_fixture("minimal_draft")
 
 
 # These extra fixtures make modifications to those built in build_fixtures


### PR DESCRIPTION
Fixes https://github.com/opensafely-core/opencodelists/issues/1275

When a coding system is updated, it can result in a mismatch between the draft version's hierarchy, and its codeset's code_to_status dict (e.g. there are new codes that are implicitly included by others, codes that have swtiched places in the hierarchy, codes that have been replaced).

This PR is an interim strategy to allow us to fix up drafts that were created prior to a coding system update, but defers the full implementation for future us.
- Adds a management command that can be run manually to update a draft
- Modifications to the main codebase are as minimal as possible.  The only addition is `Codeset.reapply_statuses`, and this is only called from the management command.  This means there's some duplicated code in the management command, but the idea was to keep and document all the logic here so that it can be extracted later if/when we get to making the proper solution.

- The management command:

    1. Logs the codes and statuses of the original draft
    2. re-runs the searches on the draft; this creates new code objs with unresolved status if there are new matching concepts
    3. deletes any code objs on the draft that no longer exist in the coding system
    4. updates the codeset by applying all the known explicitly included/excluded codes again, and recalculating all inherited statuses