### PR TITLE
Use "SNOMED CT" more consistently

### DIFF
--- a/codelists/hierarchy.py
+++ b/codelists/hierarchy.py
@@ -46,7 +46,7 @@ class Hierarchy:
         edges = ancestor_relationships | descendant_relationships
 
         # We add an edge from the root node to each code that does not appear in
-        # ancestor_relationships or descendant_relationships (eg inactive SNOMED
+        # ancestor_relationships or descendant_relationships (eg inactive SNOMED CT
         # concepts, or certain TPP Y-Codes).
         codes_in_edges = set(chain(*edges))
         for code in codes:

--- a/coding_systems/ctv3/README
+++ b/coding_systems/ctv3/README
@@ -3,8 +3,8 @@ CTV3
 
 CTV3 is a retired system of clinical terms.
 
-It is the successor to Read v2, and is replaced by SNOMED-CT.  (The "CT" stands for
-"Clinical Terms" in both CTV3 and SNOMED-CT.)
+It is the successor to Read v2, and is replaced by SNOMED CT.  (The "CT" stands for
+"Clinical Terms" in both CTV3 and SNOMED CT.)
 
 No new CTV3 codes are published, although sometimes TPP have published new "Y codes",
 which look like CTV3 codes.

--- a/coding_systems/snomedct/README
+++ b/coding_systems/snomedct/README
@@ -1,9 +1,9 @@
-SNOMED-CT
+SNOMED CT
 ---------
 
 https://www.snomed.org/
 
-SNOMED-CT aims to be the "global common language for clinical terms".
+SNOMED CT aims to be the "global common language for clinical terms".
 
 There is an interantional release, and various national releases.
 

--- a/mappings/ctv3sctmap2/import_data.py
+++ b/mappings/ctv3sctmap2/import_data.py
@@ -8,7 +8,7 @@ from django.db import connection as django_connection
 
 def import_data(release_dir):
     """
-    Import NHSD CTV3 -> SNOMED concept maps
+    Import NHSD CTV3 -> SNOMED CT concept maps
     """
     paths = glob.glob(
         os.path.join(

--- a/mappings/ctv3sctmap2/models.py
+++ b/mappings/ctv3sctmap2/models.py
@@ -3,9 +3,9 @@ from django.db import models
 
 class Mapping(models.Model):
     """
-    Mappings between CTV3 and SNOMED Concepts.
+    Mappings between CTV3 and SNOMED CT Concepts.
 
-    NHS Digital has published mappings between Concepts in the CTV3 and SNOMED
+    NHS Digital has published mappings between Concepts in the CTV3 and SNOMED CT
     coding systems [1].  We ingest those mappings and store them with this
     model.
 

--- a/mappings/ctv3sctmap2/tests/test_mappers.py
+++ b/mappings/ctv3sctmap2/tests/test_mappers.py
@@ -21,7 +21,7 @@ def test_snomedct_to_ctv3():
     """Test snomedct_to_ctv3 returns the correct format."""
     effective_time = datetime.datetime(2020, 1, 1)
 
-    # construct a mapping between a pair of SNOMED and CTV3 codes
+    # construct a mapping between a pair of SNOMED CT and CTV3 codes
     snomed_concept = SCTConcept(
         id="54219001", effective_time=effective_time, active=True
     )

--- a/opencodelists/tests/fixtures.py
+++ b/opencodelists/tests/fixtures.py
@@ -16,7 +16,7 @@ Since each fixture function needs to do the same thing (find the member of the u
 with the given name, reload it from the database, and return it) we use build_fixture()
 to avoid excessive duplication.
 
-We use a very small subset of the SNOMED hierarchy.  For details, see
+We use a very small subset of the SNOMED CT hierarchy.  For details, see
 coding_systems/snomedct/fixtures/README.
 
 There are fixtures for CodelistVersions with two different lists of codes:
@@ -161,7 +161,7 @@ def build_fixture(fixture_name):
 @pytest.fixture(scope="session")
 def snomedct_data(django_db_setup, django_db_blocker):
     with django_db_blocker.unblock():
-        # load enough of the SNOMED hierarchy to be useful
+        # load enough of the SNOMED CT hierarchy to be useful
         call_command("loaddata", SNOMED_FIXTURES_PATH / "core-model-components.json")
         call_command("loaddata", SNOMED_FIXTURES_PATH / "tennis-elbow.json")
         call_command("loaddata", SNOMED_FIXTURES_PATH / "tennis-toe.json")

--- a/userdocs/creating-a-codelist-from-a-csv-file.md
+++ b/userdocs/creating-a-codelist-from-a-csv-file.md
@@ -35,7 +35,7 @@ However, some codelists may require a 'classification' or 'type' column, which c
 Avoid:
 
 * filtering on an include or exclude column when finalising a codelist. Applied filters are lost in CSV conversion: *all* of the codes will be uploaded.
-* editing SNOMED-CT codelists. The codes get rounded.
+* editing SNOMED CT codelists. The codes get rounded.
 
 When you click _Create_ the codelist will be created and you will be taken to the codelist homepage.
 

--- a/userdocs/creating-a-codelist-from-scratch.md
+++ b/userdocs/creating-a-codelist-from-scratch.md
@@ -15,7 +15,7 @@ Choose a name for the codelist, and select a coding system from the dropdown.  I
 
 We currently support codelists using the following coding systems:
 
-- SNOMED-CT
+- SNOMED CT
 - ICD-10
 - CTV3 (Read V3)
 - BNF (British National Formulary codes)

--- a/userdocs/what-is-a-codelist.md
+++ b/userdocs/what-is-a-codelist.md
@@ -13,7 +13,7 @@ A codelist is a set of codes which can be recorded in clinical systems, represen
 Codelists are used in almost all studies in OpenSAFELY - and other health data research -
 to select patients with activities and conditions of interest within the dataset(s) being used.
 
-* Codelists each use a _coding system_ such as SNOMED, DM&D (dictionary of medicines and devices), CTv3 (Clinical Terms v3), etc.
+* Codelists each use a _coding system_ such as SNOMED CT, DM&D (dictionary of medicines and devices), CTv3 (Clinical Terms v3), etc.
 * Codelists can often be large, in order to capture the many possible codes that could represent a certain activity or condition.
 * Creating or selecting a codelist can often be very nuanced, e.g. whether a codelist for "diabetes" should _include_ or _exclude_ gestational diabetes may vary according to the study.
-* Sometimes a combination of codelists of different types may be required to fully capture patients with certain conditions, e.g. _medications_ for asthma (DM&D), _diagnoses_ of asthma in primary care (SNOMED), _diagnoses_ of asthma in a hospital admission (ICD-10).
+* Sometimes a combination of codelists of different types may be required to fully capture patients with certain conditions, e.g. _medications_ for asthma (DM&D), _diagnoses_ of asthma in primary care (SNOMED CT), _diagnoses_ of asthma in a hospital admission (ICD-10).


### PR DESCRIPTION
Relates to https://github.com/opensafely/documentation/issues/910

Most existing references use "SNOMED CT" correctly.