### PR TITLE
Sort mapped VMPs in download view

### DIFF
--- a/codelists/models.py
+++ b/codelists/models.py
@@ -621,12 +621,15 @@ class CodelistVersion(models.Model):
                 new_row[term_header_index] = description
                 table_rows.append(new_row)
 
-            for vmp in previous_vmps_to_add:
+            # Sort the VMPs being added to ensure consistent order. This will ensure that
+            # repeated CSV downloads are the same unless new mapped VMPs are added and
+            # can be used to check whether updates to study codelists are required.
+            for vmp in sorted(previous_vmps_to_add):
                 # add the code to the table data
                 # include its description as the code it was superceded by
                 add_row(vmp, f"VMP previous to {prev_to_vmp_mapping[vmp]}")
 
-            for vmp in subsequent_vmps_to_add:
+            for vmp in sorted(subsequent_vmps_to_add):
                 # add the code to the table data
                 # include its description as the code it supercedes
                 add_row(vmp, f"VMP subsequent to {vmp_to_prev_mapping[vmp]}")

--- a/codelists/tests/views/test_version_download.py
+++ b/codelists/tests/views/test_version_download.py
@@ -84,8 +84,8 @@ def test_get_with_duplicated_mapped_vmps(client, dmd_version_asthma_medication):
         ["10514511000001106", "Adrenaline (base) 220micrograms/dose inhaler"],
         ["10525011000001107", "Adrenaline (base) 220micrograms/dose inhaler refill"],
         ["999", "VMP previous to 10514511000001106, 10525011000001107"],
-        ["888", "VMP subsequent to 10514511000001106"],
         ["777", "VMP subsequent to 10514511000001106"],
+        ["888", "VMP subsequent to 10514511000001106"],
     ]
 
 


### PR DESCRIPTION
We need the order of mapped VMP codes to be consistent on each download for any checks on whether codelists have changed.