### PR TITLE
Disable the download-with-vmp button if a dm+d codelist is undownloadable

### DIFF
--- a/templates/codelists/_full_list_tab.html
+++ b/templates/codelists/_full_list_tab.html
@@ -14,3 +14,15 @@
       {% endfor %}
   </tbody>
 </table>
+
+{% if codelist.coding_system_id == "dmd" %}
+<div class="small mt-auto pt-4">
+  <hr>
+  <p>
+    * Note that this is the full list of explicitly included dm+d codes for this codelist. An OpenSAFELY project
+    will by default also include previous or subsequent codes for any included VMPs that may have changed code.
+    See the <a href="https://docs.opensafely.org/codelist-updating/"> documentation on keeping codelists up to
+    date</a> for more details.
+  </p>
+</div>
+{% endif %}

--- a/templates/codelists/version.html
+++ b/templates/codelists/version.html
@@ -16,13 +16,29 @@
     <form method="POST" action={{ clv.get_dmd_convert_url }}>
       {% csrf_token %}
       <div class="btn-group-vertical btn-block" role="group">
-      <a
-        href="{{ clv.get_download_url }}"
-        role="button"
-        class="btn btn-outline-primary btn-block"
-      >
-        Download CSV{% if clv.coding_system_id == "dmd" %} (with mapped VMPs)*{% endif %}
-      </a>
+        {% if clv.coding_system_id == "dmd" %}
+          {% if clv.downloadable %}
+            <a
+              href="{{ clv.get_download_url }}"
+              role="button"
+              class="btn btn-outline-primary btn-block"
+            >
+              Download CSV (with mapped VMPs)*
+            </a>
+          {% else %}
+            <div class="btn btn-outline-primary btn-block disabled">
+              Download CSV (with mapped VMPs)*
+            </div>
+          {% endif %}
+        {% else %}
+            <a
+              href="{{ clv.get_download_url }}"
+              role="button"
+              class="btn btn-outline-primary btn-block"
+            >
+              Download CSV
+            </a>
+        {% endif %}
       {% if clv.coding_system_id == "dmd" %}
       <a
         href="{{ clv.get_download_url }}?omit-mapped-vmps"


### PR DESCRIPTION
By undownloadable, we mean that it doesn't have an identifiable code
column header in the csv_data field, so it's undownloadable for OSI, and
also can't be used to retrieve mapped VMPs. We now validate codelists created
by csv upload, so this only applies to particularly old codelists. These
can still be downloaded in their original format.

e.g. https://opencodelists.org/codelist/opensafely/methotrexate-oral/738b5e12/#full-list
contains codes in a "VMP" column, which is not one of the allowed code headers.

This will prevent users hitting the assertion error e.g.:
https://ebm-datalab.sentry.io/issues/4628776626/?alert_rule_id=1877862&alert_type=issue&notification_uuid=788df5b5-7b73-4483-b635-ebc0cab896a6&project=5248013&referrer=slack

Also adds a footnote on the "full list" tab, [as suggested by @chrisjwood16](https://bennettoxford.slack.com/archives/C02HJTL065A/p1699894070945119?thread_ts=1699609696.257949&cid=C02HJTL065A), since "full list" for a dm+d codelist may not be the full full list including mapped VMPs that will be used in an OpenSAFELY project.