### PR TITLE
Ensure the format of database_alias always follows the expected pattern

### DIFF
--- a/coding_systems/versioning/models.py
+++ b/coding_systems/versioning/models.py
@@ -26,10 +26,17 @@ class CodingSystemRelease(models.Model):
         unique_together = ("coding_system", "release_name", "valid_from")
 
     def save(self, *args, **kwargs):
-        if not self.database_alias:
-            self.database_alias = slugify(
-                f"{self.coding_system}_{self.release_name}_{self.valid_from.strftime('%Y%m%d')}"
-            )
+        # CodingSystem methods and the database router depend on the format
+        # of database_alias following an expected pattern
+        database_alias = slugify(
+            f"{self.coding_system}_{self.release_name}_{self.valid_from.strftime('%Y%m%d')}"
+        )
+        if self.database_alias:
+            assert (
+                self.database_alias == database_alias
+            ), f"database_alias {self.database_alias} does not follow required pattern (expected '{database_alias}'"
+        else:
+            self.database_alias = database_alias
         return super().save(*args, **kwargs)
 
 

--- a/opencodelists/db_utils.py
+++ b/opencodelists/db_utils.py
@@ -87,7 +87,7 @@ class CodingSystemVersionRouter:
             # it's unlikely, but possible, that at some point there could be Mapping models
             # that have FKs to other Mapping models. In that case, `other_app_label` would be None.
             # We can ignore that and let the default router handle it.
-            if other_app_label is not None:
+            if other_app_label is not None:  # pragma: no cover
                 return other_app_label in CODING_SYSTEMS
         # Defer to the default router for anything else
         return None


### PR DESCRIPTION
A CodingSystemRelease is associated with a database_alias, which is expected to be in the format `<coding_system>_<release_name>_<valid_from>`.  The database alias is set on model save, however, it was previously possible for it to be specified on the model as something different.  We don't want to allow that, as it's used to create the release's database file, and it's used by the database router (which expects it to be in this format).  

This PR also adds a test to complete the test coverage on the database router. 