### PR TITLE
Refactor csv download code for mapped VMPs

### DIFF
--- a/codelists/api.py
+++ b/codelists/api.py
@@ -272,7 +272,7 @@ def dmd_previous_codes_mapping(request):
     This endpoint is intended to be used by backends to determine any additional related codes
     to include with set of dm+d codes.
     """
-    _, vmp_to_previous_tuples = vmp_ids_to_previous()
+    vmp_to_previous_tuples = vmp_ids_to_previous()
     return JsonResponse(vmp_to_previous_tuples, safe=False)
 
 

--- a/codelists/models.py
+++ b/codelists/models.py
@@ -597,9 +597,7 @@ class CodelistVersion(models.Model):
             codes = [row[code_header_index] for row in table_rows]
 
             # add in mapped VMP codes
-            vmp_to_prev_mapping, mapped_vmps_for_this_codelist = vmpprev_full_mappings(
-                codes
-            )
+            mapped_vmps_for_this_codelist = vmpprev_full_mappings(codes)
 
             # mapped_vmps_for_this_codelist is a full list of (vmp, previous) tuples, where one of
             # vmp/previous are in the codelist. It may contain mappings where `previous` is more than

--- a/codelists/tests/views/test_version_download.py
+++ b/codelists/tests/views/test_version_download.py
@@ -151,6 +151,6 @@ def test_get_with_mapped_vmps_more_than_one_step_distant(
         ["777", "VMP previous to 10514511000001106"],
         ["999", "VMP previous to 10514511000001106"],
         ["AAA", "VMP subsequent to 10514511000001106"],
-        ["BBB", "VMP subsequent to AAA"],
-        ["CCC", "VMP subsequent to BBB"],
+        ["BBB", "VMP subsequent to 10514511000001106"],
+        ["CCC", "VMP subsequent to 10514511000001106"],
     ]

--- a/mappings/dmdvmpprevmap/mappers.py
+++ b/mappings/dmdvmpprevmap/mappers.py
@@ -20,7 +20,7 @@ def vmp_ids_to_previous():
         for previous in all_previous:
             vmps_with_all_previous.append((vmp, previous))
 
-    return vmp_to_previous, vmps_with_all_previous
+    return vmps_with_all_previous
 
 
 def vmpprev_full_mappings(codes):
@@ -30,20 +30,17 @@ def vmpprev_full_mappings(codes):
     codes, and also a set of (id, prev) tuples, where prev may be one or more steps away
     from id in the historical mappings
     """
-    previous_mapping, vmps_with_all_previous = vmp_ids_to_previous()
+    vmps_with_all_previous = vmp_ids_to_previous()
     # limit both the list of (id, prev) pairs and mapping to only those where one of the
     # pair is in the provided codes
     codes = set(codes)
     vmps_with_all_previous_for_codes = []
-    vmp_to_previous_for_codes = {}
 
     for vmp_prev in vmps_with_all_previous:
         if not (set(vmp_prev) & codes):
             continue
-        vmp = vmp_prev[0]
         vmps_with_all_previous_for_codes.append(vmp_prev)
-        vmp_to_previous_for_codes[vmp] = previous_mapping[vmp]
-    return vmp_to_previous_for_codes, vmps_with_all_previous_for_codes
+    return vmps_with_all_previous_for_codes
 
 
 def _get_all_previous_vmpids(mapping, vmp, previous, all_previous=None):

--- a/mappings/dmdvmpprevmap/tests/test_mappers.py
+++ b/mappings/dmdvmpprevmap/tests/test_mappers.py
@@ -4,8 +4,7 @@ from mappings.dmdvmpprevmap.models import Mapping
 
 def test_codes_to_previous_no_previous():
     # in the dmd fixture data, there are no previous codes
-    vmp_to_previous_mapping, vmp_to_previous_tuples = vmp_ids_to_previous()
-    assert vmp_to_previous_mapping == {}
+    vmp_to_previous_tuples = vmp_ids_to_previous()
     assert vmp_to_previous_tuples == []
 
 
@@ -14,8 +13,7 @@ def test_codes_to_previous_with_retired_previous():
     Mapping.objects.create(id="11", vpidprev="2")
     Mapping.objects.create(id="22", vpidprev="3")
 
-    vmp_to_previous_mapping, vmp_to_previous_tuples = vmp_ids_to_previous()
-    assert vmp_to_previous_mapping == {"11": "2", "22": "3"}
+    vmp_to_previous_tuples = vmp_ids_to_previous()
     assert vmp_to_previous_tuples == [
         ("11", "2"),
         ("22", "3"),
@@ -30,12 +28,7 @@ def test_codes_to_previous_with_chained_previous():
     Mapping.objects.create(id="2", vpidprev="1")
     Mapping.objects.create(id="3", vpidprev="2")
 
-    vmp_to_previous_mapping, vmp_to_previous_tuples = vmp_ids_to_previous()
-    assert vmp_to_previous_mapping == {
-        "1": "0",
-        "2": "1",
-        "3": "2",
-    }
+    vmp_to_previous_tuples = vmp_ids_to_previous()
     assert sorted(vmp_to_previous_tuples) == [
         ("1", "0"),
         ("2", "0"),
@@ -51,8 +44,7 @@ def test_codes_to_previous_with_self_previous():
     # Presumably this is an error; in any case, there's no need to include it in
     # the mapping
     Mapping.objects.create(id="1", vpidprev="1")
-    vmp_to_previous_mapping, vmp_to_previous_tuples = vmp_ids_to_previous()
-    assert vmp_to_previous_mapping == {}
+    vmp_to_previous_tuples = vmp_ids_to_previous()
     assert vmp_to_previous_tuples == []
 
 
@@ -68,16 +60,7 @@ def test_codes_to_previous_with_codes():
     # This mapping doesn't affect specified codes
     Mapping.objects.create(id="5", vpidprev="6")
 
-    vmp_to_previous_mapping, vmp_to_previous_tuples = vmpprev_full_mappings(
-        codes=["1", "2"]
-    )
-
-    assert vmp_to_previous_mapping == {
-        "1": "0",
-        "2": "1",
-        "3": "2",
-        "4": "3",
-    }
+    vmp_to_previous_tuples = vmpprev_full_mappings(codes=["1", "2"])
 
     assert sorted(vmp_to_previous_tuples) == [
         # mapped previous for the specified codes


### PR DESCRIPTION
Discovered another small bug in how the mapped VMP descriptions were produced, and realised that the previous code was ridiculously overcomplicated.  The first commit refactors the way the mapped-VMP descriptions are generated, the second one removed the extra code that was only there for the overcomplicated previous version.