### PR TITLE
Make dmd VMP mappings handle multiple future mappings

### DIFF
--- a/codelists/models.py
+++ b/codelists/models.py
@@ -637,11 +637,17 @@ class CodelistVersion(models.Model):
                         prev_to_vmp_mapping[previous_vmp] = vmp
                 else:
                     # if the vmp wasn't in the codelist codes, then the mapped previous one
-                    # must be
+                    # must be. We're mapping in a code that is subsequent to one in the current codelist.
                     assert previous_vmp in codes
-                    # and it must be in the mapping of vmp to previous that we'll look it up in
-                    # later
-                    assert previous_vmp in vmp_to_prev_mapping
+
+                    # The mapped code must be in ONE of the direct mappings
+                    # It's either previous to a current code (and in vmp_to_prev_mapping), or previous to
+                    # another previous code of current code,in which case it will be in the
+                    # prev_to_vmp_mapping
+                    if previous_vmp not in vmp_to_prev_mapping:
+                        assert previous_vmp in prev_to_vmp_mapping
+                        # add the mapped VMP into the mapping so we can add in the description
+                        vmp_to_prev_mapping[vmp] = prev_to_vmp_mapping[previous_vmp]
                     # mapping a code in the codelist to a new code that supercedes it
                     subsequent_vmps_to_add.add(vmp)
 

--- a/codelists/tests/views/test_version_download.py
+++ b/codelists/tests/views/test_version_download.py
@@ -130,10 +130,16 @@ def test_get_with_mapped_vmps_more_than_one_step_distant(
     # create a previous mapping for one of the dmd codes
     Mapping.objects.create(id="10514511000001106", vpidprev="999")
     # create a previous mapping for this previous code
-    # create a new mapping for one of the dmd codes; neither of these
-    # codes are in the codelist, but 777 needs to be mapped in as a previou
+    # create two more mapping for one of the dmd codes; neither of these
+    # codes are in the codelist, but 777 and 666 need to be mapped in as a previous
     # code to 10514511000001106, which is in the codelist
     Mapping.objects.create(id="999", vpidprev="777")
+    Mapping.objects.create(id="777", vpidprev="666")
+
+    # create some new mappings for one of the dmd codes
+    Mapping.objects.create(id="AAA", vpidprev="10514511000001106")
+    Mapping.objects.create(id="BBB", vpidprev="AAA")
+    Mapping.objects.create(id="CCC", vpidprev="BBB")
 
     rsp = client.get(dmd_version_asthma_medication.get_download_url())
     data = rsp.content.decode("utf8")
@@ -141,6 +147,10 @@ def test_get_with_mapped_vmps_more_than_one_step_distant(
         ["code", "term"],
         ["10514511000001106", "Adrenaline (base) 220micrograms/dose inhaler"],
         ["10525011000001107", "Adrenaline (base) 220micrograms/dose inhaler refill"],
+        ["666", "VMP previous to 10514511000001106"],
         ["777", "VMP previous to 10514511000001106"],
         ["999", "VMP previous to 10514511000001106"],
+        ["AAA", "VMP subsequent to 10514511000001106"],
+        ["BBB", "VMP subsequent to AAA"],
+        ["CCC", "VMP subsequent to BBB"],
     ]


### PR DESCRIPTION
#1696 fixed the issue for past VMP mappings more than one step away from codes in the codelist being downloaded; this fixes the issue for future ones too :facepalm: 

I'm not entirely happy with how the description ends up - every mapped code that's previous to a VMP in the codelist gets labelled as "previous to" the codelist code (even if it's in a chain of mappings, so not immediately previous), whereas every future mapped code gets labelled as "subsequent to" the code it's actually mapped to.  However, all the right codes end up in the codelist, and the description notes were only ever a nice-to-have, so I don't think it's worth spending a lot of time trying to make it work better (right now, at least).