### PR TITLE
Call tech-support in slack for failed automated imports

### DIFF
--- a/deploy/bin/import_latest_dmd.sh
+++ b/deploy/bin/import_latest_dmd.sh
@@ -37,6 +37,6 @@ if [ $RESULT == 0 ] ; then
 else
   #  Post failure message to slack
   curl -X POST -H 'Content-type: application/json' \
-    --data '{"text":"Latest dm+d release failed to import to OpenCodelists"}'\
+    --data '{"text":"Latest dm+d release failed to import to OpenCodelists. Calling tech-support."}'\
     "${SLACK_WEBHOOK_URL}"
 fi

--- a/deploy/bin/import_latest_snomedct.sh
+++ b/deploy/bin/import_latest_snomedct.sh
@@ -35,6 +35,6 @@ if [ $RESULT == 0 ] ; then
 else
   #  Post failure message to slack
   curl -X POST -H 'Content-type: application/json' \
-    --data '{"text":"Latest snomedct release failed to import to OpenCodelists; this is probably because no new release was found."}'\
+    --data '{"text":"Latest snomedct release failed to import to OpenCodelists; this is probably because no new release was found. tech-support please check latest SNOMED-CT release at https://www.opencodelists.org/coding-systems/latest-releases against https://isd.digital.nhs.uk/trud/users/authenticated/filters/0/categories/26/items/101/releases"}'\
     "${SLACK_WEBHOOK_URL}"
 fi


### PR DESCRIPTION
A few weeks ago, dm+d automated import started to fail, but we didn't notice for a while because the failure notifications were posted into #tech-noise.  This makes them call tech-support for investigation.

Note that snomed isn't released on a very regular schedule (it's around every 2 months, but sometimes has interim minor releases), so we try to import weekly, but we expect it to fail about 9/10 times, when it doesn't find a new release to import. We can probably fix that in the code, but for now, just notify tech support with the urls to check.