### PR TITLE
Fix the regex used to match codelists in codelists_check

### DIFF
--- a/codelists/api.py
+++ b/codelists/api.py
@@ -26,7 +26,9 @@ CODELIST_VERSION_REGEX = re.compile(
     (?P<user>user)?/?  # may start with "user/" if it's a user codelist
     (?P<owner>[\w|\d|-]+)/ # organisation slug or user name
     (?P<codelist_slug>[\w|\d|-]+)/ # codelist slug
-    (?P<tag_or_hash>[\w|\d|-]+) # version tag or hash
+    # version tag or hash; a tag can technically be any character,
+    # but exclude forward slashes, since they'd break the urls anyway.
+    (?P<tag_or_hash>[^\/]+)
     /?$ # possible trailing slash
     """,
     flags=re.X,


### PR DESCRIPTION
We need to match codelists by tag or hash; tag doesn't go through any cleaning, so it can technically be any string, including random characters and forward slashes. We're identifying whether a codelist in a codelists.txt file is valid by using forward slashes as a delimiter between user-or-org/codelist-slug/tag-or-hash, so we need to exclude forward slashes from the allowed characters for the tag-or-hash part of the regex. This is fine, since any codelist version that was created with forward slashes in the tag would have a broken url anyway.