### PR TITLE
Validate old-style CSV uploads

### DIFF
--- a/codelists/forms.py
+++ b/codelists/forms.py
@@ -186,6 +186,7 @@ class CodelistUpdateForm(forms.Form):
 
 
 class CodelistVersionForm(forms.Form, CSVValidationMixin):
+    coding_system_id = forms.CharField(widget=forms.HiddenInput())
     csv_data = forms.FileField(label="CSV data")
 
     class Meta:
@@ -193,6 +194,8 @@ class CodelistVersionForm(forms.Form, CSVValidationMixin):
         fields = ["csv_data"]
 
     def __init__(self, *args, **kwargs):
+        coding_system_id = kwargs.pop("coding_system_id", None)
         self.helper = FormHelper()
         self.helper.add_input(Submit("submit", "Submit"))
         super().__init__(*args, **kwargs)
+        self.fields["coding_system_id"].initial = coding_system_id

--- a/codelists/forms.py
+++ b/codelists/forms.py
@@ -6,8 +6,10 @@ from crispy_forms.layout import Submit
 from django import forms
 from django.forms.models import fields_for_model
 
+from opencodelists.forms import validate_csv_data_codes
 from opencodelists.models import Organisation, User
 
+from .coding_systems import CODING_SYSTEMS
 from .models import Codelist, CodelistVersion, Handle, Reference, SignOff
 
 
@@ -91,6 +93,12 @@ SignOffFormSet = forms.modelformset_factory(
 
 class CSVValidationMixin:
     def clean_csv_data(self):
+        # Eventually coding system version may be a selectable field, but for now it
+        # just defaults to using the most recent one
+        coding_system = CODING_SYSTEMS[
+            self.cleaned_data["coding_system_id"]
+        ].get_by_release_or_most_recent()
+
         data = self.cleaned_data["csv_data"].read().decode("utf-8-sig")
 
         reader = csv.reader(StringIO(data))
@@ -102,18 +110,41 @@ class CSVValidationMixin:
                     f'Header {i+1} ("{value}") contains extraneous whitespace'
                 )
 
-        num_columns = len(header)
-        errors = [i for i, row in enumerate(reader) if len(row) != num_columns]
+        # restrict the headers we expect
+        # BNF codelists downloaded as dm+d will have a `dmd_id` column that contains the
+        # code; for all others, expect a `code` column.
+        possible_code_headers = {"dmd_id", "code"}
+        code_headers = possible_code_headers & set(header)
+        if not code_headers:
+            raise forms.ValidationError(
+                "Expected code header not found: 'dmd_id' or 'code' required"
+            )
+        if code_headers == possible_code_headers:
+            raise forms.ValidationError(
+                "Ambiguous headers: both 'dmd_id' and 'code' found"
+            )
 
-        if errors:
+        code_header = next((col for col in possible_code_headers if col in header))
+        code_col_ix = header.index(code_header)
+        num_columns = len(header)
+
+        number_of_column_errors = []
+        codes = []
+        for i, row in enumerate(reader, start=1):
+            if len(row) != num_columns:
+                number_of_column_errors.append(i)
+            codes.append(row[code_col_ix])
+
+        if number_of_column_errors:
             msg = "Incorrect number of columns on row {}"
             raise forms.ValidationError(
                 [
-                    forms.ValidationError(msg.format(i + 1), code=f"row{i + 1}")
-                    for i in errors
+                    forms.ValidationError(msg.format(i), code=f"row{i}")
+                    for i in number_of_column_errors
                 ]
             )
 
+        validate_csv_data_codes(coding_system, codes)
         return data
 
 

--- a/codelists/models.py
+++ b/codelists/models.py
@@ -472,10 +472,17 @@ class CodelistVersion(models.Model):
             return self._new_style_codes()
 
     def _old_style_codes(self):
-        if self.coding_system_id in ["ctv3", "icd10", "snomedct"]:
+        if self.coding_system_id in ["bnf", "ctv3", "icd10", "snomedct"]:
             headers, *rows = self.table
 
-            for header in ["CTV3ID", "CTV3Code", "ctv3_id", "snomedct_id", "id"]:
+            for header in [
+                "CTV3ID",
+                "CTV3Code",
+                "ctv3_id",
+                "snomedct_id",
+                "id",
+                "code",
+            ]:
                 if header in headers:
                     ix = headers.index(header)
                     break

--- a/codelists/tests/test_forms.py
+++ b/codelists/tests/test_forms.py
@@ -7,43 +7,41 @@ from codelists.forms import CSVValidationMixin
 from .helpers import csv_builder
 
 
-def test_csvvalidation_byte_order_mark():
+def test_csvvalidation_byte_order_mark(bnf_data):
     form = CSVValidationMixin()
 
     # wrap CSV up in SimpleUploadedFile to mirror how a Django view would
     # handle it
-    csv_data = "code,description\n1067731000000107,Injury"
+    csv_data = "code,description\n0301012A0AA,Adrenaline (Asthma)"
     upload_file = csv_builder("\ufeff" + csv_data)
     uploaded_file = SimpleUploadedFile("our csv", upload_file.read())
-    form.cleaned_data = {"csv_data": uploaded_file}
+    form.cleaned_data = {"csv_data": uploaded_file, "coding_system_id": "bnf"}
 
     assert form.clean_csv_data() == csv_data
 
 
-def test_csvvalidation_correct_csv_column_count():
+def test_csvvalidation_correct_csv_column_count(bnf_data):
     form = CSVValidationMixin()
 
     # wrap CSV up in SimpleUploadedFile to mirror how a Django view would
     # handle it
-    csv_data = "code,description\n1067731000000107,Injury whilst swimming (disorder)"
+    csv_data = "code,description\n0301012A0AA,Adrenaline (Asthma)"
     upload_file = csv_builder(csv_data)
     uploaded_file = SimpleUploadedFile("our csv", upload_file.read())
-    form.cleaned_data = {"csv_data": uploaded_file}
+    form.cleaned_data = {"csv_data": uploaded_file, "coding_system_id": "bnf"}
 
     assert form.clean_csv_data() == csv_data
 
 
-def test_codelistform_incorrect_csv_column_count():
+def test_codelistform_incorrect_csv_column_count(bnf_data):
     form = CSVValidationMixin()
 
     # wrap CSV up in SimpleUploadedFile to mirror how a Django view would
     # handle it
-    csv_data = (
-        "code,description\n1067731000000107,Injury whilst swimming (disorder),test"
-    )
+    csv_data = "code,description\n0301012A0AA,Adrenaline (Asthma),test"
     upload_file = csv_builder(csv_data)
     uploaded_file = SimpleUploadedFile("our csv", upload_file.read())
-    form.cleaned_data = {"csv_data": uploaded_file}
+    form.cleaned_data = {"csv_data": uploaded_file, "coding_system_id": "bnf"}
 
     with pytest.raises(ValidationError) as e:
         form.clean_csv_data()
@@ -52,18 +50,75 @@ def test_codelistform_incorrect_csv_column_count():
     assert e.value.messages[0] == "Incorrect number of columns on row 1"
 
 
-def test_codelistform_incorrect_header():
+def test_codelistform_incorrect_header(bnf_data):
     form = CSVValidationMixin()
 
     # wrap CSV up in SimpleUploadedFile to mirror how a Django view would
     # handle it
-    csv_data = "code ,description\n1067731000000107,Injury whilst swimming (disorder)"
+    csv_data = "code ,description\n0301012A0AA,Adrenaline (Asthma)"
     upload_file = csv_builder(csv_data)
     uploaded_file = SimpleUploadedFile("our csv", upload_file.read())
-    form.cleaned_data = {"csv_data": uploaded_file}
+    form.cleaned_data = {"csv_data": uploaded_file, "coding_system_id": "bnf"}
 
     with pytest.raises(ValidationError) as e:
         form.clean_csv_data()
 
     assert len(e.value.messages) == 1
     assert e.value.messages[0] == 'Header 1 ("code ") contains extraneous whitespace'
+
+
+def test_codelistform_no_code_header():
+    form = CSVValidationMixin()
+
+    # wrap CSV up in SimpleUploadedFile to mirror how a Django view would
+    # handle it
+    csv_data = "id,description\n0301012A0AA,Adrenaline (Asthma)"
+    upload_file = csv_builder(csv_data)
+    uploaded_file = SimpleUploadedFile("our csv", upload_file.read())
+    form.cleaned_data = {"csv_data": uploaded_file, "coding_system_id": "bnf"}
+
+    with pytest.raises(ValidationError) as e:
+        form.clean_csv_data()
+
+    assert len(e.value.messages) == 1
+    assert (
+        e.value.messages[0]
+        == "Expected code header not found: 'dmd_id' or 'code' required"
+    )
+
+
+def test_codelistform_ambiguous_code_header():
+    form = CSVValidationMixin()
+
+    # wrap CSV up in SimpleUploadedFile to mirror how a Django view would
+    # handle it
+    csv_data = "code,dmd_id,description\n0301012A0AA,0301012A0AA,Adrenaline (Asthma)"
+    upload_file = csv_builder(csv_data)
+    uploaded_file = SimpleUploadedFile("our csv", upload_file.read())
+    form.cleaned_data = {"csv_data": uploaded_file, "coding_system_id": "bnf"}
+
+    with pytest.raises(ValidationError) as e:
+        form.clean_csv_data()
+
+    assert len(e.value.messages) == 1
+    assert e.value.messages[0] == "Ambiguous headers: both 'dmd_id' and 'code' found"
+
+
+def test_codelistform_invalid_codes():
+    form = CSVValidationMixin()
+
+    # wrap CSV up in SimpleUploadedFile to mirror how a Django view would
+    # handle it
+    csv_data = "code,description\n1234,Adrenaline (Asthma)"
+    upload_file = csv_builder(csv_data)
+    uploaded_file = SimpleUploadedFile("our csv", upload_file.read())
+    form.cleaned_data = {"csv_data": uploaded_file, "coding_system_id": "bnf"}
+
+    with pytest.raises(ValidationError) as e:
+        form.clean_csv_data()
+
+    assert len(e.value.messages) == 1
+    assert e.value.messages[0] == (
+        "CSV file contains 1 unknown code (1234) on line 1 "
+        "(BNF release test, valid from 2020-01-01)"
+    )

--- a/codelists/tests/views/test_codelist_create.py
+++ b/codelists/tests/views/test_codelist_create.py
@@ -46,14 +46,13 @@ def test_get_for_user(client, user):
     assert response.status_code == 200
 
 
-def test_post_success(client, organisation, user):
+def test_post_success(client, organisation, user, bnf_data):
     force_login(organisation, client)
 
-    csv_data = "code,description\n1067731000000107,Injury whilst swimming (disorder)"
+    csv_data = "code,description\n0301012A0AA,Adrenaline (Asthma)"
     data = {
         "name": "Test Codelist",
-        "coding_system_id": "snomedct",
-        "coding_system_database_alias": "snomedct_test_20200101",
+        "coding_system_id": "bnf",
         "description": "This is a test",
         "methodology": "This is how we did it",
         "csv_data": csv_builder(csv_data),
@@ -94,12 +93,12 @@ def test_post_success(client, organisation, user):
 def test_post_invalid(client, organisation):
     force_login(organisation, client)
 
-    csv_data = "code,description\n1067731000000107,Injury whilst swimming (disorder)"
+    csv_data = "code,description\n0301012A0AA,Adrenaline (Asthma)"
 
     # missing signoff-0-user
     data = {
         "name": "Test Codelist",
-        "coding_system_id": "snomedct",
+        "coding_system_id": "bnf",
         "description": "This is a test",
         "methodology": "This is how we did it",
         "csv_data": csv_builder(csv_data),
@@ -130,10 +129,10 @@ def test_post_invalid(client, organisation):
 def test_post_with_duplicate_name(client, organisation):
     force_login(organisation, client)
 
-    csv_data = "code,description\n1067731000000107,Injury whilst swimming (disorder)"
+    csv_data = "code,description\n0301012A0AA,Adrenaline (Asthma)"
     data = {
-        "name": "Old-style Codelist",  # This name is already taken
-        "coding_system_id": "snomedct",
+        "name": "BNF Codelist",  # This name is already taken
+        "coding_system_id": "bnf",
         "description": "This is a test",
         "methodology": "This is how we did it",
         "csv_data": csv_builder(csv_data),
@@ -156,5 +155,5 @@ def test_post_with_duplicate_name(client, organisation):
 
     # confirm we have errors from the codelist form
     assert response.context_data["codelist_form"].errors == {
-        "__all__": ["There is already a codelist called Old-style Codelist"]
+        "__all__": ["There is already a codelist called BNF Codelist"]
     }

--- a/codelists/tests/views/test_version_upload.py
+++ b/codelists/tests/views/test_version_upload.py
@@ -26,13 +26,18 @@ def test_post_unauthorised(client, old_style_codelist):
     assert_post_unauthorised(client, old_style_codelist.get_version_upload_url())
 
 
+def test_get_success(client, old_style_codelist):
+    force_login(old_style_codelist, client)
+    response = client.get(old_style_codelist.get_version_upload_url())
+    form = response.context_data["form"]
+    assert form.fields["coding_system_id"].initial == "snomedct"
+
+
 def test_post_success(client, old_style_codelist):
     force_login(old_style_codelist, client)
 
-    csv_data = "code,description\n1068181000000106, Injury whilst synchronised swimming (disorder)"
-    data = {
-        "csv_data": csv_builder(csv_data),
-    }
+    csv_data = "code,description\n73583000,Epicondylitis (disorder)"
+    data = {"csv_data": csv_builder(csv_data), "coding_system_id": "snomedct"}
 
     with assert_difference(old_style_codelist.versions.count, expected_difference=1):
         response = client.post(old_style_codelist.get_version_upload_url(), data=data)
@@ -46,7 +51,10 @@ def test_post_missing_field(client, old_style_codelist):
     force_login(old_style_codelist, client)
 
     with assert_no_difference(old_style_codelist.versions.count):
-        response = client.post(old_style_codelist.get_version_upload_url(), data={})
+        response = client.post(
+            old_style_codelist.get_version_upload_url(),
+            data={"coding_system_id": "snomedct"},
+        )
 
     assert response.status_code == 200
     assert "form" in response.context_data

--- a/codelists/views/version_upload.py
+++ b/codelists/views/version_upload.py
@@ -16,11 +16,11 @@ template_name = "codelists/version_upload.html"
 def version_upload(request, codelist):
     if request.method == "POST":
         return handle_post(request, codelist)
-    return handle_get(request)
+    return handle_get(request, codelist.coding_system_id)
 
 
-def handle_get(request):
-    ctx = {"form": CodelistVersionForm()}
+def handle_get(request, coding_system_id):
+    ctx = {"form": CodelistVersionForm(coding_system_id=coding_system_id)}
     return TemplateResponse(request, template_name, ctx)
 
 

--- a/opencodelists/forms.py
+++ b/opencodelists/forms.py
@@ -84,23 +84,27 @@ class CodelistCreateForm(forms.Form):
 
         data = f.read().decode("utf-8-sig")
         codes = [row[0] for row in csv.reader(StringIO(data))]
-        unknown_codes_and_ixs = [
-            (ix, code)
-            for ix, code in enumerate(codes)
-            if code not in set(coding_system.lookup_names(codes))
-        ]
-
-        if unknown_codes_and_ixs:
-            line = unknown_codes_and_ixs[0][0] + 1
-            code = unknown_codes_and_ixs[0][1]
-            if len(unknown_codes_and_ixs) == 1:
-                msg = f"CSV file contains 1 unknown code ({code}) on line {line}"
-            else:
-                num = len(unknown_codes_and_ixs)
-                msg = f"CSV file contains {num} unknown code -- the first ({code}) is on line {line}"
-            raise forms.ValidationError(msg)
-
+        validate_csv_data_codes(coding_system, codes)
         return codes
+
+
+def validate_csv_data_codes(coding_system, codes):
+    unknown_codes_and_ixs = [
+        (ix, code)
+        for ix, code in enumerate(codes)
+        if code not in set(coding_system.lookup_names(codes))
+    ]
+
+    if unknown_codes_and_ixs:
+        line = unknown_codes_and_ixs[0][0] + 1
+        code = unknown_codes_and_ixs[0][1]
+        if len(unknown_codes_and_ixs) == 1:
+            msg = f"CSV file contains 1 unknown code ({code}) on line {line}"
+        else:
+            num = len(unknown_codes_and_ixs)
+            msg = f"CSV file contains {num} unknown code -- the first ({code}) is on line {line}"
+        msg += f" ({coding_system.short_name} release {coding_system.release_name}, valid from {coding_system.release.valid_from})"
+        raise forms.ValidationError(msg)
 
 
 class RegisterForm(forms.ModelForm):


### PR DESCRIPTION
Fixes #1388 

Old-style CSV data can be uploaded at `/codelist/<user/username or org>add`; this adds the uploaded csv data to `CodelistVersion.csv_data` rather than generating `CodeObj` instances for each code.  CodelistVersions without hierarchies in OpenCodelists (i.e. dm+d, OPCS-4, ReadV2) can only be uploaded via this method, but all coding systems are allowed.  It's mainly used for uploading dm+d codelists now.  No validation was being done on the uploaded data, beyond checking that headers don't contain whitespace, and all rows have the expected number of columns.

This PR adds validation of the CSV data, by checking that all codes can be looked up in the latest version of the coding system, in the same way that the normal "create a codelist" form does (reports the number of invalid codes, and where the first one is found).  If validation fails, it also reports the coding system release used to validate.  Currently this is always the most recent release that OpenCodelists has.  Even though it can't be changed via the interface yet; it may useful for identifying why an upload doesn't work.  

Validation is also added to the CodelistVersionForm, which is used to upload new CSV data for an existing old-style codelist.

I also decided to limit valid code columns in the form, so old-style CSV data requires a specific code column, which must be either "code" or "dmd_id"; this won't affect any existing CodelistVersions with csv_data that has different headers, and makes it simpler to determine with confidence which column contains the codes.  (`dmd_id` is allowed because the most likely use for this form now is for codelists that have been created in BNF and downloaded as dm+d; `dmd_id` is the header used for the dmd codes in those downloads). 

Also required some updates to tests because they need to use valid codes that exist in the test fixtures.  