### PR TITLE
Download CSVs with fixed headers

### DIFF
--- a/codelists/tests/test_models.py
+++ b/codelists/tests/test_models.py
@@ -135,6 +135,23 @@ def test_old_style_table(old_style_version):
     ]
 
 
+def test_old_style_table_with_fixed_headers(old_style_version):
+    assert old_style_version.table_with_fixed_headers() == [
+        ["code", "term"],
+        ["429554009", "Arthropathy of elbow (disorder)"],
+        ["128133004", "Disorder of elbow (disorder)"],
+        ["202855006", "Lateral epicondylitis (disorder)"],
+        ["439656005", "Arthritis of elbow (disorder)"],
+        ["73583000", "Epicondylitis (disorder)"],
+        ["35185008", "Enthesopathy of elbow region (disorder)"],
+        ["239964003", "Soft tissue lesion of elbow region (disorder)"],
+        [
+            "156659008",
+            "(Epicondylitis &/or tennis elbow) or (golfers' elbow) (disorder)",
+        ],
+    ]
+
+
 def test_old_style_codeset(old_style_version):
     assert old_style_version.codeset.codes() == set(old_style_version.codes)
 

--- a/codelists/tests/views/test_version_download.py
+++ b/codelists/tests/views/test_version_download.py
@@ -1,4 +1,38 @@
+from opencodelists.csv_utils import csv_data_to_rows
+
+
 def test_get(client, version):
     rsp = client.get(version.get_download_url())
     data = rsp.content.decode("utf8")
     assert data == version.csv_data_for_download()
+
+
+def test_get_with_fixed_headers(client, old_style_version):
+    assert old_style_version.table[0] == ["id", "name"]
+    rsp = client.get(old_style_version.get_download_url() + "?fixed-headers")
+    data = rsp.content.decode("utf8")
+    assert data == old_style_version.csv_data_for_download(fixed_headers=True)
+    assert csv_data_to_rows(data)[0] == ["code", "term"]
+
+
+def test_get_with_fixed_headers_no_matching_term(client, old_style_version):
+    old_style_version.csv_data = old_style_version.csv_data.replace(
+        "id,name", "id,unk_description"
+    )
+    old_style_version.save()
+    rsp = client.get(old_style_version.get_download_url() + "?fixed-headers")
+    data = rsp.content.decode("utf8")
+    assert data == old_style_version.csv_data_for_download(fixed_headers=True)
+    rows = csv_data_to_rows(data)
+    assert rows[0] == ["code", "term"]
+    assert {row[1] for row in rows[1:]} == {""}
+
+
+def test_get_with_fixed_headers_not_downloadable(client, old_style_version):
+    old_style_version.csv_data = old_style_version.csv_data.replace(
+        "id,name", "unk,name"
+    )
+    old_style_version.save()
+    assert not old_style_version.downloadable
+    rsp = client.get(old_style_version.get_download_url() + "?fixed-headers")
+    assert rsp.status_code == 400

--- a/codelists/views/version_download.py
+++ b/codelists/views/version_download.py
@@ -1,14 +1,17 @@
-from django.http import HttpResponse
+from django.http import HttpResponse, HttpResponseBadRequest
 
 from .decorators import load_version
 
 
 @load_version
 def version_download(request, clv):
+    fixed_headers = "fixed-headers" in request.GET
+    if fixed_headers and not clv.downloadable:
+        return HttpResponseBadRequest("Codelist is not downloadable")
     response = HttpResponse(content_type="text/csv")
     content_disposition = 'attachment; filename="{}.csv"'.format(
         clv.download_filename()
     )
     response["Content-Disposition"] = content_disposition
-    response.write(clv.csv_data_for_download())
+    response.write(clv.csv_data_for_download(fixed_headers=fixed_headers))
     return response


### PR DESCRIPTION
Fixes #1522 
By default, downloading a CSV (for an old-style codelist) just downloads the exact same data that was uploaded.  

(For a new-style codelist - one created with the form at `/users/<username>/new-codelist/` - the download builds the CSV data from the codelists codes, and always contains 2 columns headed "code" and "term".)

Old-style codelists may in the past have been uploaded with a variety of column headings.  This PR adds an optional query param `?fixed-headers` to the download URL which downloads all codelist versions, including old-style ones, with "code" and "term" columns only, with those headings.
e.g. /codelist/codelist/user/rebkwok/test/04e24d7d/download.csv?fixed-headers

This is so OSI can retrieve a codelist CSV with deterministic column headings.