### PR TITLE
API updates to support OSI

### DIFF
--- a/codelists/api.py
+++ b/codelists/api.py
@@ -41,6 +41,7 @@ def codelists_get(request, owner=None):
 
         * coding_system_id
         * tag
+        * include-users
 
     Eg:
 
@@ -56,12 +57,18 @@ def codelists_get(request, owner=None):
                     "hash": "66f08cca",
                     "tag": "2020-04-15",
                     "full_slug": "opensafely/asthma-diagnosis/2020-04-15",
-                    "status": "published"
+                    "status": "published",
+                    "downloadable": True,
+                    "updated_date": "2020-04-15"
                 }
             ]
         },
         ...
     ]
+
+    Note "downloadable" for a codelist version means that the version is either under review or
+    published, and it contains an identifiable code column in the csv data available for
+    download. This is important for use with OpenSAFELY Interactive.
 
     May 2022: The only known production usage of this endpoint is OpenSAFELY Interactive.
     """

--- a/codelists/api.py
+++ b/codelists/api.py
@@ -91,6 +91,12 @@ def codelists_get(request, owner=None):
         # Only include organisaion codelists by default
         if not include_user_codelists and not cl.organisation:
             continue
+
+        # If an owner is specified, only return codelists for which the owner is the
+        # codelist's current owner
+        if owner is not None and cl.owner != owner:
+            continue
+
         record = {
             "full_slug": cl.full_slug(),
             "slug": cl.slug,

--- a/codelists/api.py
+++ b/codelists/api.py
@@ -113,6 +113,7 @@ def codelists_get(request, owner=None):
                     "full_slug": version.full_slug(),
                     "status": version.status,
                     "downloadable": version.downloadable,
+                    "updated_date": version.updated_at.date(),
                 }
             )
 

--- a/codelists/api.py
+++ b/codelists/api.py
@@ -77,6 +77,8 @@ def codelists_get(request, owner=None):
 
     records = []
 
+    include_user_codelists = "include-users" in request.GET
+
     if owner is None:
         codelists = Codelist.objects.all()
     else:
@@ -86,6 +88,9 @@ def codelists_get(request, owner=None):
         codelists.filter(**filter_kwargs).prefetch_related("handles", "versions"),
         key=lambda cl: cl.slug,
     ):
+        # Only include organisaion codelists by default
+        if not include_user_codelists and not cl.organisation:
+            continue
         record = {
             "full_slug": cl.full_slug(),
             "slug": cl.slug,

--- a/codelists/tests/test_api.py
+++ b/codelists/tests/test_api.py
@@ -1,4 +1,5 @@
 import json
+from datetime import datetime
 
 from codelists.actions import update_codelist
 from mappings.dmdvmpprevmap.models import Mapping as VmpPrevMapping
@@ -9,6 +10,8 @@ def test_codelists_get(client, organisation):
     rsp = client.get(f"/api/v1/codelist/{organisation.slug}/")
     data = json.loads(rsp.content)
     assert rsp.status_code == 200
+
+    today = datetime.today().date().isoformat()
     assert data["codelists"] == [
         {
             "full_slug": "test-university/bnf-codelist",
@@ -23,6 +26,7 @@ def test_codelists_get(client, organisation):
                     "full_slug": "test-university/bnf-codelist/69a34cc0",
                     "status": "published",
                     "downloadable": True,
+                    "updated_date": today,
                 },
                 {
                     "hash": "5093d98b",
@@ -30,6 +34,7 @@ def test_codelists_get(client, organisation):
                     "full_slug": "test-university/bnf-codelist/5093d98b",
                     "status": "draft",
                     "downloadable": False,
+                    "updated_date": today,
                 },
             ],
         },
@@ -46,6 +51,7 @@ def test_codelists_get(client, organisation):
                     "full_slug": "test-university/codelist-from-scratch/6c560cb6",
                     "status": "draft",
                     "downloadable": False,
+                    "updated_date": today,
                 }
             ],
         },
@@ -62,6 +68,7 @@ def test_codelists_get(client, organisation):
                     "full_slug": "test-university/dmd-codelist/34d1a660",
                     "status": "under review",
                     "downloadable": True,
+                    "updated_date": today,
                 },
                 {
                     "hash": "1bc2332b",
@@ -69,6 +76,7 @@ def test_codelists_get(client, organisation):
                     "full_slug": "test-university/dmd-codelist/1bc2332b",
                     "status": "under review",
                     "downloadable": True,
+                    "updated_date": today,
                 },
                 {
                     "hash": "02b2bff6",
@@ -76,6 +84,7 @@ def test_codelists_get(client, organisation):
                     "full_slug": "test-university/dmd-codelist/02b2bff6",
                     "status": "under review",
                     "downloadable": True,
+                    "updated_date": today,
                 },
             ],
         },
@@ -92,6 +101,7 @@ def test_codelists_get(client, organisation):
                     "full_slug": "test-university/minimal-codelist/2127b317",
                     "status": "published",
                     "downloadable": True,
+                    "updated_date": today,
                 },
                 {
                     "hash": "08183fe2",
@@ -99,6 +109,7 @@ def test_codelists_get(client, organisation):
                     "full_slug": "test-university/minimal-codelist/08183fe2",
                     "status": "draft",
                     "downloadable": False,
+                    "updated_date": today,
                 },
             ],
         },
@@ -115,6 +126,7 @@ def test_codelists_get(client, organisation):
                     "full_slug": "test-university/new-style-codelist/37846656",
                     "status": "published",
                     "downloadable": True,
+                    "updated_date": today,
                 },
                 {
                     "hash": "1e74f321",
@@ -122,6 +134,7 @@ def test_codelists_get(client, organisation):
                     "full_slug": "test-university/new-style-codelist/1e74f321",
                     "status": "under review",
                     "downloadable": True,
+                    "updated_date": today,
                 },
                 {
                     "hash": "05657fec",
@@ -129,6 +142,7 @@ def test_codelists_get(client, organisation):
                     "full_slug": "test-university/new-style-codelist/05657fec",
                     "status": "under review",
                     "downloadable": True,
+                    "updated_date": today,
                 },
             ],
         },
@@ -145,6 +159,7 @@ def test_codelists_get(client, organisation):
                     "full_slug": "test-university/old-style-codelist/66f08cca",
                     "status": "under review",
                     "downloadable": True,
+                    "updated_date": today,
                 },
                 {
                     "hash": "4de11995",
@@ -152,6 +167,7 @@ def test_codelists_get(client, organisation):
                     "full_slug": "test-university/old-style-codelist/4de11995",
                     "status": "under review",
                     "downloadable": True,
+                    "updated_date": today,
                 },
             ],
         },


### PR DESCRIPTION
Fixes #1540 
updates /api/v1/codelist endpont to:

- return organisation codelists only by default
- include user codelists if the "?include-users" query param is used
- if an owner is specified (by calling e.g. /api/v1/codelist/opensafely/), ignore any codelists for which that owner is not the current owner (previously we were getting the one codelist back in the response which used to belong to opensafely and now belongs to a user)
- Add an `updated_date` for each codelist version returned. (Note this isn't "published_date" for published versions, although in general it SHOULD date of publication, because from the interface, there's no way to modify a published version.  However, since it's an autoadd field, it'll get updated on any save, with or without changes, so it could potentially get updated after actual publication, and we have no way that I know of to verify that.)