### PR TITLE
fix: Ensure valid-from in management commands is a date

### DIFF
--- a/opencodelists/management/commands/import_coding_system_data.py
+++ b/opencodelists/management/commands/import_coding_system_data.py
@@ -11,7 +11,7 @@ from coding_systems.versioning.models import CodingSystemRelease
 
 def valid_from(input_date):
     try:
-        return datetime.strptime(input_date, "%Y-%m-%d")
+        return datetime.strptime(input_date, "%Y-%m-%d").date()
     except ValueError:
         raise argparse.ArgumentTypeError(f"Not a valid date (YYYY-MM-DD): {input_date}")
 


### PR DESCRIPTION
Make sure we're passing valid-from as a date rather than a datetime.  This was causing imports of specific dm+d versions (as opposed to just the latest version) to fail when checking dates from retrieved releases against the supplied valid-from date
https://github.com/opensafely-core/opencodelists/blob/main/coding_systems/dmd/import_data.py#L59