### PR TITLE
Use most recent coding system release for new versions

### DIFF
--- a/codelists/actions.py
+++ b/codelists/actions.py
@@ -538,8 +538,6 @@ def convert_codelist_to_new_style(*, codelist):
 @transaction.atomic
 def export_to_builder(*, version, author, coding_system_database_alias):
     """Create a new CodelistVersion for editing in the builder."""
-    # Fetch the coding system for the requested version, or the most recent one, if
-    # no version is specified
     new_coding_system = version.coding_system.get_by_release(
         coding_system_database_alias
     )

--- a/codelists/tests/views/test_version_create.py
+++ b/codelists/tests/views/test_version_create.py
@@ -30,3 +30,22 @@ def test_post_success(client, version):
     draft = version.codelist.versions.get(author__isnull=False, status=Status.DRAFT)
     assert response.status_code == 302
     assert response.url == draft.get_builder_draft_url()
+
+
+def test_post_success_no_coding_system_database_alias(client, version):
+    force_login(version, client)
+
+    assert (
+        version.codelist.versions.filter(
+            author__isnull=False, status=Status.DRAFT
+        ).exists()
+        is False
+    )
+    client.post(
+        version.get_create_url(),
+        {"coding_system_database_alias": ""},
+    )
+
+    draft = version.codelist.versions.get(author__isnull=False, status=Status.DRAFT)
+    # defaults to most recent database alias for the version's coding system release
+    assert draft.coding_system.database_alias == most_recent_database_alias("snomedct")

--- a/codelists/views/version_create.py
+++ b/codelists/views/version_create.py
@@ -3,6 +3,7 @@ from django.shortcuts import redirect
 from django.views.decorators.http import require_POST
 
 from .. import actions
+from ..coding_systems import most_recent_database_alias
 from .decorators import load_version, require_permission
 
 
@@ -11,7 +12,13 @@ from .decorators import load_version, require_permission
 @load_version
 @require_permission
 def version_create(request, version):
+    # Use the requested coding system release, or the most recent one, if
+    # no release is specified
     coding_system_database_alias = request.POST["coding_system_database_alias"]
+    if not coding_system_database_alias:
+        coding_system_database_alias = most_recent_database_alias(
+            version.coding_system.id
+        )
     draft = actions.export_to_builder(
         version=version,
         author=request.user,

--- a/templates/codelists/version.html
+++ b/templates/codelists/version.html
@@ -108,7 +108,7 @@
         <div class="btn-group-vertical btn-block" role="group">
           {% if codelist.is_new_style %}
             {% if can_create_new_version %}
-              <input type="hidden" name="coding_system_database_alias" value={{ clv.coding_system.database_alias }} />
+              <input type="hidden" name="coding_system_database_alias" value="" />
               <button
                 type="submit"
                 class="btn btn-outline-primary btn-block">


### PR DESCRIPTION
We don't yet have a way for users to select a coding system release when they create a codelist or a new version of an existing codelist.  The intention was for those to continue to work as they did before - i.e. they use the most recent release.  This makes creating a new version from a codelist actually do that, rather than using the version that the original codelist was created with.