### PR TITLE
Notify data team directly for dmd and snomedct import failures

### DIFF
--- a/deploy/bin/import_latest_dmd_cronfile
+++ b/deploy/bin/import_latest_dmd_cronfile
@@ -1,11 +1,11 @@
 # /etc/cron.d/dokku-opencodelists-import-latest-dmd
 # cron job to import latest dm+d releases
-# update SLACK_WEBHOOK_URL and SLACK_TECHSUPPORT_WEBHOOK_URL with relevant channel url
-#(#tech-noise, #tech-support-channel)
+# update SLACK_WEBHOOK_URL and SLACK_DATATEAM_WEBHOOK_URL with relevant channel url
+#(#tech-noise, #team-data)
 
 PATH=/usr/local/bin:/usr/bin:/bin
 SHELL=/bin/bash
 SLACK_WEBHOOK_URL=dummy-url
-SLACK_TECHSUPPORT_WEBHOOK_URL=dummy-url
+SLACK_DATATEAM_WEBHOOK_URL=dummy-url
 
 5 23 * * 1 dokku /var/lib/dokku/data/storage/opencodelists/import_latest_release.sh dmd

--- a/deploy/bin/import_latest_release.sh
+++ b/deploy/bin/import_latest_release.sh
@@ -17,7 +17,7 @@ set -euo pipefail
 
 # This script should be copied to /var/lib/dokku/data/storage/opencodelists/import_latest_release.sh
 # on dokku3 and run using the cronfile at opencodelists/deploy/bin/import_latest_dmd_cron
-# SLACK_WEBHOOK_URL and SLACK_TECHSUPPORT_WEBHOOK_URL is an environment variable set in the cronfile on dokku3
+# SLACK_WEBHOOK_URL and SLACK_DATATEAM_WEBHOOK_URL is an environment variable set in the cronfile on dokku3
 
 
 CODING_SYSTEM=$1
@@ -69,12 +69,9 @@ function post_success_message_and_cleanup() {
 function post_failure_message_and_cleanup() {
   # restart app
   /usr/bin/dokku ps:restart opencodelists
-  # Report and notify tech-support
+  # Report and notify data team in slack
   failure_message_text="Latest ${CODING_SYSTEM} release failed to import to OpenCodelists.\nCheck logs on dokku3 at ${LOG_FILE}"
-  post_to_slack "${failure_message_text}" "${SLACK_TECHSUPPORT_WEBHOOK_URL}"
-
-  failure_notification_text="Latest dm+d release failed to import to OpenCodelists. Tech-support has been notified."
-  post_to_slack "${failure_notification_text}" "${SLACK_WEBHOOK_URL}"
+  post_to_slack "${failure_message_text}" "${SLACK_DATATEAM_WEBHOOK_URL}"
 }
 
 

--- a/deploy/bin/import_latest_snomedct_cronfile
+++ b/deploy/bin/import_latest_snomedct_cronfile
@@ -1,11 +1,11 @@
 # /etc/cron.d/dokku-opencodelists-import-latest-snomedct
 # cron job to import latest snomedct releases
-# update SLACK_WEBHOOK_URL and SLACK_TECHSUPPORT_WEBHOOK_URL with relevant channel url
-#(#tech-noise, #tech-support-channel)
+# update SLACK_WEBHOOK_URL and SLACK_DATATEAM_WEBHOOK_URL with relevant channel url
+#(#tech-noise, #team-data)
 
 PATH=/usr/local/bin:/usr/bin:/bin
 SHELL=/bin/bash
 SLACK_WEBHOOK_URL=dummy-url
-SLACK_TECHSUPPORT_WEBHOOK_URL=dummy-url
+SLACK_DATATEAM_WEBHOOK_URL=dummy-url
 
 5 23 * * 2 dokku /var/lib/dokku/data/storage/opencodelists/import_latest_release.sh snomedct


### PR DESCRIPTION
Change slack notification to post directly to #team-data instead of tech support.