### PR TITLE
Show terms from original CSV data in diff view if unknown in coding system

### DIFF
--- a/codelists/models.py
+++ b/codelists/models.py
@@ -491,12 +491,25 @@ class CodelistVersion(models.Model):
     def _old_style_codes(self):
         if self.coding_system_id in ["bnf", "ctv3", "icd10", "snomedct"]:
             headers, *rows = self.table
-
+            headers = [header.lower().strip() for header in headers]
+            # (non-dmd) old style codelists are now required to contain a column named "code"
+            # However, older ones could be uploaded with any column names, so we need to
+            # check the headers to identify the most likely one
+            # These represent the valid case-insensitive code column names across all existing
+            # old-syle codelists
             for header in [
-                "CTV3ID",
-                "CTV3Code",
+                "ctv3id",
+                "ctv3code",
                 "ctv3_id",
                 "snomedct_id",
+                "snomedcode",
+                # a few snomed codelist are uploaded with dmd_id as the code column name
+                "dmd_id",
+                "icd10",
+                "icd code",
+                "icd_code",
+                "icd",
+                "icd10_code",
                 "id",
                 "code",
             ]:

--- a/codelists/tests/views/test_version_diff.py
+++ b/codelists/tests/views/test_version_diff.py
@@ -127,3 +127,24 @@ def test_get_dmd_diff_alternative_column_names(
             "term": "Adrenaline (base) 220micrograms/dose inhaler refill (VMP)",
         }
     ]
+
+
+def test_get_dmd_diff_no_code_column(
+    client,
+    dmd_version_asthma_medication,
+    dmd_version_asthma_medication_refill,
+):
+    # in the fixtures, the column names are: dmd_type, dmd_id, dmd_name, bnf_code
+    # rename the code column in one codelist version so no matching code column
+    # will be foung
+    replacement_csv_data = dmd_version_asthma_medication_refill.csv_data.replace(
+        "dmd_type,dmd_id,dmd_name,bnf_code",
+        "dmd_type,unk_id,dmd_name,bnf_code",
+    )
+    dmd_version_asthma_medication_refill.csv_data = replacement_csv_data
+    dmd_version_asthma_medication_refill.save()
+    rsp = client.get(
+        dmd_version_asthma_medication.get_diff_url(dmd_version_asthma_medication_refill)
+    )
+    assert rsp.status_code == 400
+    assert rsp.content.decode() == "Could not identify code columns"

--- a/codelists/tests/views/test_version_diff.py
+++ b/codelists/tests/views/test_version_diff.py
@@ -1,3 +1,5 @@
+import pytest
+
 from codelists.views.version_diff import summarise
 
 
@@ -45,7 +47,7 @@ def test_get_dmd_diff_codes_differ(
     # codelists have one common code, one different
     # terms for the common code differ but are extracted from the coding system, so are
     # summarised identically
-    # Code 123 is unknown in the coding system
+    # Code 123 is unknown in the coding system; it is displayed with the data from the CSV
     # dmd_version_asthma_medication
     # 10514511000001106 - Adrenaline (base) 220micrograms/dose inhaler
     # 10525011000001107 - Adrenaline (base) 220micrograms/dose inhaler refill
@@ -58,7 +60,67 @@ def test_get_dmd_diff_codes_differ(
     assert rsp.context["common_codes"] == {"10525011000001107"}
     assert rsp.context["lhs_only_codes"] == {"10514511000001106"}
     assert rsp.context["rhs_only_codes"] == {"123"}
-    assert rsp.context["rhs_only_summary"] == [{"code": "123", "term": "Unknown"}]
+    assert rsp.context["rhs_only_summary"] == [
+        {"code": "123", "term": "[Unknown] Test refill (VMP)"}
+    ]
+    assert rsp.context["common_summary"] == [
+        {
+            "code": "10525011000001107",
+            "term": "Adrenaline (base) 220micrograms/dose inhaler refill (VMP)",
+        }
+    ]
+
+
+@pytest.mark.parametrize(
+    "rhs_column_names,expected_unknown_term",
+    [
+        ("type,dmd,nm,bnf_code", "[Unknown] Test refill (VMP)"),
+        ("type,id,name,bnf_code", "[Unknown] Test refill (VMP)"),
+        ("obj_type,code,dmd_name,bnf_code", "[Unknown] Test refill (VMP)"),
+        ("dmd_type,snomed_id,term,bnf_code", "[Unknown] Test refill (VMP)"),
+        # no type column name found
+        ("unk,snomed_id,term,bnf_code", "[Unknown] Test refill"),
+        # no term column name found
+        ("type,snomed_id,unk,bnf_code", "Unknown"),
+        # neither term or type column name found
+        ("unk1,snomed_id,unk2,bnf_code", "Unknown"),
+    ],
+)
+def test_get_dmd_diff_alternative_column_names(
+    client,
+    dmd_version_asthma_medication,
+    dmd_version_asthma_medication_refill,
+    rhs_column_names,
+    expected_unknown_term,
+):
+    # codelists have one common code, one different
+    # terms for the common code differ but are extracted from the coding system, so are
+    # summarised identically
+    # Code 123 is unknown in the coding system; it is displayed with the data from the CSV
+    # dmd_version_asthma_medication
+    # 10514511000001106 - Adrenaline (base) 220micrograms/dose inhaler
+    # 10525011000001107 - Adrenaline (base) 220micrograms/dose inhaler refill
+    # dmd_version_asthma_medication_refill
+    # 10525011000001107 - Adrenaline (base) 220micrograms/dose inhaler refill X
+    # 123 - Test refill
+
+    # in the fixtures, the column names are: dmd_type, dmd_id, dmd_name, bnf_code
+    # test that different column names can be used to fetch the same data
+    replacement_csv_data = dmd_version_asthma_medication_refill.csv_data.replace(
+        "dmd_type,dmd_id,dmd_name,bnf_code", rhs_column_names
+    )
+    dmd_version_asthma_medication_refill.csv_data = replacement_csv_data
+    dmd_version_asthma_medication_refill.save()
+    assert dmd_version_asthma_medication_refill.table[0] == rhs_column_names.split(",")
+    rsp = client.get(
+        dmd_version_asthma_medication.get_diff_url(dmd_version_asthma_medication_refill)
+    )
+    assert rsp.context["common_codes"] == {"10525011000001107"}
+    assert rsp.context["lhs_only_codes"] == {"10514511000001106"}
+    assert rsp.context["rhs_only_codes"] == {"123"}
+    assert rsp.context["rhs_only_summary"] == [
+        {"code": "123", "term": expected_unknown_term}
+    ]
     assert rsp.context["common_summary"] == [
         {
             "code": "10525011000001107",

--- a/codelists/views/version_diff.py
+++ b/codelists/views/version_diff.py
@@ -27,16 +27,19 @@ def version_diff(request, clv, other_tag_or_hash):
     lhs_coding_system = clv.coding_system
     rhs_coding_system = other_clv.coding_system
 
+    lhs_csv_data_codes_to_terms = rhs_csv_data_codes_to_terms = None
     if lhs_coding_system.id == "dmd":
-        lhs_codes = get_dmd_codes(clv)
-        rhs_codes = get_dmd_codes(other_clv)
-        if lhs_codes is None or rhs_codes is None:
+        lhs_csv_data_codes_to_terms = get_dmd_codes_and_terms(clv)
+        rhs_csv_data_codes_to_terms = get_dmd_codes_and_terms(other_clv)
+        if lhs_csv_data_codes_to_terms is None or rhs_csv_data_codes_to_terms is None:
             raise HttpResponseBadRequest("Could not identify code columns")
+        lhs_codes = set(lhs_csv_data_codes_to_terms)
+        rhs_codes = set(rhs_csv_data_codes_to_terms)
     else:
         lhs_codes = set(clv.codes)
         rhs_codes = set(other_clv.codes)
 
-    lhs_only_codes = lhs_codes - rhs_codes
+    lhs_only_codes = set(lhs_codes) - set(rhs_codes)
     rhs_only_codes = rhs_codes - lhs_codes
     common_codes = lhs_codes & rhs_codes
 
@@ -48,27 +51,36 @@ def version_diff(request, clv, other_tag_or_hash):
         "lhs_only_codes": lhs_only_codes,
         "rhs_only_codes": rhs_only_codes,
         "common_codes": common_codes,
-        "lhs_only_summary": summarise(lhs_only_codes, lhs_coding_system),
-        "rhs_only_summary": summarise(rhs_only_codes, rhs_coding_system),
-        "common_summary": summarise(common_codes, lhs_coding_system),
+        "lhs_only_summary": summarise(
+            lhs_only_codes, lhs_coding_system, lhs_csv_data_codes_to_terms
+        ),
+        "rhs_only_summary": summarise(
+            rhs_only_codes, rhs_coding_system, rhs_csv_data_codes_to_terms
+        ),
+        "common_summary": summarise(
+            common_codes, lhs_coding_system, lhs_csv_data_codes_to_terms
+        ),
     }
 
     return render(request, "codelists/version_diff.html", ctx)
 
 
-def summarise(codes, coding_system):
+def summarise(codes, coding_system, csv_data_codes_to_terms=None):
     code_to_term = coding_system.code_to_term(codes)
 
     if coding_system.id == "dmd":
         # dm+d has no hierarchy to look up, just return the codes themselves with their
         # terms
-        summary = [
-            {
-                "code": code,
-                "term": code_to_term[code],
-            }
-            for code in codes
-        ]
+        summary = []
+        for code in codes:
+            term = code_to_term[code]
+            if (
+                term == "Unknown"
+                and csv_data_codes_to_terms is not None
+                and csv_data_codes_to_terms[code] is not None
+            ):
+                term = f"[Unknown] {csv_data_codes_to_terms[code]}"
+            summary.append({"code": code, "term": term})
     else:
         summary = []
         hierarchy = Hierarchy.from_codes(coding_system, codes)
@@ -95,23 +107,38 @@ def summarise(codes, coding_system):
     return summary
 
 
-def get_dmd_codes(clv):
+def get_dmd_codes_and_terms(clv):
     """
     Extract dm+d codes from a codelist version's csv_data
     """
     # Uploaded dm+d codelists have a variety of headers
     # All of these represent the code column in at least one codelist version
-    possible_code_columns = ["dmd_id", "code", "id", "snomed_id", "dmd"]
+    possible_columns = {
+        "code": ["dmd_id", "code", "id", "snomed_id", "dmd"],
+        "term": ["term", "name", "dmd_name", "nm"],
+        "type": ["dmd_type", "obj_type", "type"],
+    }
     headers, *rows = clv.table
 
-    def _get_col_ix():
+    def _get_col_ix(col_type):
         column = next(
-            (col for col in possible_code_columns if col.strip() in headers), None
+            (col for col in possible_columns[col_type] if col.strip() in headers), None
         )
         if column:
             return headers.index(column)
 
-    code_ix = _get_col_ix()
+    code_ix = _get_col_ix("code")
     if code_ix is None:
         return
-    return {row[code_ix] for row in rows}
+    term_ix = _get_col_ix("term")
+    type_ix = _get_col_ix("type")
+
+    def get_term(row):
+        if term_ix is None:
+            return
+        term = row[term_ix]
+        if type_ix is not None:
+            term = f"{term} ({row[type_ix]})"
+        return term
+
+    return {row[code_ix]: get_term(row) for row in rows}

--- a/codelists/views/version_diff.py
+++ b/codelists/views/version_diff.py
@@ -27,10 +27,9 @@ def version_diff(request, clv, other_tag_or_hash):
     lhs_coding_system = clv.coding_system
     rhs_coding_system = other_clv.coding_system
 
-    lhs_csv_data_codes_to_terms = rhs_csv_data_codes_to_terms = None
+    lhs_csv_data_codes_to_terms = get_csv_data_code_to_terms(clv)
+    rhs_csv_data_codes_to_terms = get_csv_data_code_to_terms(other_clv)
     if lhs_coding_system.id == "dmd":
-        lhs_csv_data_codes_to_terms = get_dmd_codes_and_terms(clv)
-        rhs_csv_data_codes_to_terms = get_dmd_codes_and_terms(other_clv)
         if lhs_csv_data_codes_to_terms is None or rhs_csv_data_codes_to_terms is None:
             return HttpResponseBadRequest("Could not identify code columns")
         lhs_codes = set(lhs_csv_data_codes_to_terms)
@@ -66,21 +65,19 @@ def version_diff(request, clv, other_tag_or_hash):
 
 
 def summarise(codes, coding_system, csv_data_codes_to_terms=None):
+    csv_data_codes_to_terms = csv_data_codes_to_terms or {}
     code_to_term = coding_system.code_to_term(codes)
+
+    def get_term(code):
+        term = code_to_term[code]
+        if term == "Unknown" and csv_data_codes_to_terms.get(code) is not None:
+            term = f"[Unknown] {csv_data_codes_to_terms[code]}"
+        return term
 
     if coding_system.id == "dmd":
         # dm+d has no hierarchy to look up, just return the codes themselves with their
         # terms
-        summary = []
-        for code in codes:
-            term = code_to_term[code]
-            if (
-                term == "Unknown"
-                and csv_data_codes_to_terms is not None
-                and csv_data_codes_to_terms[code] is not None
-            ):
-                term = f"[Unknown] {csv_data_codes_to_terms[code]}"
-            summary.append({"code": code, "term": term})
+        summary = [{"code": code, "term": get_term(code)} for code in codes]
     else:
         summary = []
         hierarchy = Hierarchy.from_codes(coding_system, codes)
@@ -89,7 +86,7 @@ def summarise(codes, coding_system, csv_data_codes_to_terms=None):
         for ancestor_code in ancestor_codes:
             descendants = sorted(
                 (
-                    {"code": code, "term": code_to_term[code]}
+                    {"code": code, "term": get_term(code)}
                     for code in (
                         hierarchy.descendants(ancestor_code) & codes - {ancestor_code}
                     )
@@ -99,7 +96,7 @@ def summarise(codes, coding_system, csv_data_codes_to_terms=None):
             summary.append(
                 {
                     "code": ancestor_code,
-                    "term": code_to_term[ancestor_code],
+                    "term": get_term(ancestor_code),
                     "descendants": descendants,
                 }
             )
@@ -107,22 +104,55 @@ def summarise(codes, coding_system, csv_data_codes_to_terms=None):
     return summary
 
 
-def get_dmd_codes_and_terms(clv):
-    """
-    Extract dm+d codes from a codelist version's csv_data
-    """
-    # Uploaded dm+d codelists have a variety of headers
-    # All of these represent the code column in at least one codelist version
-    possible_columns = {
-        "code": ["dmd_id", "code", "id", "snomed_id", "dmd"],
-        "term": ["term", "name", "dmd_name", "nm"],
-        "type": ["dmd_type", "obj_type", "type"],
+def get_csv_data_code_to_terms(clv):
+    if not clv.csv_data:
+        return
+
+    # Old style codelists (i.e. those created with CSV data via the version_create view
+    # /codelist/<org or user>/add/) are now required to contain a column named "code"
+    # or "dmd_id".
+    # However, older ones could be uploaded with any column names, so we need to
+    # check the headers to identify the most likely one
+    # These represent the valid case-insensitive code column names across all existing
+    # old-syle codelists
+    possible_columns_by_coding_system = {
+        "dmd": {
+            "code": ["code", "dmd_id", "id", "snomed_id", "dmd"],
+            "term": ["term", "name", "dmd_name", "nm"],
+            "type": ["dmd_type", "obj_type", "type"],
+        },
+        "snomedct": {
+            "code": ["code", "id", "snomed_id", "snomedcode", "dmd_id"],
+            "term": ["term", "name", "dmd_name"],
+        },
+        "icd10": {
+            "code": ["code", "id", "icd code", "icd_code", "icd", "icd10_code"],
+            "term": ["term", "description", "diag_desc"],
+        },
+        "ctv3": {
+            "code": ["code", "ctv3id", "ctv3code", "ctv3_id"],
+            "term": [
+                "term",
+                "ctv3preferredtermdesc",
+                "ctv3_description",
+                "ctv3_description",
+                "ctvterm",
+                "readterm",
+                "ctvterm",
+            ],
+        },
+        "default": {"code": ["code"], "term": ["term"]},
     }
+
     headers, *rows = clv.table
+    headers = [header.lower().strip() for header in headers]
+    possible_columns = possible_columns_by_coding_system.get(
+        clv.codelist.coding_system_id, "default"
+    )
 
     def _get_col_ix(col_type):
         column = next(
-            (col for col in possible_columns[col_type] if col.strip() in headers), None
+            (col for col in possible_columns.get(col_type, []) if col in headers), None
         )
         if column:
             return headers.index(column)

--- a/codelists/views/version_diff.py
+++ b/codelists/views/version_diff.py
@@ -32,7 +32,7 @@ def version_diff(request, clv, other_tag_or_hash):
         lhs_csv_data_codes_to_terms = get_dmd_codes_and_terms(clv)
         rhs_csv_data_codes_to_terms = get_dmd_codes_and_terms(other_clv)
         if lhs_csv_data_codes_to_terms is None or rhs_csv_data_codes_to_terms is None:
-            raise HttpResponseBadRequest("Could not identify code columns")
+            return HttpResponseBadRequest("Could not identify code columns")
         lhs_codes = set(lhs_csv_data_codes_to_terms)
         rhs_codes = set(rhs_csv_data_codes_to_terms)
     else:


### PR DESCRIPTION
If a code from a codelist version is not found in the coding system data, its term is returned as "Unknown" in the codelist diff view.  However, some codelist versions, including all dm+d ones, are uploaded from (old-style) CSV data, which keeps a record of the literal csv data, rather than coverting it into `CodeObj` objects via the coding system data. As long as we can determine a term column from the original CSV data, we can report the term that was uploaded with the original data.  Some dm+d CSV uploads also include the dm+d type, so if we have that, we can report it too.

Terms for unknown codes are prefixed with "[Unknown]" to inform the user that the term isn't found in the coding system.

![Screenshot from 2023-03-22 10-17-07](https://user-images.githubusercontent.com/6770950/226872611-e028d8fb-698c-48d7-9747-5a8070d7d48c.png)

Fixes #1555    