### PR TITLE
Add an API endpoint to check codelists from study repos

### DIFF
--- a/codelists/api_urls.py
+++ b/codelists/api_urls.py
@@ -13,6 +13,7 @@ urlpatterns = [
         api.dmd_previous_codes_mapping,
         name="dmd_previous_codes_mapping",
     ),
+    path("check/", api.codelists_check, name="check_codelists"),
 ]
 
 for subpath, view in [

--- a/codelists/models.py
+++ b/codelists/models.py
@@ -1,3 +1,4 @@
+import hashlib
 from collections import Counter
 
 from django.contrib.auth.models import AnonymousUser
@@ -552,6 +553,14 @@ class CodelistVersion(models.Model):
         else:
             table = self.table
         return rows_to_csv_data(table)
+
+    def csv_data_sha(self):
+        """
+        sha of CSV data for download with default parameters. This matches the method
+        used to hash the CSVs downloaded in a study repo.
+        """
+        data_for_download = self.csv_data_for_download().encode()
+        return hashlib.sha1(data_for_download).hexdigest()
 
     def table_with_fixed_headers(self, include_mapped_vmps=True):
         """


### PR DESCRIPTION
Fixes #1702 
See also https://github.com/orgs/opensafely-core/projects/13/views/1?pane=issue&itemId=42536167

This endpoint may be called from opensafely-cli or from job-server. It takes as POST parameters the content of a study repo's codelists.txt file (specifying the codelists that are to be used in the study), and a manifest (codelists.json) file, which is generated when `opensafely codelists update` is run. It checks that the hashed codelist data in the manifest file matches the content of the current codelist versions, if they were to be downloaded again.

This is specifically intended to deal with dm+d codelists, which may change after they're downloaded into a study repo due to mapped VMPs.

Note opensafely-cli already has a codelists check command, which checks that the manifest file is consistent with the codelists in the study repo. However, dm+d codelists can change due to new VMP mappings, which get mapped into CSV downloads. Therefore a dm+d codelist that was downloaded into a study repo may need to be updated again, even if no changes have been made to the codelists.csv.