### PR TITLE
Skip coverage for third party ECL parser utils

### DIFF
--- a/coding_systems/snomedct/ecl_parser.py
+++ b/coding_systems/snomedct/ecl_parser.py
@@ -34,7 +34,7 @@ def handle(expr):
         return {"included": handle_expr_or_or(tree), "excluded": set()}
     elif tree["type"] == "minus":
         return handle_minus(tree)
-    else:
+    else:  # pragma: no cover
         assert False, tree
 
 
@@ -134,7 +134,7 @@ class ErrorListener:
 
     def reportAmbiguity(
         self, recognizer, dfa, startIndex, stopIndex, exact, ambigAlts, configs
-    ):
+    ):  # pragma: no cover
         raise ParseError(
             f"Ambiguity (startIndex: {startIndex}, stopIndex: {stopIndex})"
         )
@@ -148,7 +148,7 @@ class ErrorListener:
 
     def reportContextSensitivity(
         self, recognizer, dfa, startIndex, stopIndex, prediction, configs
-    ):
+    ):  # pragma: no cover
         raise ParseError(
             f"Context sensitivity (startIndex: {startIndex}, stopIndex: {stopIndex})"
         )

--- a/coding_systems/snomedct/tests/test_ecl_parser.py
+++ b/coding_systems/snomedct/tests/test_ecl_parser.py
@@ -24,6 +24,27 @@ def test_handle(subtests):
             assert handled["excluded"] == excluded
 
 
-def test_parse_error():
+def test_parse_error_syntax_error():
     with pytest.raises(ParseError):
         handle("(111111 OR 222222) MINUS (333333 OR 444444")
+
+
+def test_parse_error_attempting_full_context():
+    with pytest.raises(ParseError, match="Attempting full context"):
+        handle("111111 < 222222")
+
+
+def test_error_nested_minus_operation():
+    node = {
+        "type": "minus",
+        "lhs": {"type": "expr", "operator": None, "value": "222222"},
+        "rhs": {"type": "expr", "operator": None, "value": "333333"},
+    }
+    with pytest.raises(AssertionError, match=str(node)):
+        handle("111111 MINUS (222222 MINUS 333333)")
+
+
+def test_error_child_of():
+    # Child of operator "<!" is not allowed
+    with pytest.raises(AssertionError):
+        handle("<!111111")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,8 @@ omit = [
   "opencodelists/settings.py",
   "opencodelists/wsgi.py",
   "staticfiles",
-  "*/migrations/*"
+  "*/migrations/*",
+  "coding_systems/snomedct/parser_utils/*",
 ]
 
 [tool.coverage.report]


### PR DESCRIPTION
The parser utils for the SNOMED CT Expression Constraint Language are a set of tools that we[ download](https://github.com/opensafely-core/opencodelists/blob/main/coding_systems/snomedct/parser_utils/README).  We have a small ecl_parser module that makes use of them, but the tools themselves are third-party shouldn't need to be included in our overall coverage.

This PR adds a couple more tests for the ecl_parser and omits the third party toold from coverage.