### PR TITLE
Upgrade to Django 4.2

### DIFF
--- a/codelists/migrations/0020_auto_20201119_0932.py
+++ b/codelists/migrations/0020_auto_20201119_0932.py
@@ -3,7 +3,6 @@
 import datetime
 
 from django.db import migrations, models
-from django.utils.timezone import utc
 
 
 class Migration(migrations.Migration):
@@ -18,7 +17,7 @@ class Migration(migrations.Migration):
             name="created_at",
             field=models.DateTimeField(
                 auto_now_add=True,
-                default=datetime.datetime(2020, 11, 19, 9, 32, 9, 901186, tzinfo=utc),
+                default=datetime.datetime(2020, 11, 19, 9, 32, 9, 901186, tzinfo=datetime.timezone.utc),
             ),
             preserve_default=False,
         ),
@@ -32,7 +31,7 @@ class Migration(migrations.Migration):
             name="created_at",
             field=models.DateTimeField(
                 auto_now_add=True,
-                default=datetime.datetime(2020, 11, 19, 9, 32, 19, 101526, tzinfo=utc),
+                default=datetime.datetime(2020, 11, 19, 9, 32, 19, 101526, tzinfo=datetime.timezone.utc),
             ),
             preserve_default=False,
         ),

--- a/opencodelists/settings.py
+++ b/opencodelists/settings.py
@@ -197,6 +197,16 @@ USE_I18N = True
 USE_TZ = True
 
 
+# https://docs.djangoproject.com/en/4.2/ref/contrib/staticfiles/#module-django.contrib.staticfiles
+STORAGES = {
+    "default": {
+        "BACKEND": "django.core.files.storage.FileSystemStorage",
+    },
+    "staticfiles": {
+        "BACKEND": "whitenoise.storage.CompressedStaticFilesStorage",
+    },
+}
+
 # Static files (CSS, JavaScript, Images)
 # https://docs.djangoproject.com/en/3.0/howto/static-files/
 STATICFILES_DIRS = [BASE_DIR / "static" / "dist"]

--- a/requirements.prod.txt
+++ b/requirements.prod.txt
@@ -263,9 +263,9 @@ django-structlog==5.3.0 \
     --hash=sha256:078577c91e58cbaf66ecb47ec2b710ce4864b234f474691d29578e75c055ef8b \
     --hash=sha256:ab3e27671f6b6cea886eac86ab5b280c937adacff1a63bce9f716c7b3357571b
     # via -r requirements.prod.in
-django-taggit==3.1.0 \
-    --hash=sha256:543218ac346fbe02a65733e0341c91b57a3e0f7a41568966b26f1cea9edc4805 \
-    --hash=sha256:c8f2e4eae387939089b3d75d1d8649e008880970c068ce9d0e82f87fd5e29508
+django-taggit==4.0.0 \
+    --hash=sha256:4d52de9d37245a9b9f98c0ec71fdccf1d2283e38e8866d40a7ae6a3b6787a161 \
+    --hash=sha256:eb800dabef5f0a4e047ab0751f82cf805bc4a9e972037ef12bf519f52cd92480
     # via -r requirements.prod.in
 djangorestframework==3.14.0 \
     --hash=sha256:579a333e6256b09489cbe0a067e66abe55c6595d8926be6b99423786334350c8 \

--- a/requirements.prod.txt
+++ b/requirements.prod.txt
@@ -214,9 +214,9 @@ dj-email-url==1.0.6 \
     --hash=sha256:55ffe3329e48f54f8a75aa36ece08f365e09d61f8a209773ef09a1d4760e699a \
     --hash=sha256:cbd08327fbb08b104eac160fb4703f375532e4c0243eb230f5b960daee7a96db
     # via environs
-django==4.1.7 \
-    --hash=sha256:44f714b81c5f190d9d2ddad01a532fe502fa01c4cb8faf1d081f4264ed15dcd8 \
-    --hash=sha256:f2f431e75adc40039ace496ad3b9f17227022e8b11566f4b363da44c7e44761e
+django==4.2.4 \
+    --hash=sha256:7e4225ec065e0f354ccf7349a22d209de09cc1c074832be9eb84c51c1799c432 \
+    --hash=sha256:860ae6a138a238fc4f22c99b52f3ead982bb4b1aad8c0122bcd8c8a3a02e409d
     # via
     #   -r requirements.prod.in
     #   crispy-bootstrap4


### PR DESCRIPTION
- Adds the new STORAGES setting
- Add a test to reassure me that the [changes to update_or_create](https://docs.djangoproject.com/en/4.2/releases/4.2/#setting-update-fields-in-model-save-may-now-be-required) in 4.2 aren't a problem
- minor fixes to get rid of new deprecation warnings