### PR TITLE
Check dm+d codelists against possible previous versions of downloaded CSVs

### DIFF
--- a/codelists/api.py
+++ b/codelists/api.py
@@ -351,7 +351,7 @@ def codelists_check(requests):
                 return JsonResponse(
                     {"status": "error", "data": {"error": f"{line} could not be found"}}
                 )
-        codelist_download_data[line] = codelist_version.csv_data_sha()
+        codelist_download_data[line] = codelist_version.csv_data_shas()
 
     # Compare with manifest file
     # The manifest file is generated when `opensafely codelists update` is run in a study repo
@@ -373,7 +373,7 @@ def codelists_check(requests):
         file_data["id"]
         for file_data in manifest["files"].values()
         if file_data["id"] in codelist_download_data
-        and file_data["sha"] != codelist_download_data[file_data["id"]]
+        and file_data["sha"] not in codelist_download_data[file_data["id"]]
     ]
     if new_files or removed_files or changed:
         return JsonResponse(


### PR DESCRIPTION
CSV downloads for dm+d codelists now map in any previous or subsequent VMPs. As part of that change, the downloads also changed to use standardised fixed headers ("code" and "term"). However, this means that any old dmd download no longer matches the data that would be downloaded today - even if no VMPs were required to be mapped in.

In addition, if a user updates their study codelists, their study/dataset definitions that referred to a named code column (often "dmd_id" for codelists created from BNF conversions) will no longer work, and the user would have to update all their `codelist_from_csv(column="dmd_id")` calls to use `codelist_from_csv(column="code")` instead.

This PR address these things by:
1) Including an additional column in the dm+d CSV downloads which is a duplicate of the "code" column, but with the original column heading.  This keeps their `codelist_from_csv` references working.
2) Updating the api /check endpoint to check the shas it receives from a study repo against potential valid CSV downloads, not just the default current format.  i.e. for a dm+d codelist, it will accept shas of CSVs downloaded in the original, pre-VMP mapping (if no VMPs need to be mapped in), and it will accept shas of CSVs downloaded with just "code" and "term" columns (i.e. those that have been downloaded since the VMP mapping change.

(I have also checked these against codelists is real study, using a local opencodelists, and codelists downloaded before and after the VMP mapping changes) 