### PR TITLE
Add note to restart app after importing data to coding system READMEs

### DIFF
--- a/coding_systems/bnf/README
+++ b/coding_systems/bnf/README
@@ -34,5 +34,9 @@ imported with:
     --valid-from 2022-07-01
     --import-ref 20220701_1656687539491_BNF_Code_Information.zip
 
+After importing, restart the opencodelists app with:
+
+    dokku ps:restart opencodelists
+
 [0] https://www.bennett.ox.ac.uk/blog/2017/04/prescribing-data-bnf-codes/
 [1] https://applications.nhsbsa.nhs.uk/infosystems/data/showDataSelector.do?reportId=126

--- a/coding_systems/ctv3/README
+++ b/coding_systems/ctv3/README
@@ -42,3 +42,7 @@ For the example above, the data should be imported with:
     --release '2018-04-01 with TPP extensions 2022-11-28'
     --valid-from 2022-11-28
     --import-ref 'Extracted 2022-11-28'
+
+After importing, restart the opencodelists app with:
+
+    dokku ps:restart opencodelists

--- a/coding_systems/dmd/README
+++ b/coding_systems/dmd/README
@@ -30,11 +30,15 @@ To import the data, run:
 For the example above (`nhsbsa_dmd_11.3.0_20221128000001.zip`), the data should be
 imported with:
 
-    dokku run opencodelists python manage.py import_coding_system_data snomedct
+    dokku run opencodelists python manage.py import_coding_system_data dmd
     /storage/data/dmd/nhsbsa_dmd_11.3.0_20221128000001.zip
     --release '2022 11.3.0'
     --valid-from 2022-11-28
     --import-ref nhsbsa_dmd_11.3.0_20221128000001.zip
+
+After importing, restart the opencodelists app with:
+
+    dokku ps:restart opencodelists
 
 [0] https://www.bennett.ox.ac.uk/blog/2019/08/what-is-the-dm-d-the-nhs-dictionary-of-medicines-and-devices/
 [1] https://isd.digital.nhs.uk/trud/users/authenticated/filters/0/categories/6/items/24/releases

--- a/coding_systems/icd10/README
+++ b/coding_systems/icd10/README
@@ -35,4 +35,8 @@ imported with:
     --valid-from 2019-01-01
     --import-ref icdClaML2019ens.zip
 
+After importing, restart the opencodelists app with:
+
+    dokku ps:restart opencodelists
+
 [0] https://apps.who.int/classifications/apps/icd/ClassificationDownload/DLArea/Download.aspx

--- a/coding_systems/snomedct/README
+++ b/coding_systems/snomedct/README
@@ -42,4 +42,8 @@ imported with:
     --valid-from 2022-02-23
     --import-ref uk_sct2cl_32.10.0_20220216000001Z.zip
 
+After importing, restart the opencodelists app with:
+
+    dokku ps:restart opencodelists
+
 [0] https://isd.digital.nhs.uk/trud/users/authenticated/filters/0/categories/26/items/101/releases

--- a/opencodelists/management/commands/import_coding_system_data.py
+++ b/opencodelists/management/commands/import_coding_system_data.py
@@ -89,3 +89,7 @@ class Command(BaseCommand):
             valid_from=valid_from,
             import_ref=import_ref,
         )
+        self.stdout.write(
+            "\n*** APP RESTART REQUIRED ***\n"
+            "Import complete; run `dokku ps:restart opencodelists` to restart the app"
+        )


### PR DESCRIPTION
After importing new coding system data into the prod dokku app, we need to restart the app in order for the new database connections to be picked up