### PR TITLE
Make dokku wait longer

### DIFF
--- a/CHECKS
+++ b/CHECKS
@@ -1,6 +1,6 @@
 # Wait for 30 seconds to allow time for migrations, if necessary
 WAIT=30
 TIMEOUT=60
-ATTEMPTS=5
+ATTEMPTS=10
 
 http://localhost


### PR DESCRIPTION
The last deploy failed before it finished running migrations (it has some slow ones to do)
https://github.com/opensafely-core/opencodelists/actions/runs/3429120087/jobs/5714352203#step:9:105 