### PR TITLE
Bugfix and updated to version diffs

### DIFF
--- a/codelists/tests/test_api.py
+++ b/codelists/tests/test_api.py
@@ -155,6 +155,32 @@ def test_codelists_get(client, organisation):
             ],
         },
         {
+            "full_slug": "test-university/null-codelist",
+            "slug": "null-codelist",
+            "name": "Null Codelist",
+            "coding_system_id": "null",
+            "organisation": "Test University",
+            "user": "",
+            "versions": [
+                {
+                    "hash": "6f08ccac",
+                    "tag": None,
+                    "full_slug": "test-university/null-codelist/6f08ccac",
+                    "status": "under review",
+                    "downloadable": True,
+                    "updated_date": "2023-12-20",
+                },
+                {
+                    "hash": "55f95977",
+                    "tag": None,
+                    "full_slug": "test-university/null-codelist/55f95977",
+                    "status": "under review",
+                    "downloadable": True,
+                    "updated_date": "2023-12-20",
+                },
+            ],
+        },
+        {
             "full_slug": "test-university/old-style-codelist",
             "slug": "old-style-codelist",
             "name": "Old-style Codelist",
@@ -206,7 +232,7 @@ def test_codelists_get_with_coding_system_id(client, organisation):
 
     rsp = client.get(f"/api/v1/codelist/{organisation.slug}/?coding_system_id=")
     data = json.loads(rsp.content)
-    assert len(data["codelists"]) == 6
+    assert len(data["codelists"]) == 7
 
     rsp = client.get(f"/api/v1/codelist/{organisation.slug}/?coding_system_id=bnf")
     data = json.loads(rsp.content)

--- a/codelists/tests/views/test_index.py
+++ b/codelists/tests/views/test_index.py
@@ -46,7 +46,12 @@ def test_paginate_codelists(client, organisation, create_codelists):
 
 
 def test_under_review_index(
-    client, organisation, version_under_review, old_style_codelist, dmd_codelist
+    client,
+    organisation,
+    version_under_review,
+    old_style_codelist,
+    dmd_codelist,
+    null_codelist,
 ):
     # The organisation has three codelists (new style, old style, dmd)
     # All three codelists have under review versions
@@ -69,13 +74,22 @@ def test_under_review_index(
     dmd_under_review_count = dmd_codelist.versions.filter(status="under review").count()
     assert dmd_under_review_count > 0
 
+    assert null_codelist.organisation == organisation
+    null_under_review_count = null_codelist.versions.filter(
+        status="under review"
+    ).count()
+    assert null_under_review_count > 0
+
     # Get the under-review index.
     rsp = client.get(f"/codelist/{organisation.slug}/under-review/")
     # Assert that only under-review versions are returned
     versions = rsp.context["versions_page"].object_list
     assert (
         len(versions)
-        == under_review_count + old_style_under_review_count + dmd_under_review_count
+        == under_review_count
+        + old_style_under_review_count
+        + dmd_under_review_count
+        + null_under_review_count
     )
     for version in versions:
         assert version.status == "under review"

--- a/codelists/tests/views/test_version_diff.py
+++ b/codelists/tests/views/test_version_diff.py
@@ -176,3 +176,22 @@ def test_get_snomed_diff_new_vs_old_style_with_unknown(
         },
         {"code": "1234", "term": "[Unknown] Test code", "descendants": []},
     ]
+
+
+def test_get_version_diff_no_matching_version(
+    client, version_with_no_searches, old_style_version
+):
+    url = version_with_no_searches.get_diff_url(old_style_version)
+    url = url.replace(old_style_version.hash, "unknown-version-hash")
+    rsp = client.get(url)
+    assert rsp.status_code == 404
+
+
+def test_version_diff_default_columns(client, null_codelist):
+    # null_codelist has 2 old-style versions
+    # null coding_system doesn't have any named code/term columns, so
+    # should use the defaults
+    version1, version2 = list(null_codelist.versions.all())
+    rsp = client.get(version1.get_diff_url(version2))
+    assert rsp.context["rhs_only_codes"] == {"5678"}
+    assert rsp.context["lhs_only_codes"] == {"1234"}

--- a/coding_systems/base/coding_system_base.py
+++ b/coding_systems/base/coding_system_base.py
@@ -123,3 +123,6 @@ class DummyCodingSystem(BaseCodingSystem):
     """
 
     has_database = False
+
+    def code_to_term(self, codes):
+        return {code: "unknown" for code in codes}

--- a/coding_systems/base/tests/test_coding_system.py
+++ b/coding_systems/base/tests/test_coding_system.py
@@ -11,7 +11,7 @@ def test_most_recent_some_coding_system_releases(
     snomedct_data, dmd_data, icd10_data, coding_system
 ):
     # CodingSystemRelease created in fixtures for these
-    if coding_system in ["ctv3", "dmd", "snomedct", "icd10", "bnf"]:
+    if coding_system in ["ctv3", "dmd", "snomedct", "icd10", "bnf", "null"]:
         assert (
             most_recent_database_alias(coding_system)
             == f"{coding_system}_test_20200101"

--- a/coding_systems/versioning/fixtures/coding_system_releases.json
+++ b/coding_systems/versioning/fixtures/coding_system_releases.json
@@ -63,5 +63,18 @@
     "database_alias": "bnf_test_20200101",
     "state": "ready"
   }
+},
+{
+  "model": "versioning.codingsystemrelease",
+  "pk": 6,
+  "fields": {
+    "coding_system": "null",
+    "release_name": "test",
+    "valid_from": "2020-01-01",
+    "import_timestamp": "2022-10-24T15:38:52.231Z",
+    "import_ref": "unknown",
+    "database_alias": "null_test_20200101",
+    "state": "ready"
+  }
 }
 ]

--- a/opencodelists/tests/fixtures.py
+++ b/opencodelists/tests/fixtures.py
@@ -712,6 +712,27 @@ def build_fixtures():
     )
     # Check that all code_objs are linked to searches
     assert not minimal_draft.code_objs.filter(results__isnull=True).exists()
+
+    # null codelist
+    # A codelist using the "null" coding system, which isn't associated with
+    # a coding system database
+    # Has 2 versions
+    null_codelist = create_old_style_codelist(
+        owner=organisation,
+        name="Null Codelist",
+        coding_system_id="null",
+        coding_system_database_alias="null_test_20200101",
+        csv_data="code,term\n1234,Test code",
+        description="",
+        methodology="",
+    )
+    null_version1 = null_codelist.versions.get()
+    null_version2 = create_old_style_version(
+        codelist=null_codelist,
+        csv_data="code,term\n5678,Test code1",
+        coding_system_database_alias="null_test_20200101",
+    )
+
     return locals()
 
 
@@ -813,6 +834,7 @@ version_from_scratch = build_fixture("version_from_scratch")
 user_codelist = build_fixture("user_codelist")
 user_version = build_fixture("user_version")
 minimal_draft = build_fixture("minimal_draft")
+null_codelist = build_fixture("null_codelist")
 
 
 # These extra fixtures make modifications to those built in build_fixtures


### PR DESCRIPTION
Fixes the [sentry error](https://ebm-datalab.sentry.io/issues/4739425662/?alert_rule_id=1877862&alert_type=issue&notification_uuid=186c6ca7-93fc-432c-8355-cc98d87ea9fe&project=5248013&referrer=slack) here.

At the same time (and so that the bugfix can be tested), adds a "null" coding system codelist fixture, and allows diffs of codelists from all non-hierarchical coding systems (not just dm+d)