### PR TITLE
Default params for snomed import_release

### DIFF
--- a/coding_systems/snomedct/import_data.py
+++ b/coding_systems/snomedct/import_data.py
@@ -32,7 +32,7 @@ def import_data(
 
 
 def import_release(
-    release_zipfile, release_name, valid_from, import_ref, check_compatibility
+    release_zipfile, release_name, valid_from, import_ref=None, check_compatibility=True
 ):
     import_ref = import_ref or release_zipfile.name
 


### PR DESCRIPTION
import_release is now called directly from the import_latest_data manage command, so it needs to have default values for the import_ref and check_compatability args