### PR TITLE
Add a view to show latest release for each coding system

### DIFF
--- a/coding_systems/versioning/tests/test_views.py
+++ b/coding_systems/versioning/tests/test_views.py
@@ -1,0 +1,15 @@
+from django.urls import reverse
+
+from codelists.coding_systems import CODING_SYSTEMS
+
+
+def test_latest_releases(client, setup_coding_systems):
+    response = client.get(reverse("versioning:latest_releases"))
+    assert response.status_code == 200
+    # Coding system releases with database aliases (i.e. not "null", "opcs4" "readv2")
+    # are shown
+    latest_releases_ids = {
+        release.id for release in response.context["latest_releases"]
+    }
+    assert latest_releases_ids == {"icd10", "snomedct", "ctv3", "dmd", "bnf"}
+    assert set(CODING_SYSTEMS) - latest_releases_ids == {"null", "opcs4", "readv2"}

--- a/coding_systems/versioning/urls.py
+++ b/coding_systems/versioning/urls.py
@@ -1,0 +1,11 @@
+from django.urls import path
+
+from . import views
+
+app_name = "versioning"
+
+urlpatterns = [
+    # There was a typo in the codelist names.  If this happens a lot, we could
+    # add a "formerly known as" field to Codelist.
+    path("latest-releases", views.latest_releases, name="latest_releases")
+]

--- a/coding_systems/versioning/views.py
+++ b/coding_systems/versioning/views.py
@@ -1,0 +1,16 @@
+from django.shortcuts import render
+
+from codelists.coding_systems import CODING_SYSTEMS
+
+
+def latest_releases(request):
+    """List latest releases for each coding system"""
+
+    ctx = {
+        "latest_releases": [
+            cs.get_by_release_or_most_recent()
+            for cs in CODING_SYSTEMS.values()
+            if cs.has_database
+        ]
+    }
+    return render(request, "versioning/latest_releases.html", ctx)

--- a/opencodelists/urls.py
+++ b/opencodelists/urls.py
@@ -36,6 +36,7 @@ urlpatterns = [
     path("accounts/register/", views.register, name="register"),
     path("builder/", include("builder.urls")),
     path("conversions/", include("conversions.urls")),
+    path("coding-systems/", include("coding_systems.versioning.urls")),
     path("docs/", include("userdocs.urls")),
     path("__debug__/", include(debug_toolbar.urls)),
     path("robots.txt", RedirectView.as_view(url=settings.STATIC_URL + "robots.txt")),

--- a/templates/versioning/latest_releases.html
+++ b/templates/versioning/latest_releases.html
@@ -1,0 +1,21 @@
+{% extends 'base.html' %}
+
+{% load crispy_forms_tags %}
+
+{% block title_extra %}: Coding System Releases{% endblock %}
+
+{% block content %}
+
+<h1> Coding System Releases</h1>
+
+{% for coding_system_release in latest_releases %}
+    <h4>{{ coding_system_release.name }}</h4>
+    <ul>
+        <li>Latest release: {{ coding_system_release.release_name }}</li>
+        <li>Valid from: {{ coding_system_release.release.valid_from }}
+        <li>Imported on: {{ coding_system_release.release.import_timestamp }}
+    </ul>
+
+{% endfor %}
+
+{% endblock %}


### PR DESCRIPTION
Adds a page at /coding-systems/latest-releases to show the latest release of each coding system (with valid from and import timestamp).  

Currently this is really just for convenience so we can check what the latest imports are and easily see whether a coding system needs to be updated, so it isn't linked from anywhere else.