### PR TITLE
Respect fixed_headers for non-dm+d codelist downloads

### DIFF
--- a/codelists/models.py
+++ b/codelists/models.py
@@ -530,9 +530,23 @@ class CodelistVersion(models.Model):
         return tuple(sorted(self.codeset.codes()))
 
     def csv_data_for_download(self, fixed_headers=False, include_mapped_vmps=True):
-        fixed_headers = fixed_headers or include_mapped_vmps
+        """
+        Prepare codes for download.  If this is a new-style codelists, the csv data with
+        code and related term will be built from the code objects, looking up the terms in
+        the coding system.  If it is an old-style codelist, it has no associated code objects,
+        and it will use the uploaded csv_data.
+
+        include_mapped_vmps: if True, a dm+d codelist will include mapped VMPs in its download.
+          This value defaults to True, so that when these downloads are requested by OpenSafely CLI,
+          no additional query params need to be passed that are specidfic to dm+d codelists.
+        fixed_headers: if True, uploaded csv_data is converted to two columns, headed "code" and "term".
+          This parameter is ignored for dmd downloads that include mapped VMPs
+        """
         if self.csv_data:
-            if not fixed_headers:
+            dmd_with_mapped_vmps = (
+                self.coding_system_id == "dmd" and include_mapped_vmps
+            )
+            if not fixed_headers and not dmd_with_mapped_vmps:
                 return self.csv_data
             table = self.table_with_fixed_headers(include_mapped_vmps)
         else:

--- a/codelists/tests/views/test_version_download.py
+++ b/codelists/tests/views/test_version_download.py
@@ -8,11 +8,15 @@ def test_get(client, version):
     assert data == version.csv_data_for_download()
 
 
+def test_get_with_original_headers(client, old_style_version):
+    # by default, the original csv data is downloaded
+    rsp = client.get(old_style_version.get_download_url())
+    data = rsp.content.decode("utf8")
+    assert data == old_style_version.csv_data_for_download()
+    assert csv_data_to_rows(data)[0] == ["code", "name"]
+
+
 def test_get_with_fixed_headers(client, old_style_version):
-    old_style_version.csv_data = old_style_version.csv_data.replace(
-        "id,name", "code,name"
-    )
-    old_style_version.save()
     assert old_style_version.table[0] == ["code", "name"]
     rsp = client.get(old_style_version.get_download_url() + "?fixed-headers")
     data = rsp.content.decode("utf8")


### PR DESCRIPTION
For dm+d codelists, we now default to including mapped VMPs in CSV downloads. In order to do that, we need to use the code that downloads with fixed headers (i.e. two columns, headed 'code' and 'term'), so for dm+d codelists ONLY, we need toignore the default value of fixed_headers (False).