### PR TITLE
CSV download options for dm+d codelists

### DIFF
--- a/templates/codelists/_about_tab.html
+++ b/templates/codelists/_about_tab.html
@@ -52,6 +52,13 @@
       We don't offer any guarantees about what they do or don't identify. Users should carefully
       check that any codelist meets their needs, and seek clinical input where appropriate.
     </p>
+    {% if codelist.coding_system_id == "dmd" %}
+    <p>
+      * dm+d codelists can be downloaded with codes mapped to changed VMPs included - this is the default
+      for an OpenSAFELY project.  See the <a href="https://docs.opensafely.org/codelist-updating/">
+      documentation on keeping codelists up to date</a> for more details.
+    </p>
+    {% endif %}
   </div>
 
 </div>

--- a/templates/codelists/version.html
+++ b/templates/codelists/version.html
@@ -21,8 +21,17 @@
         role="button"
         class="btn btn-outline-primary btn-block"
       >
-        Download CSV
+        Download CSV{% if clv.coding_system_id == "dmd" %} (with mapped VMPs)*{% endif %}
       </a>
+      {% if clv.coding_system_id == "dmd" %}
+      <a
+        href="{{ clv.get_download_url }}?omit-mapped-vmps"
+        role="button"
+        class="btn btn-outline-primary btn-block"
+      >
+        Download CSV (original)
+      </a>
+      {% endif %}
       {% if clv.codeset %}
       <a
         href="{{ clv.get_download_definition_url }}"


### PR DESCRIPTION
Add alternative download options in the UI for dm+d codelists, to download the original CSV data, or data with mapped VMPs. Also adds a note about mapped VMPs and link to docs page.

![Screenshot from 2023-11-10 11-19-38](https://github.com/opensafely-core/opencodelists/assets/6770950/3e47b71a-c887-4ec1-b3d3-bf4c1c5e47ad)
