### PR TITLE
Support diffing dm+d codelists

### DIFF
--- a/builder/views.py
+++ b/builder/views.py
@@ -215,7 +215,7 @@ def new_search(request, draft):
     search = actions.create_search(draft=draft, term=term, code=code, codes=codes)
 
     if not codes:
-        messages.info(request, f'There are no results for "{term}"')
+        messages.info(request, f'There are no results for "{code or term}"')
 
     return redirect(draft.get_builder_search_url(search.slug))
 

--- a/codelists/tests/test_api.py
+++ b/codelists/tests/test_api.py
@@ -16,11 +16,38 @@ def test_codelists_get(client, organisation):
             "coding_system_id": "snomedct",
             "versions": [
                 {
-                    "hash": "69a34cc0",
+                    "hash": "1e74f321",
                     "tag": None,
-                    "full_slug": "test-university/codelist-from-scratch/69a34cc0",
+                    "full_slug": "test-university/codelist-from-scratch/1e74f321",
                     "status": "draft",
                 }
+            ],
+        },
+        {
+            "full_slug": "test-university/dmd-codelist",
+            "slug": "dmd-codelist",
+            "name": "DMD Codelist",
+            "coding_system_id": "dmd",
+            "organisation": "Test University",
+            "versions": [
+                {
+                    "hash": "34d1a660",
+                    "tag": None,
+                    "full_slug": "test-university/dmd-codelist/34d1a660",
+                    "status": "under review",
+                },
+                {
+                    "hash": "1bc2332b",
+                    "tag": None,
+                    "full_slug": "test-university/dmd-codelist/1bc2332b",
+                    "status": "under review",
+                },
+                {
+                    "hash": "02b2bff6",
+                    "tag": None,
+                    "full_slug": "test-university/dmd-codelist/02b2bff6",
+                    "status": "under review",
+                },
             ],
         },
         {
@@ -31,15 +58,15 @@ def test_codelists_get(client, organisation):
             "coding_system_id": "snomedct",
             "versions": [
                 {
-                    "hash": "1e74f321",
+                    "hash": "53469981",
                     "tag": None,
-                    "full_slug": "test-university/minimal-codelist/1e74f321",
+                    "full_slug": "test-university/minimal-codelist/53469981",
                     "status": "published",
                 },
                 {
-                    "hash": "05657fec",
+                    "hash": "3a37264c",
                     "tag": None,
-                    "full_slug": "test-university/minimal-codelist/05657fec",
+                    "full_slug": "test-university/minimal-codelist/3a37264c",
                     "status": "draft",
                 },
             ],
@@ -52,21 +79,21 @@ def test_codelists_get(client, organisation):
             "coding_system_id": "snomedct",
             "versions": [
                 {
-                    "hash": "34d1a660",
+                    "hash": "69a34cc0",
                     "tag": None,
-                    "full_slug": "test-university/new-style-codelist/34d1a660",
+                    "full_slug": "test-university/new-style-codelist/69a34cc0",
                     "status": "published",
                 },
                 {
-                    "hash": "1bc2332b",
+                    "hash": "5093d98b",
                     "tag": None,
-                    "full_slug": "test-university/new-style-codelist/1bc2332b",
+                    "full_slug": "test-university/new-style-codelist/5093d98b",
                     "status": "under review",
                 },
                 {
-                    "hash": "02b2bff6",
+                    "hash": "37846656",
                     "tag": None,
-                    "full_slug": "test-university/new-style-codelist/02b2bff6",
+                    "full_slug": "test-university/new-style-codelist/37846656",
                     "status": "under review",
                 },
             ],
@@ -102,7 +129,7 @@ def test_codelists_get_with_coding_system_id(client, organisation):
 
     rsp = client.get(f"/api/v1/codelist/{organisation.slug}/?coding_system_id=")
     data = json.loads(rsp.content)
-    assert len(data["codelists"]) == 4
+    assert len(data["codelists"]) == 5
 
     rsp = client.get(f"/api/v1/codelist/{organisation.slug}/?coding_system_id=bnf")
     data = json.loads(rsp.content)

--- a/codelists/tests/views/test_index.py
+++ b/codelists/tests/views/test_index.py
@@ -46,10 +46,10 @@ def test_paginate_codelists(client, organisation, create_codelists):
 
 
 def test_under_review_index(
-    client, organisation, version_under_review, old_style_codelist
+    client, organisation, version_under_review, old_style_codelist, dmd_codelist
 ):
-    # The organisation has two codelists whose name matches "style", and both
-    # have under review versions
+    # The organisation has three codelists (new style, old style, dmd)
+    # All three codelists have under review versions
 
     # Validate our assumptions about the fixtures.
     assert version_under_review.codelist.organisation == organisation
@@ -65,11 +65,18 @@ def test_under_review_index(
     ).count()
     assert old_style_under_review_count > 0
 
+    assert dmd_codelist.organisation == organisation
+    dmd_under_review_count = dmd_codelist.versions.filter(status="under review").count()
+    assert dmd_under_review_count > 0
+
     # Get the under-review index.
     rsp = client.get(f"/codelist/{organisation.slug}/under-review/")
     # Assert that only under-review versions are returned
     versions = rsp.context["versions_page"].object_list
-    assert len(versions) == under_review_count + old_style_under_review_count
+    assert (
+        len(versions)
+        == under_review_count + old_style_under_review_count + dmd_under_review_count
+    )
     for version in versions:
         assert version.status == "under review"
 

--- a/codelists/tests/views/test_version_diff.py
+++ b/codelists/tests/views/test_version_diff.py
@@ -20,3 +20,48 @@ def test_summarise(version_with_no_searches, version_with_some_searches):
             "term": "Arthritis of elbow",
         }
     ]
+
+
+def test_get_dmd_diff_codes_match(
+    client, dmd_version_asthma_medication, dmd_version_asthma_medication_alt_headers
+):
+    # codelists have identical codes, different CSV headers
+    # 2 codes only:
+    # 10514511000001106 - Adrenaline (base) 220micrograms/dose inhaler
+    # 10525011000001107 - Adrenaline (base) 220micrograms/dose inhaler refill
+
+    rsp = client.get(
+        dmd_version_asthma_medication.get_diff_url(
+            dmd_version_asthma_medication_alt_headers
+        )
+    )
+    assert rsp.context["common_codes"] == {"10514511000001106", "10525011000001107"}
+    assert rsp.context["rhs_only_codes"] == rsp.context["lhs_only_codes"] == set()
+
+
+def test_get_dmd_diff_codes_differ(
+    client, dmd_version_asthma_medication, dmd_version_asthma_medication_refill
+):
+    # codelists have one common code, one different
+    # terms for the common code differ but are extracted from the coding system, so are
+    # summarised identically
+    # Code 123 is unknown in the coding system
+    # dmd_version_asthma_medication
+    # 10514511000001106 - Adrenaline (base) 220micrograms/dose inhaler
+    # 10525011000001107 - Adrenaline (base) 220micrograms/dose inhaler refill
+    # dmd_version_asthma_medication_refill
+    # 10525011000001107 - Adrenaline (base) 220micrograms/dose inhaler refill X
+    # 123 - Test refill
+    rsp = client.get(
+        dmd_version_asthma_medication.get_diff_url(dmd_version_asthma_medication_refill)
+    )
+    assert rsp.context["common_codes"] == {"10525011000001107"}
+    assert rsp.context["lhs_only_codes"] == {"10514511000001106"}
+    assert rsp.context["rhs_only_codes"] == {"123"}
+    assert rsp.context["rhs_only_summary"] == [{"code": "123", "term": "Unknown"}]
+    assert rsp.context["common_summary"] == [
+        {
+            "code": "10525011000001107",
+            "term": "Adrenaline (base) 220micrograms/dose inhaler refill",
+        }
+    ]

--- a/codelists/tests/views/test_version_diff.py
+++ b/codelists/tests/views/test_version_diff.py
@@ -62,6 +62,6 @@ def test_get_dmd_diff_codes_differ(
     assert rsp.context["common_summary"] == [
         {
             "code": "10525011000001107",
-            "term": "Adrenaline (base) 220micrograms/dose inhaler refill",
+            "term": "Adrenaline (base) 220micrograms/dose inhaler refill (VMP)",
         }
     ]

--- a/codelists/views/version_diff.py
+++ b/codelists/views/version_diff.py
@@ -1,5 +1,5 @@
 from django.db.models import Q
-from django.http import Http404
+from django.http import Http404, HttpResponseBadRequest
 from django.shortcuts import get_object_or_404, render
 
 from opencodelists.hash_utils import unhash
@@ -26,8 +26,15 @@ def version_diff(request, clv, other_tag_or_hash):
 
     coding_system = clv.coding_system
 
-    lhs_codes = set(clv.codes)
-    rhs_codes = set(other_clv.codes)
+    if coding_system.id == "dmd":
+        lhs_codes = get_dmd_codes(clv)
+        rhs_codes = get_dmd_codes(other_clv)
+        if lhs_codes is None or rhs_codes is None:
+            raise HttpResponseBadRequest("Could not identify code columns")
+    else:
+        lhs_codes = set(clv.codes)
+        rhs_codes = set(other_clv.codes)
+
     lhs_only_codes = lhs_codes - rhs_codes
     rhs_only_codes = rhs_codes - lhs_codes
     common_codes = lhs_codes & rhs_codes
@@ -50,25 +57,60 @@ def version_diff(request, clv, other_tag_or_hash):
 
 def summarise(codes, coding_system):
     code_to_term = coding_system.code_to_term(codes)
-    hierarchy = Hierarchy.from_codes(coding_system, codes)
-    ancestor_codes = hierarchy.filter_to_ultimate_ancestors(codes)
-    summary = []
-    for ancestor_code in ancestor_codes:
-        descendants = sorted(
-            (
-                {"code": code, "term": code_to_term[code]}
-                for code in (
-                    hierarchy.descendants(ancestor_code) & codes - {ancestor_code}
-                )
-            ),
-            key=lambda d: d["term"],
-        )
-        summary.append(
+
+    if coding_system.id == "dmd":
+        # dm+d has no hierarchy to look up, just return the codes themselves with their
+        # terms
+        summary = [
             {
-                "code": ancestor_code,
-                "term": code_to_term[ancestor_code],
-                "descendants": descendants,
+                "code": code,
+                "term": code_to_term[code],
             }
-        )
+            for code in codes
+        ]
+    else:
+        summary = []
+        hierarchy = Hierarchy.from_codes(coding_system, codes)
+        ancestor_codes = hierarchy.filter_to_ultimate_ancestors(codes)
+
+        for ancestor_code in ancestor_codes:
+            descendants = sorted(
+                (
+                    {"code": code, "term": code_to_term[code]}
+                    for code in (
+                        hierarchy.descendants(ancestor_code) & codes - {ancestor_code}
+                    )
+                ),
+                key=lambda d: d["term"],
+            )
+            summary.append(
+                {
+                    "code": ancestor_code,
+                    "term": code_to_term[ancestor_code],
+                    "descendants": descendants,
+                }
+            )
     summary.sort(key=lambda d: d["term"])
     return summary
+
+
+def get_dmd_codes(clv):
+    """
+    Extract dm+d codes from a codelist version's csv_data
+    """
+    # Uploaded dm+d codelists have a variety of headers
+    # All of these represent the code column in at least one codelist version
+    possible_code_columns = ["dmd_id", "code", "id", "snomed_id", "dmd"]
+    headers, *rows = clv.table
+
+    def _get_col_ix():
+        column = next(
+            (col for col in possible_code_columns if col.strip() in headers), None
+        )
+        if column:
+            return headers.index(column)
+
+    code_ix = _get_col_ix()
+    if code_ix is None:
+        return
+    return {row[code_ix] for row in rows}

--- a/coding_systems/dmd/coding_system.py
+++ b/coding_systems/dmd/coding_system.py
@@ -1,2 +1,26 @@
+from .models import AMP, AMPP, VMP, VMPP, VTM
+
 name = "Dictionary of Medicines and Devices"
 short_name = "dm+d"
+
+
+def lookup_codes(codes):
+    # A code is a unique identifier in dm+d which corresponds to a SNOMED-CT code
+    # It could be the identifier for any of AMP, VMP, VTM, VMPP, AMPP
+    # dm+d codelists generally only include AMPs and VMPs, so we attempt to match codes in
+    # these models first
+    # If not found, look up VTM, VMPP, AMPPs also, in case of user-uploaded codelists that
+    # might contain these
+    for code in codes:
+        for model_cls in [AMP, VMP, AMPP, VMPP, VTM]:
+            try:
+                yield code, model_cls.objects.get(id=code).nm
+                continue
+            except model_cls.DoesNotExist:
+                ...
+
+
+def code_to_term(codes):
+    lookup = {code: term for code, term in lookup_codes(codes)}
+    unknown = set(codes) - set(lookup)
+    return {**lookup, **{code: "Unknown" for code in unknown}}

--- a/coding_systems/dmd/coding_system.py
+++ b/coding_systems/dmd/coding_system.py
@@ -4,7 +4,7 @@ name = "Dictionary of Medicines and Devices"
 short_name = "dm+d"
 
 
-def lookup_codes(codes):
+def lookup_names(codes):
     # A code is a unique identifier in dm+d which corresponds to a SNOMED-CT code
     # It could be the identifier for any of AMP, VMP, VTM, VMPP, AMPP
     # dm+d codelists generally only include AMPs and VMPs, so we attempt to match codes in
@@ -14,13 +14,13 @@ def lookup_codes(codes):
     for code in codes:
         for model_cls in [AMP, VMP, AMPP, VMPP, VTM]:
             try:
-                yield code, model_cls.objects.get(id=code).nm
+                yield code, f"{model_cls.objects.get(id=code).nm} ({model_cls.__name__})"
                 continue
             except model_cls.DoesNotExist:
                 ...
 
 
 def code_to_term(codes):
-    lookup = {code: term for code, term in lookup_codes(codes)}
+    lookup = {code: term for code, term in lookup_names(codes)}
     unknown = set(codes) - set(lookup)
     return {**lookup, **{code: "Unknown" for code in unknown}}

--- a/coding_systems/dmd/coding_system.py
+++ b/coding_systems/dmd/coding_system.py
@@ -11,13 +11,14 @@ def lookup_names(codes):
     # these models first
     # If not found, look up VTM, VMPP, AMPPs also, in case of user-uploaded codelists that
     # might contain these
-    for code in codes:
-        for model_cls in [AMP, VMP, AMPP, VMPP, VTM]:
-            try:
-                yield code, f"{model_cls.objects.get(id=code).nm} ({model_cls.__name__})"
-                continue
-            except model_cls.DoesNotExist:
-                ...
+    codes = set(codes)
+    for model_cls in [AMP, VMP, AMPP, VMPP, VTM]:
+        matched = dict(model_cls.objects.filter(id__in=codes).values_list("id", "nm"))
+        for code, name in matched.items():
+            yield code, f"{name} ({model_cls.__name__})"
+        codes = codes - set(matched.keys())
+        if not codes:
+            break
 
 
 def code_to_term(codes):

--- a/coding_systems/dmd/fixtures/asthma-medication-alt-headers.csv
+++ b/coding_systems/dmd/fixtures/asthma-medication-alt-headers.csv
@@ -1,0 +1,3 @@
+code,term
+10514511000001106,Adrenaline (base) 220micrograms/dose inhaler
+10525011000001107,Adrenaline (base) 220micrograms/dose inhaler refill

--- a/coding_systems/dmd/fixtures/asthma-medication-refill.csv
+++ b/coding_systems/dmd/fixtures/asthma-medication-refill.csv
@@ -1,0 +1,3 @@
+dmd_type,dmd_id,dmd_name,bnf_code
+VMP,10525011000001107,Adrenaline (base) 220micrograms/dose inhaler refill X,0301012A0AAACAC
+VMP,123,Test refill,0301012A0AAACATEST

--- a/coding_systems/dmd/fixtures/asthma-medication.csv
+++ b/coding_systems/dmd/fixtures/asthma-medication.csv
@@ -1,0 +1,3 @@
+dmd_type,dmd_id,dmd_name,bnf_code
+VMP,10514511000001106,Adrenaline (base) 220micrograms/dose inhaler,0301012A0AAABAB
+VMP,10525011000001107,Adrenaline (base) 220micrograms/dose inhaler refill,0301012A0AAACAC

--- a/coding_systems/dmd/fixtures/asthma-medication.json
+++ b/coding_systems/dmd/fixtures/asthma-medication.json
@@ -1,0 +1,157 @@
+[
+{
+    "model": "dmd.vmp",
+    "pk": "10514511000001106",
+    "fields": {
+        "vpiddt": null,
+        "vpidprev": null,
+        "vtm": "65502005",
+        "invalid": false,
+        "nm": "Adrenaline (base) 220micrograms/dose inhaler",
+        "abbrevnm": null,
+        "basis": 2,
+        "nmdt": "2012-02-28",
+        "nmprev": "Adrenaline 220micrograms/dose inhaler",
+        "basis_prev": 2,
+        "nmchange": 4,
+        "combprod": null,
+        "pres_stat": 1,
+        "sug_f": false,
+        "glu_f": false,
+        "pres_f": false,
+        "cfc_f": false,
+        "non_avail": 1,
+        "non_availdt": "2013-03-18",
+        "df_ind": 1,
+        "udfs": "1.000",
+        "udfs_uom": "3317411000001100",
+        "unit_dose_uom": "3317411000001100"
+    }
+},
+{
+    "model": "dmd.vmp",
+    "pk": "10525011000001107",
+    "fields": {
+        "vpiddt": null,
+        "vpidprev": null,
+        "vtm": "65502005",
+        "invalid": false,
+        "nm": "Adrenaline (base) 220micrograms/dose inhaler refill",
+        "abbrevnm": null,
+        "basis": 2,
+        "nmdt": "2012-02-28",
+        "nmprev": "Adrenaline 220micrograms/dose inhaler refill",
+        "basis_prev": 2,
+        "nmchange": 4,
+        "combprod": null,
+        "pres_stat": 1,
+        "sug_f": false,
+        "glu_f": false,
+        "pres_f": false,
+        "cfc_f": false,
+        "non_avail": 1,
+        "non_availdt": "2013-03-18",
+        "df_ind": 1,
+        "udfs": "1.000",
+        "udfs_uom": "3317411000001100",
+        "unit_dose_uom": "3317411000001100"
+    }
+},
+{
+    "model": "dmd.vmpp",
+    "pk": "10514611000001105",
+    "fields": {
+        "invalid": false,
+        "nm": "Adrenaline (base) 220micrograms/dose inhaler 15 ml",
+        "vmp": "10514511000001106",
+        "qtyval": "15.00",
+        "qty_uom": "258773002",
+        "combpack": null,
+        "bnf_code": null
+    }
+},
+{
+    "model": "dmd.vmpp",
+    "pk": "10525411000001103",
+    "fields": {
+        "invalid": false,
+        "nm": "Adrenaline (base) 220micrograms/dose inhaler refill 15 ml",
+        "vmp": "10525011000001107",
+        "qtyval": "15.00",
+        "qty_uom": "258773002",
+        "combpack": null,
+        "bnf_code": null
+    }
+},
+{
+    "model": "dmd.vtm",
+    "pk": "65502005",
+    "fields": {
+        "invalid": false,
+        "nm": "Adrenaline",
+        "abbrevnm": null,
+        "vtmidprev": null,
+        "vtmiddt": "2006-06-05"
+    }
+},
+{
+    "model": "dmd.unitofmeasure",
+    "pk": "3317411000001100",
+    "fields": {
+        "cddt": null,
+        "cdprev": null,
+        "descr": "dose"
+    }
+},
+{
+    "model": "dmd.unitofmeasure",
+    "pk": "258773002",
+    "fields": {
+        "cddt": null,
+        "cdprev": null,
+        "descr": "ml"
+    }
+},
+{
+    "model": "dmd.basisofname",
+    "pk": 1,
+    "fields": {
+        "descr": "rINN - Recommended International Non-proprietary"
+    }
+},
+{
+    "model": "dmd.basisofname",
+    "pk": 2,
+    "fields": {
+        "descr": "BAN - British Approved Name"
+    }
+},
+{
+    "model": "dmd.dfindicator",
+    "pk": 1,
+    "fields": {
+        "descr": "Discrete"
+    }
+},
+{
+    "model": "dmd.virtualproductnonavail",
+    "pk": 1,
+    "fields": {
+        "descr": "Actual Products not Available"
+    }
+},
+{
+    "model": "dmd.virtualproductpresstatus",
+    "pk": 1,
+    "fields": {
+        "descr": "Valid as a prescribable product"
+    }
+},
+{
+    "model": "dmd.namechangereason",
+    "pk": 4,
+    "fields": {
+        "descr": "Other"
+    }
+}
+]

--- a/coding_systems/dmd/tests/test_coding_system.py
+++ b/coding_systems/dmd/tests/test_coding_system.py
@@ -1,0 +1,19 @@
+from coding_systems.dmd.coding_system import code_to_term, lookup_names
+
+
+def test_lookup_names(dmd_data):
+    assert list(lookup_names(["10514511000001106", "10525011000001107", "99999"])) == [
+        ("10514511000001106", "Adrenaline (base) 220micrograms/dose inhaler (VMP)"),
+        (
+            "10525011000001107",
+            "Adrenaline (base) 220micrograms/dose inhaler refill (VMP)",
+        ),
+    ]
+
+
+def test_code_to_term(dmd_data):
+    assert code_to_term(["10514511000001106", "10525011000001107", "99999"]) == {
+        "10514511000001106": "Adrenaline (base) 220micrograms/dose inhaler (VMP)",
+        "10525011000001107": "Adrenaline (base) 220micrograms/dose inhaler refill (VMP)",
+        "99999": "Unknown",
+    }


### PR DESCRIPTION
Fixes #1387

We have a view already for diffing codelists, e.g. https://www.opencodelists.org/codelist/primis-covid19-vacc-uptake/bmi_stage/v1.2/diff/08641331/

This currently only works for codelist versions that have code objects - i.e. new-style codelists that have been imported from CSV using the "create a codelist" form, or built using searches in the codelist builder.  dm+d codelists aren't currently buildable via the builder, so only contain uploaded data in the `CodelistVersion.csv_data` field.  To complicate things further, dm+d uploaded csv data may have different headers, so we have to figure out which column contains the code.  

This PR updates the codelist diff view to support dm+d codelists.  This involves:
1) retrieving codes from the uploaded csv_data for a dm+d codelist verision.
I checked all the headers in the database for dm+d codelists, and there are a limited number of possible headers (most versions have been created by downloading a BNF codelist as dm+d and so have standardised headers). If they have no headers, we raise an error for now (I think this is only a few very old codelist versions)
2) Adding a new `code_to_term` function for dm+d, in line with other coding systems.  The diff view uses this to build the summaries of code differences.
3) Adds some new dmd fixtures and tests


