### PR TITLE
Automate weekly dm+d imports

### DIFF
--- a/coding_systems/dmd/README
+++ b/coding_systems/dmd/README
@@ -12,8 +12,14 @@ On the TRUD release page, subscribe to the releases.
 For local testing, you will need your API key.  Find it on your [account page](https://isd.digital.nhs.uk/trud/users/authenticated/filters/0/account/manage), and set the
 `TRUD_API_KEY` variable in your local .env file.
 
+## Automated updates
 dm+d updates are released weekly.  The release number (11.3.0 in the example above) refers to the month and (zero-indexed) week of the current year.
 
+The latest dm+d data is imported automatically, via a cron job that runs the script at
+deploy/bin/import_latest_dmd.sh each Monday.
+
+
+## Manual updates
 To import the latest release, run:
   ./manage.py import_latest_dmd_data path/to/dmd/download/dir/in/dokku/app
 

--- a/deploy/bin/import_latest_dmd.sh
+++ b/deploy/bin/import_latest_dmd.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+
+set -euo pipefail
+
+# NOTE: this script is run by cron (as the dokku user) every Monday, to co-incide with weekly
+# dm+d releases
+# https://isd.digital.nhs.uk/trud/users/authenticated/filters/0/categories/6/items/24/releases
+
+# Updates to coding systems require restarting the dokku app, so this job is
+# not dokku-managed
+
+# This script should be copied to /var/lib/dokku/data/storage/opencodelists/import_latest_dmd.sh
+# on dokku3 and run using the cronfile at opencodelists/deploy/bin/import_latest_dmd_cron
+# SLACK_WEBHOOK_URL is an environment variable set in the cronfile on dokku3
+
+REPO_ROOT="/app"
+DOWNLOAD_DIR="/storage/data/dmd"
+
+
+#  Post starting import message to slack
+curl -X POST -H 'Content-type: application/json' \
+    --data '{"text":"Starting OpenCodelists import of latest dm+d release"}'\
+    "${SLACK_WEBHOOK_URL}"
+
+
+/usr/bin/dokku run opencodelists \
+    python "$REPO_ROOT"/manage.py import_latest_dmd_data "${DOWNLOAD_DIR}" \
+    && /usr/bin/dokku ps:restart opencodelists
+
+RESULT=$?
+
+if [ $RESULT == 0 ] ; then
+  #  Post success message to slack
+  curl -X POST -H 'Content-type: application/json' \
+    --data '{"text":"Latest dm+d release successfully imported to OpenCodelists"}'\
+    "${SLACK_WEBHOOK_URL}"
+else
+  #  Post failure message to slack
+  curl -X POST -H 'Content-type: application/json' \
+    --data '{"text":"Latest dm+d release failed to import to OpenCodelists"}'\
+    "${SLACK_WEBHOOK_URL}"
+fi

--- a/deploy/bin/import_latest_dmd_cronfile
+++ b/deploy/bin/import_latest_dmd_cronfile
@@ -1,0 +1,9 @@
+# /etc/cron.d/dokku-opencodelists-import-latest-dmd
+# cron job to import latest dm+d releases
+# update SLACK_WEBHOOK_URL with relevant channel url (#tech-noise)
+
+PATH=/usr/local/bin:/usr/bin:/bin
+SHELL=/bin/bash
+SLACK_WEBHOOK_URL=dummy-url
+
+5 23 * * 1 dokku /var/lib/dokku/data/storage/opencodelists/import_latest_dmd.sh


### PR DESCRIPTION
This consists of a script and template cronfile to be run as a cron job each Monday to:
1) Notify slack that dm+d import has started
2) Run the manage command to import the latest dm+d release and restart the dokku app
3) Notify slack about success/failure

We can't use the `app.json` to run the import via dokku-managed cron, because we need to also restart the app when it's done.  So once this is deployed, we'll need to manually copy the script to /var/lib/dokku/data/storage/opencodelists/ on dokku3 and add the cronfile at /etc/cron.d (including updating the SLACK_WEBHOOK_URL with the #tech-noise webhook [found in the Bennett Bot config](https://api.slack.com/apps/A03UM1N45JN/incoming-webhooks?)