### PR TITLE
Put the coding system database files in separate directories

### DIFF
--- a/coding_systems/versioning/management/commands/migrate_coding_system.py
+++ b/coding_systems/versioning/management/commands/migrate_coding_system.py
@@ -89,7 +89,11 @@ class Command(BaseCommand):
         Generate filepath for the new database and delete existing database file if necessary
         """
         db_name = coding_system_version.db_name
-        new_db_path = settings.DATABASE_DIR / f"{db_name}.sqlite3"
+        new_db_path = (
+            settings.CODING_SYSTEMS_DATABASE_DIR
+            / coding_system_version.coding_system
+            / f"{db_name}.sqlite3"
+        )
 
         if new_db_path.exists() and force:
             self.stdout.write(f"Database {new_db_path} already exists, deleting...")

--- a/coding_systems/versioning/models.py
+++ b/coding_systems/versioning/models.py
@@ -51,7 +51,11 @@ def update_coding_system_database_connections():
     # (i.e. migrations have been run)
     if database_ready():  # pragma: no cover
         for coding_system_version in CodingSystemVersion.objects.all():
-            db_path = settings.DATABASE_DIR / f"{coding_system_version.db_name}.sqlite3"
+            db_path = (
+                settings.CODING_SYSTEMS_DATABASE_DIR
+                / coding_system_version.coding_system
+                / f"{coding_system_version.db_name}.sqlite3"
+            )
             database_dict = {
                 **connections.databases[DEFAULT_DB_ALIAS],
                 **dj_database_url.parse(f"sqlite:///{db_path}"),

--- a/opencodelists/settings.py
+++ b/opencodelists/settings.py
@@ -153,6 +153,7 @@ DATABASE_DIR = Path(
     env("DATABASE_DIR", BASE_DIR)
 )  # location of sqlite files e.g. /storage/
 DATABASE_DUMP_DIR = DATABASE_DIR / "sql_dump"
+CODING_SYSTEMS_DATABASE_DIR = DATABASE_DIR / "coding_systems"
 
 # Default type for auto-created primary keys
 # https://docs.djangoproject.com/en/3.2/releases/3.2/#customizing-type-of-auto-created-primary-keys


### PR DESCRIPTION
With PR #1397, each coding systems will be migrated to use a separate database.  Whenever we import new data, that will also be imported to a separate database so that we can maintain historic versions of coding systems.  If we keep the database files in the same location as the main db, it will quickly litter the filesystem with sqlite files (in the base directory for local development, and in the /storage/ directory in prod).  This PR just makes each coding system's db files live in a separate subdirectory.