### PR TITLE
Management command to create and update a draft for use in the builder

### DIFF
--- a/codelists/actions.py
+++ b/codelists/actions.py
@@ -537,7 +537,9 @@ def convert_codelist_to_new_style(*, codelist):
 
 
 @transaction.atomic
-def export_to_builder(*, version, author, coding_system_database_alias):
+def export_to_builder(
+    *, version, author, coding_system_database_alias, ignore_unknown_statuses=False
+):
     """Create a new CodelistVersion for editing in the builder."""
     new_coding_system = version.coding_system.get_by_release(
         coding_system_database_alias
@@ -573,7 +575,11 @@ def export_to_builder(*, version, author, coding_system_database_alias):
     # the builder frontend cannot deal with a CodeObj with status ?  if any of its
     # ancestors are included or excluded.  We will have to deal with this soon but for
     # now fail loudly.
-    assert not draft.code_objs.filter(status="?").exists()
+    if not ignore_unknown_statuses:
+        assert not draft.code_objs.filter(
+            status="?"
+        ).exists(), "Unknown code statuses; this draft may be created manually with "
+        "the create_and_update_draft command"
 
     cache_hierarchy(version=draft)
 

--- a/codelists/management/commands/create_and_update_draft.py
+++ b/codelists/management/commands/create_and_update_draft.py
@@ -1,0 +1,65 @@
+import structlog
+from django.contrib.auth import get_user_model
+from django.core.management import BaseCommand, call_command
+
+from ...actions import export_to_builder
+from ...coding_systems import most_recent_database_alias
+from ...models import CodelistVersion
+
+
+logger = structlog.get_logger()
+
+User = get_user_model()
+
+
+class Command(BaseCommand):
+
+    """
+    Create a new draft from a CodelistVersion, using the most recent coding system release, ignoring
+    any unknown code statuses if encountered. Then update the draft to fix any unknown codes that we
+    can, and report the results.
+
+    This command can be run to create and update a draft that cannot be generated in the builder
+    UI in the usual way (i.e. `export_to_builder` raises an AssertionError because re-running the
+    searched for a new draft imports new matching concepts).  At the moment,
+    the builder frontend cannot deal with a CodeObj with status ?  if any of its ancestors are
+    included or excluded. From the frontend, we just make the build fail so as not to magically
+    add statuses for new concepts without users being made explicitly aware of them.
+    """
+
+    def add_arguments(self, parser):
+        parser.add_argument("version_hash")
+        parser.add_argument("--author", help="author username")
+
+    def handle(self, version_hash, author, **kwargs):
+        if author is None:
+            self.stderr.write("Author username is required")
+            return
+
+        try:
+            author_obj = User.objects.get(username=author)
+        except User.DoesNotExist:
+            self.stderr.write(f"Author with username {author} not found")
+            return
+
+        codelist_version = next(
+            (
+                version
+                for version in CodelistVersion.objects.all()
+                if version.hash == version_hash
+            ),
+            None,
+        )
+        if codelist_version is None:
+            self.stderr.write(f"No CodelistVersion found with hash '{version_hash}'")
+            return
+
+        draft = export_to_builder(
+            version=codelist_version,
+            author=author_obj,
+            coding_system_database_alias=most_recent_database_alias(
+                codelist_version.coding_system_id
+            ),
+            ignore_unknown_statuses=True,
+        )
+        call_command("update_draft", draft.hash)

--- a/codelists/tests/test_actions.py
+++ b/codelists/tests/test_actions.py
@@ -526,7 +526,9 @@ def test_export_to_builder_unknown_codes(
     ).first()
     missing_implicit_concept.delete()
 
-    with pytest.raises(AssertionError, match="Unknown code statuses"):
+    with pytest.raises(
+        actions.UnknownCodeError, match="Codes with unknown status found"
+    ):
         actions.export_to_builder(
             version=version_with_complete_searches,
             author=organisation_user,

--- a/codelists/tests/test_actions.py
+++ b/codelists/tests/test_actions.py
@@ -516,6 +516,53 @@ def test_export_to_builder(organisation_user, new_style_version):
     assert draft.searches.count() == new_style_version.searches.count()
 
 
+def test_export_to_builder_unknown_codes(
+    organisation_user, version_with_complete_searches
+):
+    # delete a CodeObj that's included by a parent from the version to simulate a new concept
+    # in the coding system
+    missing_implicit_concept = version_with_complete_searches.code_objs.filter(
+        status="(+)"
+    ).first()
+    missing_implicit_concept.delete()
+
+    with pytest.raises(AssertionError, match="Unknown code statuses"):
+        actions.export_to_builder(
+            version=version_with_complete_searches,
+            author=organisation_user,
+            coding_system_database_alias=most_recent_database_alias("snomedct"),
+        )
+
+
+def test_export_to_builder_unknown_codes_ignored(
+    organisation_user, version_with_complete_searches
+):
+    # delete a CodeObj that's included by a parent from the version to simulate a new concept
+    # in the coding system
+    missing_implicit_concept = version_with_complete_searches.code_objs.filter(
+        status="(+)"
+    ).first()
+    missing_implicit_concept.delete()
+
+    with assert_difference(
+        version_with_complete_searches.codelist.versions.count, expected_difference=1
+    ):
+        draft = actions.export_to_builder(
+            version=version_with_complete_searches,
+            author=organisation_user,
+            coding_system_database_alias=most_recent_database_alias("snomedct"),
+            ignore_unknown_statuses=True,
+        )
+
+    # The newly created draft has one additional code obj (the one we deleted)
+    assert (
+        draft.code_objs.count() == version_with_complete_searches.code_objs.count() + 1
+    )
+    unknown_code = draft.code_objs.get(code=missing_implicit_concept.code)
+    assert unknown_code.status == "?"
+    assert draft.searches.count() == version_with_complete_searches.searches.count()
+
+
 def test_add_codelist_tag(codelist):
     actions.add_codelist_tag(codelist=codelist, tag="TAG")
 

--- a/codelists/views/version_create.py
+++ b/codelists/views/version_create.py
@@ -1,3 +1,4 @@
+from django.contrib import messages
 from django.contrib.auth.decorators import login_required
 from django.shortcuts import redirect
 from django.views.decorators.http import require_POST
@@ -19,9 +20,14 @@ def version_create(request, version):
         coding_system_database_alias = most_recent_database_alias(
             version.coding_system.id
         )
-    draft = actions.export_to_builder(
-        version=version,
-        author=request.user,
-        coding_system_database_alias=coding_system_database_alias,
-    )
+    try:
+        draft = actions.export_to_builder(
+            version=version,
+            author=request.user,
+            coding_system_database_alias=coding_system_database_alias,
+        )
+    except actions.UnknownCodeError as err:
+        messages.error(request, err)
+        return redirect(version.get_absolute_url())
+
     return redirect(draft.get_builder_draft_url())


### PR DESCRIPTION
This allows us to manually create a new draft that can't be generated via the builder UI.

See https://bennettoxford.slack.com/archives/C03FB777L1M/p1684936597607569

We currently can't create a new draft if the coding system has changed since the original version was created, such that the searches on the original version now bring back new codes, which will be given unknown ("?") status.

We already had an `update_draft` management command, which would fix up an **existing** draft which had fallen behind the coding system (i.e. the draft was created in the past, and the coding system had been updated since).  We can use the same mechanism to create a new draft with the current coding system release, and update any unknown codes on it.

Note that we still don't want to do this automatically, because of the potential risk of users creating a new version and not being aware of new codes that have been added to it (and assigned an implicit status) due to an updated coding system release.
The new `create_and_update_draft` management command will output the codes that have had their status updated; this can be be reported to the user so they can check and confirm them.  (Technically we could do this on creation of a draft in the builder, and report on the new/changed/removed codes there, but it requires some more consideration of the risks first) 