### PR TITLE
Include mapped VMPs in dm+d CSV downloads

### DIFF
--- a/codelists/api.py
+++ b/codelists/api.py
@@ -257,4 +257,5 @@ def dmd_previous_codes_mapping(request):
     This endpoint is intended to be used by backends to determine any additional related codes
     to include with set of dm+d codes.
     """
-    return JsonResponse(vmp_ids_to_previous(), safe=False)
+    _, vmp_to_previous_tuples = vmp_ids_to_previous()
+    return JsonResponse(vmp_to_previous_tuples, safe=False)

--- a/codelists/models.py
+++ b/codelists/models.py
@@ -527,7 +527,7 @@ class CodelistVersion(models.Model):
     def _new_style_codes(self):
         return tuple(sorted(self.codeset.codes()))
 
-    def csv_data_for_download(self, fixed_headers=False, include_mapped_vmps=False):
+    def csv_data_for_download(self, fixed_headers=False, include_mapped_vmps=True):
         fixed_headers = fixed_headers or include_mapped_vmps
         if self.csv_data:
             if not fixed_headers:
@@ -537,7 +537,7 @@ class CodelistVersion(models.Model):
             table = self.table
         return rows_to_csv_data(table)
 
-    def table_with_fixed_headers(self, include_mapped_vmps=False):
+    def table_with_fixed_headers(self, include_mapped_vmps=True):
         """
         Find the code and term columns from csv data (which may be labelled with different
         headers), and return just those columns with the with the headers "code" and "term".

--- a/codelists/tests/views/test_version_download.py
+++ b/codelists/tests/views/test_version_download.py
@@ -44,8 +44,11 @@ def test_get_with_fixed_headers_not_downloadable(client, old_style_version):
 
 
 def test_get_with_mapped_vmps(client, dmd_version_asthma_medication):
-    # create a mapping for one of the dmd codes
+    # create a previous mapping for one of the dmd codes
     Mapping.objects.create(id="10514511000001106", vpidprev="999")
+    # create a new mapping for one of the dmd codes
+    Mapping.objects.create(id="888", vpidprev="10514511000001106")
+
     rsp = client.get(dmd_version_asthma_medication.get_download_url())
     data = rsp.content.decode("utf8")
     # Includes mapped VMPs by default, and uses fixed headers
@@ -53,7 +56,8 @@ def test_get_with_mapped_vmps(client, dmd_version_asthma_medication):
         ["code", "term"],
         ["10514511000001106", "Adrenaline (base) 220micrograms/dose inhaler"],
         ["10525011000001107", "Adrenaline (base) 220micrograms/dose inhaler refill"],
-        ["999", "Mapped previous VMP for 10514511000001106"],
+        ["999", "VMP previous to 10514511000001106"],
+        ["888", "VMP subsequent to 10514511000001106"],
     ]
 
 

--- a/codelists/views/version_download.py
+++ b/codelists/views/version_download.py
@@ -6,7 +6,7 @@ from .decorators import load_version
 @load_version
 def version_download(request, clv):
     fixed_headers = "fixed-headers" in request.GET
-    include_mapped_vmps = "include-mapped-vmps" in request.GET
+    omit_mapped_vmps = "omit-mapped-vmps" in request.GET
     if fixed_headers and not clv.downloadable:
         return HttpResponseBadRequest("Codelist is not downloadable")
     response = HttpResponse(content_type="text/csv")
@@ -16,7 +16,7 @@ def version_download(request, clv):
     response["Content-Disposition"] = content_disposition
     response.write(
         clv.csv_data_for_download(
-            fixed_headers=fixed_headers, include_mapped_vmps=include_mapped_vmps
+            fixed_headers=fixed_headers, include_mapped_vmps=not omit_mapped_vmps
         )
     )
     return response

--- a/codelists/views/version_download.py
+++ b/codelists/views/version_download.py
@@ -6,6 +6,7 @@ from .decorators import load_version
 @load_version
 def version_download(request, clv):
     fixed_headers = "fixed-headers" in request.GET
+    include_mapped_vmps = "include-mapped-vmps" in request.GET
     if fixed_headers and not clv.downloadable:
         return HttpResponseBadRequest("Codelist is not downloadable")
     response = HttpResponse(content_type="text/csv")
@@ -13,5 +14,9 @@ def version_download(request, clv):
         clv.download_filename()
     )
     response["Content-Disposition"] = content_disposition
-    response.write(clv.csv_data_for_download(fixed_headers=fixed_headers))
+    response.write(
+        clv.csv_data_for_download(
+            fixed_headers=fixed_headers, include_mapped_vmps=include_mapped_vmps
+        )
+    )
     return response

--- a/mappings/dmdvmpprevmap/mappers.py
+++ b/mappings/dmdvmpprevmap/mappers.py
@@ -1,17 +1,21 @@
 from mappings.dmdvmpprevmap.models import Mapping
 
 
-def vmp_ids_to_previous():
+def vmp_ids_to_previous(codes=None):
     """
     Return any codes with previous IDs
     This applies to VMP IDs only
     """
     # Simple dict of vmp id: previous id from the mappings across historical dm+d releases
     # Filter out any where the current and previous are identical
+    if codes:
+        mapping_objs = Mapping.objects.filter(id__in=codes).values_list(
+            "id", "vpidprev"
+        )
+    else:
+        mapping_objs = Mapping.objects.values_list("id", "vpidprev")
     vmp_to_previous = {
-        vpid: vpidprev
-        for (vpid, vpidprev) in Mapping.objects.values_list("id", "vpidprev")
-        if vpid != vpidprev
+        vpid: vpidprev for (vpid, vpidprev) in mapping_objs if vpid != vpidprev
     }
     # Build list of (id, prev_id) tuples in case of codes with multiple previous ones that
     # we can trace back in the current coding system

--- a/mappings/dmdvmpprevmap/tests/test_mappers.py
+++ b/mappings/dmdvmpprevmap/tests/test_mappers.py
@@ -4,7 +4,8 @@ from mappings.dmdvmpprevmap.models import Mapping
 
 def test_codes_to_previous_no_previous():
     # in the dmd fixture data, there are no previous codes
-    _, vmp_to_previous_tuples = vmp_ids_to_previous()
+    vmp_to_previous_mapping, vmp_to_previous_tuples = vmp_ids_to_previous()
+    assert vmp_to_previous_mapping == {}
     assert vmp_to_previous_tuples == []
 
 
@@ -13,7 +14,8 @@ def test_codes_to_previous_with_retired_previous():
     Mapping.objects.create(id="11", vpidprev="2")
     Mapping.objects.create(id="22", vpidprev="3")
 
-    _, vmp_to_previous_tuples = vmp_ids_to_previous()
+    vmp_to_previous_mapping, vmp_to_previous_tuples = vmp_ids_to_previous()
+    assert vmp_to_previous_mapping == {"11": "2", "22": "3"}
     assert vmp_to_previous_tuples == [
         ("11", "2"),
         ("22", "3"),
@@ -28,7 +30,12 @@ def test_codes_to_previous_with_chained_previous():
     Mapping.objects.create(id="2", vpidprev="1")
     Mapping.objects.create(id="3", vpidprev="2")
 
-    _, vmp_to_previous_tuples = vmp_ids_to_previous()
+    vmp_to_previous_mapping, vmp_to_previous_tuples = vmp_ids_to_previous()
+    assert vmp_to_previous_mapping == {
+        "1": "0",
+        "2": "1",
+        "3": "2",
+    }
     assert sorted(vmp_to_previous_tuples) == [
         ("1", "0"),
         ("2", "0"),
@@ -44,19 +51,33 @@ def test_codes_to_previous_with_self_previous():
     # Presumably this is an error; in any case, there's no need to include it in
     # the mapping
     Mapping.objects.create(id="1", vpidprev="1")
-    _, vmp_to_previous_tuples = vmp_ids_to_previous()
+    vmp_to_previous_mapping, vmp_to_previous_tuples = vmp_ids_to_previous()
+    assert vmp_to_previous_mapping == {}
     assert vmp_to_previous_tuples == []
 
 
 def test_codes_to_previous_with_codes():
-    # return previous for selected codes only
+    # return previous for selected codes "1" and "2" only
+
+    # These mappings directly affect a specified code
     Mapping.objects.create(id="1", vpidprev="0")
     Mapping.objects.create(id="2", vpidprev="1")
     Mapping.objects.create(id="3", vpidprev="2")
+    # This mapping affects a code via a related mapping ("4" -> "3" -> "2")
     Mapping.objects.create(id="4", vpidprev="3")
+    # This mapping doesn't affect specified codes
     Mapping.objects.create(id="5", vpidprev="6")
 
-    _, vmp_to_previous_tuples = vmpprev_full_mappings(codes=["1", "2"])
+    vmp_to_previous_mapping, vmp_to_previous_tuples = vmpprev_full_mappings(
+        codes=["1", "2"]
+    )
+
+    assert vmp_to_previous_mapping == {
+        "1": "0",
+        "2": "1",
+        "3": "2",
+        "4": "3",
+    }
 
     assert sorted(vmp_to_previous_tuples) == [
         # mapped previous for the specified codes

--- a/mappings/dmdvmpprevmap/tests/test_mappers.py
+++ b/mappings/dmdvmpprevmap/tests/test_mappers.py
@@ -42,3 +42,16 @@ def test_codes_to_previous_with_self_previous():
     # the mapping
     Mapping.objects.create(id="1", vpidprev="1")
     assert vmp_ids_to_previous() == []
+
+
+def test_codes_to_previous_with_codes():
+    # return previous for selected codes only
+    Mapping.objects.create(id="1", vpidprev="0")
+    Mapping.objects.create(id="2", vpidprev="1")
+    Mapping.objects.create(id="3", vpidprev="2")
+
+    assert sorted(vmp_ids_to_previous(codes=[1, 2])) == [
+        ("1", "0"),
+        ("2", "0"),
+        ("2", "1"),
+    ]

--- a/mappings/dmdvmpprevmap/tests/test_mappers.py
+++ b/mappings/dmdvmpprevmap/tests/test_mappers.py
@@ -1,10 +1,11 @@
-from mappings.dmdvmpprevmap.mappers import vmp_ids_to_previous
+from mappings.dmdvmpprevmap.mappers import vmp_ids_to_previous, vmpprev_full_mappings
 from mappings.dmdvmpprevmap.models import Mapping
 
 
 def test_codes_to_previous_no_previous():
     # in the dmd fixture data, there are no previous codes
-    assert vmp_ids_to_previous() == []
+    _, vmp_to_previous_tuples = vmp_ids_to_previous()
+    assert vmp_to_previous_tuples == []
 
 
 def test_codes_to_previous_with_retired_previous():
@@ -12,7 +13,8 @@ def test_codes_to_previous_with_retired_previous():
     Mapping.objects.create(id="11", vpidprev="2")
     Mapping.objects.create(id="22", vpidprev="3")
 
-    assert vmp_ids_to_previous() == [
+    _, vmp_to_previous_tuples = vmp_ids_to_previous()
+    assert vmp_to_previous_tuples == [
         ("11", "2"),
         ("22", "3"),
     ]
@@ -26,7 +28,8 @@ def test_codes_to_previous_with_chained_previous():
     Mapping.objects.create(id="2", vpidprev="1")
     Mapping.objects.create(id="3", vpidprev="2")
 
-    assert sorted(vmp_ids_to_previous()) == [
+    _, vmp_to_previous_tuples = vmp_ids_to_previous()
+    assert sorted(vmp_to_previous_tuples) == [
         ("1", "0"),
         ("2", "0"),
         ("2", "1"),
@@ -41,7 +44,8 @@ def test_codes_to_previous_with_self_previous():
     # Presumably this is an error; in any case, there's no need to include it in
     # the mapping
     Mapping.objects.create(id="1", vpidprev="1")
-    assert vmp_ids_to_previous() == []
+    _, vmp_to_previous_tuples = vmp_ids_to_previous()
+    assert vmp_to_previous_tuples == []
 
 
 def test_codes_to_previous_with_codes():
@@ -49,9 +53,20 @@ def test_codes_to_previous_with_codes():
     Mapping.objects.create(id="1", vpidprev="0")
     Mapping.objects.create(id="2", vpidprev="1")
     Mapping.objects.create(id="3", vpidprev="2")
+    Mapping.objects.create(id="4", vpidprev="3")
+    Mapping.objects.create(id="5", vpidprev="6")
 
-    assert sorted(vmp_ids_to_previous(codes=[1, 2])) == [
+    _, vmp_to_previous_tuples = vmpprev_full_mappings(codes=["1", "2"])
+
+    assert sorted(vmp_to_previous_tuples) == [
+        # mapped previous for the specified codes
         ("1", "0"),
         ("2", "0"),
         ("2", "1"),
+        # mapped code that supercedes one of the specified codes
+        ("3", "1"),
+        ("3", "2"),
+        # mapped code that supercedes specified codes, via another code (3)
+        ("4", "1"),
+        ("4", "2"),
     ]


### PR DESCRIPTION
Includes mapped VMPs in dm+d CSV downloads by default (they can be omitted with a query parameter flag ?omit-mapped-vmps)

This means that running `opensafely codelists update` on a study will download CSVs that include mapped VMPs (and  note in the downloaded CSV which VMP they map to).  The study will have codelists with mapped VMPs that it can use, without modifying CSV files that have already downloaded (which would cause OS CLI's codelist checks to fail), and we don't have to create new dm+d versions that circumvent the current coding system validation.

Example download from the opiods study that currently having problems with mapped VMPs:
[opensafely-opioid-containing-medicines-parenteral-excluding-drugs-for-substance-misuse-dmd.csv](https://github.com/opensafely-core/opencodelists/files/12731152/opensafely-opioid-containing-medicines-parenteral-excluding-drugs-for-substance-misuse-dmd.csv)

