### PR TITLE
Create new draft versions with CodeObj instances for unknown codes

### DIFF
--- a/codelists/actions.py
+++ b/codelists/actions.py
@@ -17,10 +17,6 @@ from .search import do_search
 logger = structlog.get_logger()
 
 
-class UnknownCodeError(Exception):
-    ...
-
-
 @transaction.atomic
 def create_old_style_codelist(
     *,
@@ -541,9 +537,7 @@ def convert_codelist_to_new_style(*, codelist):
 
 
 @transaction.atomic
-def export_to_builder(
-    *, version, author, coding_system_database_alias, ignore_unknown_statuses=False
-):
+def export_to_builder(*, version, author, coding_system_database_alias):
     """Create a new CodelistVersion for editing in the builder."""
     new_coding_system = version.coding_system.get_by_release(
         coding_system_database_alias
@@ -575,17 +569,34 @@ def export_to_builder(
             draft=draft, term=search.term, code=search.code, codes=codes
         )
 
-    # This assert will fire if new matching concepts have been imported.  At the moment,
-    # the builder frontend cannot deal with a CodeObj with status ?  if any of its
-    # ancestors are included or excluded.  We will have to deal with this soon but for
-    # now fail loudly.
-    if not ignore_unknown_statuses and draft.code_objs.filter(status="?").exists():
-        raise UnknownCodeError(
-            "Codes with unknown status found when creating new version; this is likely due "
-            "to an update in the coding system. Please contact tech-support for assistance."
-        )
+    # The builder frontend cannot deal with a new code if any of its ancestors are included or
+    # excluded. It CAN deal with a status of ?, as long as the CodeObj exists. New codes that
+    # are returned as the result of a search will be created as CodeObj instances, with status
+    # ?, which is fine. However, if a codelist version was created without searches (e.g. via
+    # the API), there may be new child codes that do not have corresponding CodeObj instances.
+    #
+    # We don't do any status assignment based on whether parent codes are included or excluded,
+    # we just create the CodeObj, which will by default have a status of ?. These new codes
+    # will show up in the builder as unresolved, and the user will need to deal with them
+    # manually.
+    #
+    # See codelists/management/commands/update_draft.py for a mangement
+    # command that will do the status assignment and report on codes that have been updated.
 
+    # cache hierarchy so we can use the codeset and calculated hierarchy
     cache_hierarchy(version=draft)
+    new_descendants = set()
+    for code in draft.codeset.all_codes():
+        descendants = set(draft.codeset.hierarchy.descendants(code))
+        for descendant in descendants:
+            if descendant not in draft.code_objs.values_list("code", flat=True):
+                new_descendants.add(descendant)
+    if new_descendants:
+        CodeObj.objects.bulk_create(
+            [CodeObj(version=draft, code=new_code) for new_code in new_descendants]
+        )
+        # cache hierarchy again after new codes have been added
+        cache_hierarchy(version=draft)
 
     return draft
 

--- a/codelists/actions.py
+++ b/codelists/actions.py
@@ -569,36 +569,46 @@ def export_to_builder(*, version, author, coding_system_database_alias):
             draft=draft, term=search.term, code=search.code, codes=codes
         )
 
-    # The builder frontend cannot deal with a new code if any of its ancestors are included or
-    # excluded. It CAN deal with a status of ?, as long as the CodeObj exists. New codes that
-    # are returned as the result of a search will be created as CodeObj instances, with status
-    # ?, which is fine. However, if a codelist version was created without searches (e.g. via
-    # the API), there may be new child codes that do not have corresponding CodeObj instances.
-    #
-    # We don't do any status assignment based on whether parent codes are included or excluded,
-    # we just create the CodeObj, which will by default have a status of ?. These new codes
-    # will show up in the builder as unresolved, and the user will need to deal with them
-    # manually.
-    #
-    # See codelists/management/commands/update_draft.py for a mangement
-    # command that will do the status assignment and report on codes that have been updated.
-
     # cache hierarchy so we can use the codeset and calculated hierarchy
     cache_hierarchy(version=draft)
-    new_descendants = set()
-    for code in draft.codeset.all_codes():
-        descendants = set(draft.codeset.hierarchy.descendants(code))
-        for descendant in descendants:
-            if descendant not in draft.code_objs.values_list("code", flat=True):
-                new_descendants.add(descendant)
+
+    # Find and add any new descendants of codes on the original version. This can
+    # occur when the coding system has changed since the original version was
+    # created.
+    add_new_descendants(version=draft)
+    return draft
+
+
+def add_new_descendants(*, version):
+    """
+    Find any missing descendant codes on a version and add them.
+
+    The builder frontend cannot deal with a new code if any of its ancestors are included or
+    excluded. It CAN deal with a status of ?, as long as the CodeObj exists. New codes that
+    are returned as the result of a search will be created as CodeObj instances, with status
+    ?, which is fine. However, if a codelist version was created without searches (e.g. via
+    the API), there may be new child codes that do not have corresponding CodeObj instances.
+
+    We don't do any status assignment based on whether parent codes are included or excluded,
+    we just create the CodeObj, which will by default have a status of ?. These new codes
+    will show up in the builder as unresolved, and the user will need to deal with them
+    manually.
+
+    See codelists/management/commands/update_draft.py for a mangement
+    command that will do the status assignment and report on codes that have been updated.
+    """
+    current_codes = set(version.codeset.all_codes())
+    all_descendants = set().union(
+        *[set(version.codeset.hierarchy.descendants(code)) for code in current_codes]
+    )
+    new_descendants = all_descendants - current_codes
+
     if new_descendants:
         CodeObj.objects.bulk_create(
-            [CodeObj(version=draft, code=new_code) for new_code in new_descendants]
+            [CodeObj(version=version, code=new_code) for new_code in new_descendants]
         )
         # cache hierarchy again after new codes have been added
-        cache_hierarchy(version=draft)
-
-    return draft
+        cache_hierarchy(version=version)
 
 
 def add_collaborator(*, codelist, collaborator):

--- a/codelists/management/commands/create_and_update_draft.py
+++ b/codelists/management/commands/create_and_update_draft.py
@@ -15,16 +15,8 @@ User = get_user_model()
 class Command(BaseCommand):
 
     """
-    Create a new draft from a CodelistVersion, using the most recent coding system release, ignoring
-    any unknown code statuses if encountered. Then update the draft to fix any unknown codes that we
-    can, and report the results.
-
-    This command can be run to create and update a draft that cannot be generated in the builder
-    UI in the usual way (i.e. `export_to_builder` raises an AssertionError because re-running the
-    searched for a new draft imports new matching concepts).  At the moment,
-    the builder frontend cannot deal with a CodeObj with status ?  if any of its ancestors are
-    included or excluded. From the frontend, we just make the build fail so as not to magically
-    add statuses for new concepts without users being made explicitly aware of them.
+    Create a new draft from a CodelistVersion, using the most recent coding system release. Then
+    update the draft to assign statuses to any unknown codes that we can, and report the results.
     """
 
     def add_arguments(self, parser):
@@ -60,6 +52,6 @@ class Command(BaseCommand):
             coding_system_database_alias=most_recent_database_alias(
                 codelist_version.coding_system_id
             ),
-            ignore_unknown_statuses=True,
         )
         call_command("update_draft", draft.hash)
+        self.stdout.write(f"New draft created at {draft.get_absolute_url()}")

--- a/codelists/management/commands/update_draft.py
+++ b/codelists/management/commands/update_draft.py
@@ -5,7 +5,7 @@ from django.core.management import BaseCommand
 from django.db import transaction
 from django.utils.text import slugify
 
-from ...actions import cache_hierarchy
+from ...actions import add_new_descendants, cache_hierarchy
 from ...models import CodelistVersion, CodeObj, SearchResult
 from ...search import do_search
 
@@ -65,7 +65,7 @@ class Command(BaseCommand):
             )
             self.update_searches(draft)
             self.delete_removed_codes(draft)
-            self.add_new_descendants(draft)
+            add_new_descendants(version=draft)
             self.update_code_statuses(draft)
             updates = self.diff(draft.codeset, original_codeset)
             cache_hierarchy(version=draft)
@@ -154,32 +154,6 @@ class Command(BaseCommand):
                 draft=draft,
                 coding_system=draft.coding_system,
                 removed_codes=old_codes,
-            )
-
-    def add_new_descendants(self, draft):
-        """
-        Identify any codes that are new descendants of codes previously included
-        or excluded.
-        This duplicates code in export_to_builder, but is needed here in case any
-        older drafts that predated it need to be updated.
-        """
-        new_descendants = set()
-        for code in draft.codeset.all_codes():
-            descendants = set(draft.codeset.hierarchy.descendants(code))
-            for descendant in descendants:
-                if descendant not in draft.code_objs.values_list("code", flat=True):
-                    new_descendants.add(descendant)
-
-        if new_descendants:
-            CodeObj.objects.bulk_create(
-                [CodeObj(version=draft, code=new_code) for new_code in new_descendants]
-            )
-            logger.info(
-                "New descendant codes found and added to draft",
-                draft=draft.hash,
-                coding_system=draft.coding_system.name,
-                coding_system_release=draft.coding_system.release,
-                new_descendant_codes=new_descendants,
             )
 
     def update_code_statuses(self, draft):

--- a/codelists/tests/test_commands.py
+++ b/codelists/tests/test_commands.py
@@ -44,23 +44,22 @@ def test_update_draft_version_no_changes_needed(draft_with_some_searches):
     assert err == ""
 
 
-def test_update_draft_output(draft_with_complete_searches):
+def test_update_draft_output(new_style_draft):
     # Test that a draft that requires an update outputs the expected message
+    # the new_style_draft fixture runs this test with drafts with no, some and complete
+    # searches. For no searches, the missing code obj will be added by checking the
+    # hierarchy for new descendant codes, rather than by rerunning searches
 
     # delete a CodeObj that's included by a parent from the draft to simulate a new concept on the
     # coding system
-    missing_implicit_concept = draft_with_complete_searches.code_objs.filter(
-        status="(+)"
-    ).first()
+    missing_implicit_concept = new_style_draft.code_objs.filter(status="(+)").first()
     missing_code = missing_implicit_concept.code
     missing_implicit_concept.delete()
 
-    out, err = output_from_call_command(
-        "update_draft", draft_with_complete_searches.hash
-    )
+    out, err = output_from_call_command("update_draft", new_style_draft.hash)
     assert (
         out
-        == f"CodelistVersion {draft_with_complete_searches.hash} updated:\n{missing_code} - (+) (new)"
+        == f"CodelistVersion {new_style_draft.hash} updated:\n{missing_code} - (+) (new)"
     )
     assert err == ""
 

--- a/codelists/tests/views/test_version_create.py
+++ b/codelists/tests/views/test_version_create.py
@@ -52,7 +52,7 @@ def test_post_success_no_coding_system_database_alias(client, version):
 
 
 def test_post_unknown_code_status(client, version_with_complete_searches):
-    version_count = version_with_complete_searches.codelist.versions.count()
+    version_with_complete_searches.codelist.versions.count()
     force_login(version_with_complete_searches, client)
     # delete a CodeObj that's included by a parent from the version to simulate a new concept
     # in the coding system; this will cause the export_to_builder function called from
@@ -66,8 +66,12 @@ def test_post_unknown_code_status(client, version_with_complete_searches):
         version_with_complete_searches.get_create_url(),
         {"coding_system_database_alias": most_recent_database_alias("snomedct")},
     )
-    # redirects to origin version
+    # new version created
+    draft = version_with_complete_searches.codelist.versions.get(
+        author__isnull=False, status=Status.DRAFT
+    )
     assert response.status_code == 302
-    assert response.url == version_with_complete_searches.get_absolute_url()
-    # no new version created
-    assert version_with_complete_searches.codelist.versions.count() == version_count
+    assert response.url == draft.get_builder_draft_url()
+    # the new code has unknown status
+    new_code = draft.code_objs.get(code=missing_implicit_concept.code)
+    assert new_code.status == "?"

--- a/codelists/views/version_create.py
+++ b/codelists/views/version_create.py
@@ -1,4 +1,3 @@
-from django.contrib import messages
 from django.contrib.auth.decorators import login_required
 from django.shortcuts import redirect
 from django.views.decorators.http import require_POST
@@ -20,14 +19,9 @@ def version_create(request, version):
         coding_system_database_alias = most_recent_database_alias(
             version.coding_system.id
         )
-    try:
-        draft = actions.export_to_builder(
-            version=version,
-            author=request.user,
-            coding_system_database_alias=coding_system_database_alias,
-        )
-    except actions.UnknownCodeError as err:
-        messages.error(request, err)
-        return redirect(version.get_absolute_url())
-
+    draft = actions.export_to_builder(
+        version=version,
+        author=request.user,
+        coding_system_database_alias=coding_system_database_alias,
+    )
     return redirect(draft.get_builder_draft_url())

--- a/opencodelists/tests/fixtures.py
+++ b/opencodelists/tests/fixtures.py
@@ -866,6 +866,23 @@ def new_style_version(universe, request):
     return type(version).objects.get(pk=version.pk)
 
 
+@pytest.fixture(
+    scope="function",
+    params=[
+        "version_with_no_searches",
+        "version_with_some_searches",
+        "version_with_complete_searches",
+    ],
+)
+def new_style_draft(universe, request, organisation_user):
+    version = universe[request.param]
+    return export_to_builder(
+        version=version,
+        author=organisation_user,
+        coding_system_database_alias=most_recent_database_alias("snomedct"),
+    )
+
+
 @pytest.fixture
 def create_codelists(organisation):
     """Fixture to create a batch of codelists with a specific status"""


### PR DESCRIPTION
Fixes #1563 

When we create a new draft from an existing version, it reruns the searches, and if any codes are returned with unknown (?) status, it raises an error (because - according to a comment - the frontend can't deal with codes of unknown status if an ancestor code is included/excluded) and tells the user to contact tech-support.  However, in fact, the frontend can deal with these just fine.

What the frontend can't deal with is new codes that have an ancestor code that is included/excluded, and which have no CodeObj created on the draft. We now check for those in `export_to_builder` and create them with no specific status (so they will be assigned unknown).  We don't do any automatic assigning of statuses based on the parent codes, we just return the draft to the user with unresolved codes, which they will need to deal with before they can save the new draft for review.

This should avoid the need for using the management commands to manually create/update drafts, although they can still be used to automatically assign statuses based on parent codes, which might be useful if someone creates a new draft that has a lot of new codes.

The codelist in #1563 has no associated searches, and was presumably created either by uploading a CSV or by using the API. This means that the codes from the original version just get copied over onto the new draft, and rerunning searches does nothing, so no new code objs are created. The affected codelist had some new child codes which now get created as unknown codes:
![Screenshot from 2023-06-21 17-04-39](https://github.com/opensafely-core/opencodelists/assets/6770950/b3ceff37-0e38-4d0e-bc3c-a255ddf76fba)

