### PR TITLE
Include original csv data columns with default dm+d downloads

### DIFF
--- a/codelists/models.py
+++ b/codelists/models.py
@@ -771,13 +771,9 @@ class CodelistVersion(models.Model):
 
     def download_filename(self):
         if self.codelist_type == "user":
-            return "{}-{}-{}".format(
-                self.codelist.user_id, self.codelist.slug, self.tag_or_hash
-            )
+            return f"{self.codelist.user_id}-{self.codelist.slug}-{self.tag_or_hash}"
         else:
-            return "{}-{}-{}".format(
-                self.codelist.organisation_id, self.codelist.slug, self.tag_or_hash
-            )
+            return f"{self.codelist.organisation_id}-{self.codelist.slug}-{self.tag_or_hash}"
 
     @property
     def is_draft(self):

--- a/codelists/models.py
+++ b/codelists/models.py
@@ -533,7 +533,7 @@ class CodelistVersion(models.Model):
 
     def csv_data_for_download(self, fixed_headers=False, include_mapped_vmps=True):
         """
-        Prepare codes for download.  If this is a new-style codelists, the csv data with
+        Prepare codes for download.  If this is a new-style codelist, the csv data with
         code and related term will be built from the code objects, looking up the terms in
         the coding system.  If it is an old-style codelist, it has no associated code objects,
         and it will use the uploaded csv_data.
@@ -541,8 +541,9 @@ class CodelistVersion(models.Model):
         include_mapped_vmps: if True, a dm+d codelist will include mapped VMPs in its download.
           This value defaults to True, so that when these downloads are requested by OpenSafely CLI,
           no additional query params need to be passed that are specidfic to dm+d codelists.
-        fixed_headers: if True, uploaded csv_data is converted to two columns, headed "code" and "term".
-          This parameter is ignored for dmd downloads that include mapped VMPs
+        fixed_headers: if True, uploaded csv_data for old-style codelists is converted
+          to two columns, headed "code" and "term". Note that new-style codelists, will
+          always download with just "code" and "term" headers.
         """
         dmd_version_needs_refreshed = (
             self.coding_system_id == "dmd"
@@ -558,16 +559,10 @@ class CodelistVersion(models.Model):
                 if not fixed_headers and not dmd_with_mapped_vmps:
                     csv_data = self.csv_data
                 else:
-                    # if fixed_headers were not explicitly requested (i.e. by OSI), include a column
-                    # with the original code column header. This ensures that any new downloads continue
-                    # to work with existing study/data definitions that import codelists with a named
-                    # code column.
-                    # Currently this is likely to only apply to dm+d codelists which have often been
-                    # converted from BNF codelists, and previously used "dmd_id" as the code column
                     csv_data = rows_to_csv_data(
-                        self.table_with_fixed_headers(
+                        self.formatted_table(
+                            fixed_headers=fixed_headers,
                             include_mapped_vmps=include_mapped_vmps,
-                            include_original_header=not fixed_headers,
                         )
                     )
             else:
@@ -649,24 +644,33 @@ class CodelistVersion(models.Model):
 
         return self.cached_csv_data["shas"]
 
-    def table_with_fixed_headers(
-        self, include_mapped_vmps=True, include_original_header=False
-    ):
+    def formatted_table(self, fixed_headers=False, include_mapped_vmps=False):
         """
-        Find the code and term columns from csv data (which may be labelled with different
-        headers), and return just those columns with the with the headers "code" and "term".
+        Format the table data for download
+        Table data will always include a "code" and "term" column (if it exists in the
+        original data) extracted from the original csv data. These may be labelled
+        with different headers in the original CSV.
+
+        If fixed_headers=True, return just the code/term columns with the with the standardised headings "code" and "term".
+
+        If fixed_headers=False, we also include an original code column (a duplicate of
+        the column labelled "code" but with the heading from the original CSV data), and
+        any other columns from the original CSV data.
+
+        include_mapped_vmps: for dm+d codelists, also map in any previous/subsequent
+        VMPs
         """
         assert self.downloadable
         header_row = [header.lower() for header in self.table[0]]
         # Find the first matching header from the possible code and term column headers for this
         # codelist's coding system.  These are listed in order of assumed most-to-least likely,
         # in case of multiple matching headers
-        code_header = next(
+        original_code_header = next(
             header
             for header in self.codelist.coding_system_cls.csv_headers["code"]
             if header in header_row
         )
-        term_header = next(
+        original_term_header = next(
             (
                 header
                 for header in self.codelist.coding_system_cls.csv_headers["term"]
@@ -675,88 +679,138 @@ class CodelistVersion(models.Model):
             None,
         )
         # Identify the index for the two columns we want
-        code_header_index = header_row.index(code_header)
-        if include_original_header and code_header == "code":
-            # avoid duplicate columns if the code header is already "code"
-            include_original_header = False
-        term_header_index = header_row.index(term_header) if term_header else None
+        code_header_index = header_row.index(original_code_header)
+        term_header_index = (
+            header_row.index(original_term_header) if original_term_header else None
+        )
 
         table_rows = self.table[1:]
         if include_mapped_vmps and self.coding_system_id == "dmd":
             # ignore include_mapped_vmps if coding system is anything other than dmd
-            term_header_index = term_header_index or len(self.table[0])
-            codes = [row[code_header_index] for row in table_rows]
-
-            # add in mapped VMP codes
-            mapped_vmps_for_this_codelist = vmpprev_full_mappings(codes)
-
-            # mapped_vmps_for_this_codelist is a full list of (vmp, previous) tuples, where one of
-            # vmp/previous are in the codelist. It may contain mappings where `previous` is more than
-            # one historical step away from `vmp`
-
-            # create a mapping of previous and subsequent VMPs to add, where the
-            # keys are the mapped VMPs, and the values are the code(s) in the
-            # codelist that they map to/from. Usually there is just a 1:1 mapping, but
-            # it's possible that a single VMP could be split and map to 2 new VMPs, or
-            # that 2 VMPs could be merged to a single new code.
-            previous_vmps_to_add = {}
-            subsequent_vmps_to_add = {}
-
-            for vmp, previous in mapped_vmps_for_this_codelist:
-                if vmp in codes:
-                    # mapping in a previous code
-                    previous_vmps_to_add.setdefault(previous, []).append(vmp)
-                else:
-                    # mapping in a subsequent code
-                    subsequent_vmps_to_add.setdefault(vmp, []).append(previous)
-
-            assert not set(previous_vmps_to_add) & set(subsequent_vmps_to_add)
-
-            def add_row(vmp, description):
-                new_row = ["" for i in range(len(table_rows[0]) + 1)]
-                new_row[code_header_index] = vmp
-                new_row[term_header_index] = description
-                table_rows.append(new_row)
-
-            # Sort the VMPs being added to ensure consistent order. This will ensure that
-            # repeated CSV downloads are the same unless new mapped VMPs are added and
-            # can be used to check whether updates to study codelists are required.
-            for previous_vmp in sorted(previous_vmps_to_add):
-                # add the code to the table data
-                # include its description as the code it was superceded by
-                add_row(
-                    previous_vmp,
-                    f"VMP previous to {', '.join(previous_vmps_to_add[previous_vmp])}",
-                )
-
-            for subsequent_vmp in sorted(subsequent_vmps_to_add):
-                # add the code to the table data
-                # include its description as the code it supercedes
-                add_row(
-                    subsequent_vmp,
-                    f"VMP subsequent to {', '.join(subsequent_vmps_to_add[subsequent_vmp])}",
-                )
+            table_rows = self._add_mapped_vmps_to_table_data(
+                table_rows, code_header_index, term_header_index
+            )
 
         headers = ["code", "term"]
-        if include_original_header:
-            headers += [header_row[code_header_index]]
+        code_header_relabelled = original_code_header != "code"
+
+        # Add in any original columns we need to include
+        if not fixed_headers:
+            if code_header_relabelled:
+                # only add in the original code column if it was relabelled (i.e. it
+                # wasn't already called "code"
+                headers += [header_row[code_header_index]]
+
+            # Include any other original columns as well
+            # Other columns in the csv_data may include category column(s). We
+            # have no easy way of telling which those are since there's no
+            # verification of columns in uploads other than code columns, so if we
+            # haven't explicitly requested fixed headers (i.e. this is a dm+d
+            # download that's mapping in previous/subsequent VMPs), we just write
+            # out all other columns
+            other_headers = [
+                (i, header)
+                for i, header in enumerate(header_row)
+                if header and i not in [code_header_index, term_header_index]
+            ]
+            other_header_ix, other_header_names = (
+                list(zip(*other_headers)) if other_headers else [(), ()]
+            )
+            headers += list(other_header_names)
 
         # re-write the table data with the new headers, and only the code and term columns
-        # plus a duplicate code column with the original column header if required
+        # plus a duplicate code column with the original column header if required, and
+        # any other original columns
         def _csv_row(row):
             csv_row = [
                 row[code_header_index],
-                row[term_header_index] if term_header else "",
+                row[term_header_index] if original_term_header else "",
             ]
-            if include_original_header:
-                csv_row += [row[code_header_index]]
+            if not fixed_headers:
+                if code_header_relabelled:
+                    csv_row += [row[code_header_index]]
+                csv_row += [row[ix] for ix in list(other_header_ix)]
             return csv_row
 
         table_data = [
             headers,
             *[_csv_row(row) for row in table_rows],
         ]
+
         return table_data
+
+    def _add_mapped_vmps_to_table_data(self, table_rows, code_ix, term_ix):
+        """
+        Take a list of dm+d table rows for CSV download, plus an index identifying
+        which column to find the code and term in for each row, and append to it
+        any previous or subsequent mapped VMPs
+        """
+        term_ix = term_ix or len(self.table[0])
+        codes_dict = {row[code_ix]: row for row in table_rows}
+
+        # add in mapped VMP codes
+        mapped_vmps_for_this_codelist = vmpprev_full_mappings(codes_dict.keys())
+
+        # mapped_vmps_for_this_codelist is a full list of (vmp, previous) tuples, where one of
+        # vmp/previous are in the codelist. It may contain mappings where `previous` is more than
+        # one historical step away from `vmp`
+
+        # create a mapping of previous and subsequent VMPs to add, where the
+        # keys are the mapped VMPs, and the values are the code(s) in the
+        # codelist that they map to/from. Usually there is just a 1:1 mapping, but
+        # it's possible that a single VMP could be split and map to 2 new VMPs, or
+        # that 2 VMPs could be merged to a single new code.
+        previous_vmps_to_add = {}
+        subsequent_vmps_to_add = {}
+
+        for vmp, previous in mapped_vmps_for_this_codelist:
+            if vmp in codes_dict:
+                # mapping in a previous code
+                previous_vmps_to_add.setdefault(previous, []).append(vmp)
+            else:
+                # mapping in a subsequent code
+                subsequent_vmps_to_add.setdefault(vmp, []).append(previous)
+
+        assert not set(previous_vmps_to_add) & set(subsequent_vmps_to_add)
+
+        def add_row(vmp, description, original_code):
+            # copy the row for the original code that this VMP mapped to,
+            # and replace the code and term columns
+            # original code is a list, because it's a possiblity that a VMP could
+            # (although so far hasn't) mapped to more than one code. We just take the
+            # first one to get the starting row
+            original_code = original_code[0]
+            new_row = [*codes_dict[original_code]]
+            new_row[code_ix] = vmp
+            new_row[term_ix] = description
+            table_rows.append(new_row)
+
+        # Sort the VMPs being added to ensure consistent order. This will ensure that
+        # repeated CSV downloads are the same unless new mapped VMPs are added and
+        # can be used to check whether updates to study codelists are required.
+        for previous_vmp in sorted(previous_vmps_to_add):
+            # add the code to the table data
+            # include its description as the code(s) it was superceded by
+            # sort the codes so that ordering is consistent between downloads
+            original_codes = sorted(previous_vmps_to_add[previous_vmp])
+            add_row(
+                previous_vmp,
+                f"VMP previous to {', '.join(original_codes)}",
+                original_codes,
+            )
+
+        for subsequent_vmp in sorted(subsequent_vmps_to_add):
+            # add the code to the table data
+            # include its description as the code it supercedes
+            # sort the codes so that ordering is consistent between downloads
+            original_codes = sorted(subsequent_vmps_to_add[subsequent_vmp])
+            add_row(
+                subsequent_vmp,
+                f"VMP subsequent to {', '.join(original_codes)}",
+                original_codes,
+            )
+
+        return table_rows
 
     def definition_csv_data_for_download(self):
         return rows_to_csv_data(present_definition_for_download(self))

--- a/codelists/tests/test_api.py
+++ b/codelists/tests/test_api.py
@@ -739,6 +739,15 @@ def test_codelists_check_dmd_alternative_downloads(
     [
         (
             (  # default download (as expected from a current `opensafely codelists update`)
+                "code,term,dmd_id,dmd_type,bnf_code\r\n"
+                "10514511000001106,Adrenaline (base) 220micrograms/dose inhaler,10514511000001106,VMP,0301012A0AAABAB\r\n"
+                "10525011000001107,Adrenaline (base) 220micrograms/dose inhaler refill,10525011000001107,VMP,0301012A0AAACAC\r\n"
+                "999,VMP previous to 10514511000001106,999,VMP,0301012A0AAABAB\r\n"
+            ),
+            "ok",
+        ),
+        (
+            (  # download with code, term and original code column
                 "code,term,dmd_id\r\n"
                 "10514511000001106,Adrenaline (base) 220micrograms/dose inhaler,10514511000001106\r\n"
                 "10525011000001107,Adrenaline (base) 220micrograms/dose inhaler refill,10525011000001107\r\n"

--- a/codelists/tests/test_models.py
+++ b/codelists/tests/test_models.py
@@ -340,12 +340,14 @@ def test_cached_csv_data_dmd_codelist(dmd_version_asthma_medication):
     # - original
     # - mapped version, with fixed headers
     # - mapped version with fixed headers and extra original code column
-    assert len(clv.cached_csv_data["shas"]) == 3
+    # - mapped version with all additional original columns
+    assert len(clv.cached_csv_data["shas"]) == 4
 
-    clv.csv_data = "code,term"
+    clv.csv_data = "code,term\n123,foo\n"
     clv.save()
+    new_download_data = "code,term\r\n123,foo\r\n"
     # csv_data_for_download still returns the cached data
-    assert clv.csv_data_for_download() != "code,term\r\n"
+    assert clv.csv_data_for_download() != new_download_data
     assert (
         clv.csv_data_for_download()
         == cached_csv_data["download_data_fixed_headers_False_include_mapped_vmps_True"]
@@ -354,4 +356,4 @@ def test_cached_csv_data_dmd_codelist(dmd_version_asthma_medication):
     # make the release not the latest one so the data needs to be re-cached
     clv.cached_csv_data["release"] = "old"
     clv.save()
-    assert clv.csv_data_for_download() == "code,term\r\n"
+    assert clv.csv_data_for_download() == new_download_data

--- a/codelists/tests/test_models.py
+++ b/codelists/tests/test_models.py
@@ -135,8 +135,8 @@ def test_old_style_table(old_style_version):
     ]
 
 
-def test_old_style_table_with_fixed_headers(old_style_version):
-    assert old_style_version.table_with_fixed_headers() == [
+def test_old_style_formatted_table_with_fixed_headers(old_style_version):
+    assert old_style_version.formatted_table(fixed_headers=True) == [
         ["code", "term"],
         ["429554009", "Arthropathy of elbow (disorder)"],
         ["128133004", "Disorder of elbow (disorder)"],

--- a/codelists/tests/views/test_version_download.py
+++ b/codelists/tests/views/test_version_download.py
@@ -58,19 +58,35 @@ def test_get_with_mapped_vmps(client, dmd_version_asthma_medication):
     # Includes mapped VMPs  and uses fixed headers by default
     # Includes an additional column with the original code header
     assert csv_data_to_rows(data) == [
-        ["code", "term", "dmd_id"],
+        ["code", "term", "dmd_id", "dmd_type", "bnf_code"],
         [
             "10514511000001106",
             "Adrenaline (base) 220micrograms/dose inhaler",
             "10514511000001106",
+            "VMP",
+            "0301012A0AAABAB",
         ],
         [
             "10525011000001107",
             "Adrenaline (base) 220micrograms/dose inhaler refill",
             "10525011000001107",
+            "VMP",
+            "0301012A0AAACAC",
         ],
-        ["999", "VMP previous to 10514511000001106", "999"],
-        ["888", "VMP subsequent to 10514511000001106", "888"],
+        [
+            "999",
+            "VMP previous to 10514511000001106",
+            "999",
+            "VMP",
+            "0301012A0AAABAB",
+        ],
+        [
+            "888",
+            "VMP subsequent to 10514511000001106",
+            "888",
+            "VMP",
+            "0301012A0AAABAB",
+        ],
     ]
 
 
@@ -90,10 +106,25 @@ def test_get_with_mapped_vmps_and_original_code_column(
     # Includes mapped VMPs by default, and uses fixed headers
     # No additional column when the original code column was already "code"
     assert csv_data_to_rows(data) == [
-        ["code", "term"],
-        ["10514511000001106", "Adrenaline (base) 220micrograms/dose inhaler"],
-        ["10525011000001107", "Adrenaline (base) 220micrograms/dose inhaler refill"],
-        ["999", "VMP previous to 10514511000001106"],
+        ["code", "term", "dmd_type", "bnf_code"],
+        [
+            "10514511000001106",
+            "Adrenaline (base) 220micrograms/dose inhaler",
+            "VMP",
+            "0301012A0AAABAB",
+        ],
+        [
+            "10525011000001107",
+            "Adrenaline (base) 220micrograms/dose inhaler refill",
+            "VMP",
+            "0301012A0AAACAC",
+        ],
+        [
+            "999",
+            "VMP previous to 10514511000001106",
+            "VMP",
+            "0301012A0AAABAB",
+        ],
     ]
 
 
@@ -137,20 +168,30 @@ def test_get_with_duplicated_mapped_vmps(client, dmd_version_asthma_medication):
     data = rsp.content.decode("utf8")
     # Includes mapped VMPs by default, and uses fixed headers
     assert csv_data_to_rows(data) == [
-        ["code", "term", "dmd_id"],
+        ["code", "term", "dmd_id", "dmd_type", "bnf_code"],
         [
             "10514511000001106",
             "Adrenaline (base) 220micrograms/dose inhaler",
             "10514511000001106",
+            "VMP",
+            "0301012A0AAABAB",
         ],
         [
             "10525011000001107",
             "Adrenaline (base) 220micrograms/dose inhaler refill",
             "10525011000001107",
+            "VMP",
+            "0301012A0AAACAC",
         ],
-        ["999", "VMP previous to 10514511000001106, 10525011000001107", "999"],
-        ["777", "VMP subsequent to 10514511000001106", "777"],
-        ["888", "VMP subsequent to 10514511000001106", "888"],
+        [
+            "999",
+            "VMP previous to 10514511000001106, 10525011000001107",
+            "999",
+            "VMP",
+            "0301012A0AAABAB",
+        ],
+        ["777", "VMP subsequent to 10514511000001106", "777", "VMP", "0301012A0AAABAB"],
+        ["888", "VMP subsequent to 10514511000001106", "888", "VMP", "0301012A0AAABAB"],
     ]
 
 
@@ -162,16 +203,20 @@ def test_get_with_mapped_vmps_nothing_to_map(client, dmd_version_asthma_medicati
     data = rsp.content.decode("utf8")
 
     assert csv_data_to_rows(data) == [
-        ["code", "term", "dmd_id"],
+        ["code", "term", "dmd_id", "dmd_type", "bnf_code"],
         [
             "10514511000001106",
             "Adrenaline (base) 220micrograms/dose inhaler",
             "10514511000001106",
+            "VMP",
+            "0301012A0AAABAB",
         ],
         [
             "10525011000001107",
             "Adrenaline (base) 220micrograms/dose inhaler refill",
             "10525011000001107",
+            "VMP",
+            "0301012A0AAACAC",
         ],
     ]
 
@@ -214,21 +259,25 @@ def test_get_with_mapped_vmps_more_than_one_step_distant(
     rsp = client.get(dmd_version_asthma_medication.get_download_url())
     data = rsp.content.decode("utf8")
     assert csv_data_to_rows(data) == [
-        ["code", "term", "dmd_id"],
+        ["code", "term", "dmd_id", "dmd_type", "bnf_code"],
         [
             "10514511000001106",
             "Adrenaline (base) 220micrograms/dose inhaler",
             "10514511000001106",
+            "VMP",
+            "0301012A0AAABAB",
         ],
         [
             "10525011000001107",
             "Adrenaline (base) 220micrograms/dose inhaler refill",
             "10525011000001107",
+            "VMP",
+            "0301012A0AAACAC",
         ],
-        ["666", "VMP previous to 10514511000001106", "666"],
-        ["777", "VMP previous to 10514511000001106", "777"],
-        ["999", "VMP previous to 10514511000001106", "999"],
-        ["AAA", "VMP subsequent to 10514511000001106", "AAA"],
-        ["BBB", "VMP subsequent to 10514511000001106", "BBB"],
-        ["CCC", "VMP subsequent to 10514511000001106", "CCC"],
+        ["666", "VMP previous to 10514511000001106", "666", "VMP", "0301012A0AAABAB"],
+        ["777", "VMP previous to 10514511000001106", "777", "VMP", "0301012A0AAABAB"],
+        ["999", "VMP previous to 10514511000001106", "999", "VMP", "0301012A0AAABAB"],
+        ["AAA", "VMP subsequent to 10514511000001106", "AAA", "VMP", "0301012A0AAABAB"],
+        ["BBB", "VMP subsequent to 10514511000001106", "BBB", "VMP", "0301012A0AAABAB"],
+        ["CCC", "VMP subsequent to 10514511000001106", "CCC", "VMP", "0301012A0AAABAB"],
     ]

--- a/codelists/views/version_dmd_download.py
+++ b/codelists/views/version_dmd_download.py
@@ -6,9 +6,7 @@ from .decorators import load_version
 @load_version
 def version_dmd_download(request, clv):
     response = HttpResponse(content_type="text/csv")
-    content_disposition = 'attachment; filename="{}-dmd.csv"'.format(
-        clv.download_filename()
-    )
+    content_disposition = f'attachment; filename="{clv.download_filename()}-dmd.csv"'
     response["Content-Disposition"] = content_disposition
     response.write(clv.dmd_csv_data_for_download())
     return response

--- a/codelists/views/version_download.py
+++ b/codelists/views/version_download.py
@@ -10,9 +10,7 @@ def version_download(request, clv):
     if fixed_headers and not clv.downloadable:
         return HttpResponseBadRequest("Codelist is not downloadable")
     response = HttpResponse(content_type="text/csv")
-    content_disposition = 'attachment; filename="{}.csv"'.format(
-        clv.download_filename()
-    )
+    content_disposition = f'attachment; filename="{clv.download_filename()}.csv"'
     response["Content-Disposition"] = content_disposition
     response.write(
         clv.csv_data_for_download(


### PR DESCRIPTION
Fixes #1760 

dm+d downloads were previously downloading with just a code and term column by default, and mapping in any previous/subsequent VMPs that they needed to (with a note in the term column to describe where they were mapped from/to). However, in some cases, a study uses other columns from the original uploaded csv data - particularly category columns. OpenCodelists doesn't know or care about category columns, so we just add in any other original columns to the csv download. 