### PR TITLE
Bugfixes for dm+d and bnfdmd mapping imports

### DIFF
--- a/coding_systems/dmd/import_data.py
+++ b/coding_systems/dmd/import_data.py
@@ -19,6 +19,10 @@ def import_data(release_zipfile, release_name, valid_from, import_ref=None):
         logger.info("Extracting", release_zip=release_zip.filename)
         release_zip.extractall(path=tempdir)
 
+        inner_zip = Path(tempdir).glob("*.zip")
+        for inner_zipfile in inner_zip:
+            ZipFile(inner_zipfile).extractall(path=tempdir)
+
         with CodingSystemImporter(
             "dmd", release_name, valid_from, import_ref
         ) as database_alias:

--- a/mappings/bnfdmd/README
+++ b/mappings/bnfdmd/README
@@ -1,0 +1,22 @@
+BNF to DM+D (SNOMED) Mappings
+------------------------------------------
+
+dm+d codes are used to identify medicines and devices in use across the NHS.
+
+Codelists are typically built using pseudoBNF and converted to dm+d for use in study definitions.
+
+For more details, see our blog posts [0] and [1].
+
+We obtain the mapping data from the NHS Business Services Authority [2].  New mapping data is released monthly.
+
+On the download page, download the latest release, which will be an zip file called something like `SNOMED - BNF mapping document September 2022.zip`, containing a single
+xlsx file.
+
+To import the data, unzip the file and run:
+
+    ./manage.py import_mapping_data mapping.bnfdmd path/to/xlsx/file
+
+
+[0] https://www.bennett.ox.ac.uk/blog/2019/08/what-is-the-dm-d-the-nhs-dictionary-of-medicines-and-devices/
+[1] https://www.bennett.ox.ac.uk/blog/2022/11/difference-between-bnf-dm-d-and-snomed-ct-codes/
+[2] https://isd.digital.nhs.uk/trud/users/authenticated/filters/0/categories/6/items/24/releases

--- a/mappings/bnfdmd/import_data.py
+++ b/mappings/bnfdmd/import_data.py
@@ -1,3 +1,4 @@
+from django.db import transaction
 from openpyxl import load_workbook
 
 from .models import Mapping
@@ -28,7 +29,9 @@ def import_data(filename):
 
             yield [dmd_code, dmd_type, bnf_code]
 
-    Mapping.objects.bulk_create(
-        Mapping(dmd_code=r[0], dmd_type=r[1], bnf_concept_id=r[2])
-        for r in load_records()
-    )
+    with transaction.atomic():
+        Mapping.objects.all().delete()
+        Mapping.objects.bulk_create(
+            Mapping(dmd_code=r[0], dmd_type=r[1], bnf_concept_id=r[2])
+            for r in load_records()
+        )


### PR DESCRIPTION
Some fixes for dm+d imports, needed to address #1463 

1) dm+d data downloads are a zip file; in the most recent downloads, one of the zip's subfolders is now also zipped, so the importer needs to unzip that too.

2) bnf to dmd mappings are released monthly; I'm not sure when the mappings were last updated in opencodelists, but the import_data command errored due to a unique constraint, because it was trying to bulk import Mapping objects without deleting the existing ones first.  Since we only use the most recent dm+d release currently (both for converting bnf codelists to dm+d, and for uploading dm+d codelists), we want the mapping to also be the most recent.  Mappings might change between releases, so i think it's safest to delete them all and start from a clean slate with the new import.  

Note that we have an issue #1433 with some questions for later around whether we should be maintaining releases of mappings as well as bnf/dm+d coding systems. 