### PR TITLE
Updates to xlsx codelist imports

### DIFF
--- a/DEPLOY.md
+++ b/DEPLOY.md
@@ -110,29 +110,3 @@ root$ dokku letsencrypt:enable opencodelists
 dokku$ dokku http-auth:on opencodelists <user> <password>
 dokku$ dokku http-auth:off opencodelists
 ```
-
-### Manually creating and updating codelist versions
-
-Currently OpenCodelists handles multiple coding system releases, however it can't always handle
-new versions of codelists when the coding system has changed significantly since the original
-version was created. When a user creates a new version of a codelist, the searches from the
-original codelist are re-run. If these searches bring back any new codes, the version will fail
-to be created.  Users will see a message prompting them to contact tech-support:
-
-```
-Codes with unknown status found when creating new version; this is likely due to an update in
-the coding system. Please contact tech-support for assistance.
-```
-
-The codelist version can be manually created by running the following command on dokku3:
-
-```
-dokku$ dokku run opencodelists \
-    python manage.py create_and_update_draft <original version hash> --author <username>
-```
-
-The command will create a new draft version, and will assign statuses to each unknown code where
-possible. i.e. if a new code has an ancestor code that is included, it will be implicitly
-included (`(+)` status), and if it has an ancestor code that is excluded, it will be implictly
-excluded (`(-)` status).  The command will output a list of codes that were returned as "unknown"
-(`?`) status from the re-run searches, and have been assigned an assumed status. These should be passed on to the user to confirm.

--- a/DEVELOPERS.md
+++ b/DEVELOPERS.md
@@ -155,3 +155,7 @@ Run a command in the dev docker containter
 ```sh
 just docker-run <command>
 ```
+
+### Import codelists from an xlsx file
+
+See [codelists/scripts/README.md](codelists/scripts/README.md#bulk-import-codelists-from an-xlsx-file)

--- a/DEVELOPERS.md
+++ b/DEVELOPERS.md
@@ -156,6 +156,32 @@ Run a command in the dev docker containter
 just docker-run <command>
 ```
 
+### Manually creating and updating codelist versions
+
+Currently OpenCodelists handles multiple coding system releases, however it can't always handle
+new versions of codelists when the coding system has changed significantly since the original
+version was created. When a user creates a new version of a codelist, the searches from the
+original codelist are re-run. If these searches bring back any new codes, the version will fail
+to be created.  Users will see a message prompting them to contact tech-support:
+
+```
+Codes with unknown status found when creating new version; this is likely due to an update in
+the coding system. Please contact tech-support for assistance.
+```
+
+The codelist version can be manually created by running the following command on dokku3:
+
+```
+dokku$ dokku run opencodelists \
+    python manage.py create_and_update_draft <original version hash> --author <username>
+```
+
+The command will create a new draft version, and will assign statuses to each unknown code where
+possible. i.e. if a new code has an ancestor code that is included, it will be implicitly
+included (`(+)` status), and if it has an ancestor code that is excluded, it will be implictly
+excluded (`(-)` status).  The command will output a list of codes that were returned as "unknown"
+(`?`) status from the re-run searches, and have been assigned an assumed status. These should be passed on to the user to confirm.
+
 ### Import codelists from an xlsx file
 
 See [codelists/scripts/README.md](codelists/scripts/README.md#bulk-import-codelists-from an-xlsx-file)

--- a/codelists/scripts/README
+++ b/codelists/scripts/README
@@ -1,0 +1,151 @@
+# Bulk import codelists from an xlsx file
+
+`codelists/scripts/import_codelists_from_xlsx.py` reads an XLSX file and creates new
+codelists/codelist versions. All new versions are created as "under review".
+
+This script is intended to be run on a local machine, and will use the OpenCodelists
+API to create the new codelist versions.
+
+## Running the script
+
+```
+usage: import_codelists_from_xlsx.py [-h] [--force-new-version] [--live-run]
+                                     [--host HOST]
+                                     xlsx_file config_file
+
+positional arguments:
+  xlsx_file             Path/to/xlsx/file
+  config_file           Path/to/config/json/file
+
+options:
+  -h, --help            show this help message and exit
+  --force-new-version, -f
+                        Always create a new version, even if a version with
+                        identical codes already exists.
+  --live-run            Run this command for real; if not specified, this will be a
+                        dry run that reports codelists/versions that will be
+                        created but does not actually do anything.
+  --host HOST           Host to use for API calls; https://www.opencodelists.org for
+                        live prod run
+```
+
+Run with:
+```sh
+API_TOKEN=###
+python codelists/scripts/ \import_codelists_from_xlsx.py
+    <path/to/xlsx> \
+    <path/to/config/json> \
+    --host \ # run on the specified host; defaults to localhost:7000
+    --force-new-version -f \ # to force a new version, even if there are no changes
+    --live-run \ # run for real; if not set, just reports what would be done
+```
+
+Always run without the `--live-run` flag first. This will tell you if the script will
+create a new codelist or a new version for each codelist in the xlsx file; confirm
+that for any codelists that already exist, it reports that they will create new
+*versions*.
+
+To test with a local server, obtain a copy of the prod database and the relevant coding
+system dbs, create an API token for the local user, run `just run` and then run
+the script, using `--host http://localhost:7000`.
+
+**NOTE:** when running on prod use --host https://www.opencodelists.org;
+if run with https://opencodelists.org, the redirect to www will make the API calls
+return 405s.
+
+## Create API token
+
+Create a token on the server (via the django shell) with:
+```python
+from rest_framework.authtoken.models import Token
+
+user = User.objects.get(username=...)
+token = Token.objects.create(user=user)
+print(user.api_token)
+```
+
+NOTE: the token user must be a member of the relevant organisation on OpenCodelists.
+
+## XLSX file format
+
+Provide a path to an xlsx file, which should contain at least one sheet, with at least columns (these can be aliased using the [config](#config)):
+ - coding_system
+ - codelist_name
+ - code
+ - term (only required if file includes dm+d codelists)
+
+ Each row represents one code in one codelist version, e.g. the following represents
+ one SNOMED-CT codelist and one dm+d codelist, each with 3 codes.
+
+ coding_system | codelist_name | code
+ --------------|---------------|-----
+ snomedct      | Asthma        | 1234
+ snomedct      | Asthma        | 2345
+ snomedct      | Asthma        | 3456
+ dmd           | Paracetemol   | ABCD
+ dmd           | Paracetemol   | BCDE
+ dmd           | Paracetemol   | CDEF
+
+Note the columns names, coding system refs and codelist names can be aliased
+in the config file, see below.
+
+## Config
+
+Provide a config file in json format
+
+### Required keys
+- **organisation** (Organisation slug)
+- **sheet** (name of the sheet in the workbook that contains the list of codes)
+- **coding_systems** (for each coding system value present in the workbook,
+  the id of the coding system in OpenCodelists and the database alias of the
+  release to be used for the new codelist. In the example below, the coding
+  system column in the xlsx file  contains values "SNOMED CT" and "dm+d")
+
+### Optional keys:
+- **tag** (optional tag for the codelist versions)
+- **column_aliases** (optional aliases for column names. We expect columns named
+  coding_system, codelist_name, code, term (optional); column aliases is a dict
+  mapping one or more of these column names to the actual name in the xlsx file.)
+- **codelist_name_aliases** (in case the the name in OpenCodelists doesn't exactly
+  match the value in the codelist_name column). This is a dict mapping from the
+  name in the xlsx file (key) to name in OpenCodelists (value). It can also be
+  used with the `limit_to_named_codelists` flag to specify updates for only a
+  subset of codelists in the xlsx file.
+- **limit_to_named_codelists**: boolean, defaults to False; only import update for
+  codelists named in codelist_name_aliases
+
+### example_config.json:
+```json
+{
+    "organisation": "pincer",
+    "sheet": "SCT codeclusters",
+    "coding_systems": {
+        "SNOMED CT": {
+            "id": "snomedct",
+            "release": "snomedct_3600_20230419"
+        },
+        "dm+d": {
+            "id": "dmd",
+            "release": "dmd_2023-530_20230522"
+        }
+    },
+    "tag": "v2.0",
+    "column_aliases": {
+        "coding_system": "Coding_scheme",
+        "codelist_name": "Cluster_description",
+        "code": "SNOMED code"
+        "term": "SNOMED_Description",
+    },
+    "codelist_name_aliases": {
+        "Loop diuretics": "Loop diuretics Rx",
+        "Lithium medication": "Lithium Rx",
+        "Methrotrexate": "Methotrexate Rx",
+        "NSAID medication": "oral NSAID Rx",
+        "Non Aspirin antiplatelet": "Antiplatelet Rx without aspirin Rx",
+        "Non Selective Beta Blockers": "Non cardio-selective beta-blocker Rx",
+        "Aspirin & other antiplatelets": "aspirin + other antiplatelet Rx",
+        "PPIs and H2 blockers": "Ulcer healing drugs: PPI & H2 blockers Rx"
+    },
+    limit_to_named_codelists: false
+}
+```

--- a/codelists/scripts/import_codelists_from_xlsx.py
+++ b/codelists/scripts/import_codelists_from_xlsx.py
@@ -138,7 +138,8 @@ def main(
     codelists_resp = requests.get(base_url)
     if codelists_resp.status_code == 404:
         print(
-            "Could not retrieve codelists for organisation {}; ensure organisation slug is correct."
+            f"Could not retrieve codelists for organisation {config['organisation']}; "
+            "ensure organisation slug is correct and authorised user has access to it."
         )
         sys.exit(1)
     # Create a mapping of codelist name to slug
@@ -198,9 +199,19 @@ def main(
                 if response.status_code == 200:
                     print(f"Created {message_part}")
                 else:
-                    print(
+                    error_message = (
                         f"Failed to create new {message_part}: {response.status_code}"
                     )
+                    if (
+                        response.status_code == 400
+                        and not dry_run
+                        and not force_new_version
+                    ):
+                        error_message += (
+                            "\nA version with these codes may already exist. "
+                            "Use -f to force creation of a new version."
+                        )
+                    print(error_message)
 
 
 def get_headers():

--- a/codelists/scripts/import_codelists_from_xlsx.py
+++ b/codelists/scripts/import_codelists_from_xlsx.py
@@ -179,16 +179,16 @@ def process_xlsx_to_dataframe(xlsx_filepath, config):
         # ensure all required columns are now present
         assert column in relevant_df_columns, f"Expected column {column} not found"
 
-    # Remove extraneous whitespace from all columns of interest
-    for column in relevant_df_columns:
-        codelist_df[column] = codelist_df[column].str.strip()
-
     # update the codelist name column with any aliases
     def update_name(name):
         return codelist_name_aliases.get(name, name)
 
     aliased_names = codelist_df["codelist_name"].apply(update_name)
     codelist_df["codelist_name"] = aliased_names
+
+    # Remove extraneous whitespace from all columns of interest
+    for column in relevant_df_columns:
+        codelist_df[column] = codelist_df[column].str.strip()
 
     return codelist_df
 

--- a/codelists/scripts/import_codelists_from_xlsx.py
+++ b/codelists/scripts/import_codelists_from_xlsx.py
@@ -239,6 +239,14 @@ def process_xlsx_to_dataframe(xlsx_filepath, config):
         sheet_name=config["sheet"],
         converters={column_aliases["code"]: str},
     )
+
+    if config.get("limit_to_named_codelists", False):
+        # if necessary, limit to only the named columns
+        codelist_name_col = codelist_df[
+            config["column_aliases"].get("codelist_name", "codelist_name")
+        ]
+        codelist_df = codelist_df[codelist_name_col.isin(codelist_name_aliases.keys())]
+
     # Rename df columns with any aliased column names
     codelist_df.rename(columns={v: k for k, v in column_aliases.items()}, inplace=True)
 

--- a/codelists/scripts/import_codelists_from_xlsx.py
+++ b/codelists/scripts/import_codelists_from_xlsx.py
@@ -6,11 +6,6 @@ Reads an XLSX file and updates/creates codelist versions
 This script is intended to be run on a local machine, and will use the OpenCodelists
 API to create the new codelist versions.
 
-Create a token on the server with:
-    from rest_framework.authtoken.models import Token
-    token = Token.objects.create(user=...)
-    print(user.api_token)
-
 Run with:
     API_TOKEN=###
     python codelists/scripts/import_codelists_from_xlsx.py
@@ -20,79 +15,7 @@ Run with:
       --force-new-version -f  # to force a new version, even if there are no changes
       --live-run  # run for real; if not set, just reports what would be done
 
-(NOTE: when running on prod use --host https://www.opensafely.org; if run with https://opensafely.org, the
-redirect to www will make the api calls return 405s.)
-
-Provide a path to an xlsx file, which should contain at least one sheet, with at least columns:
- - coding_system
- - codelist_name
- - code
- - term (only required if file includes dm+d codelists)
-
- Each row represents one code in one codelist version, e.g. the following represents
- one SNOMED-CT codelist and one dm+d codelist, each with 3 codes.
-
- coding_system | codelist_name | code
- --------------|---------------|-----
- snomedct      | Asthma        | 1234
- snomedct      | Asthma        | 2345
- snomedct      | Asthma        | 3456
- dmd           | Paracetemol   | ABCD
- dmd           | Paracetemol   | BCDE
- dmd           | Paracetemol   | CDEF
-
-Note the columns names, coding system refs and codelist names can be aliased
-in the config file, see below.
-
-Provide a config file in json format:
-required keys:
-- organisation (Organisation slug)
-- sheet (sheet in the workbook that contains the list of codes)
-- coding_systems (for each coding system value present in the workbook,
-  the id of the coding system in OpenCodelists and the database alias of the
-  release to be used for the new codelist. In the example below, the coding
-  system column in the xlsx file  contains values "SNOMED CT" and "dm+d")
-optional keys:
-- tag (optional tag for the codelist versions)
-- column_aliases (optional aliases for column names. We expect columns named
-  coding_system, codelist_name, code, term (optional); column aliases is a dict
-  mapping one or more of these column names to the actual name in the xlsx file.)
-- codelist_name_aliases (in case the the name
-  in OpenCodelists doesn't exactly match the value in the codelist_name column.
-  Dict mapping from the name in the xlsx file (key) to name in OpenCodelists (value)
-
-example_config.json:
-{
-    "organisation": "pincer",
-    "sheet": "SCT codeclusters",
-    "coding_systems": {
-        "SNOMED CT": {
-            "id": "snomedct",
-            "release": "snomedct_3600_20230419"
-        },
-        "dm+d": {
-            "id": "dmd",
-            "release": "dmd_2023-530_20230522"
-        }
-    },
-    "tag": "v2.0",
-    "column_aliases": {
-        "coding_system": "Coding_scheme",
-        "codelist_name": "Cluster_description",
-        "code": "SNOMED code"
-        "term": "SNOMED_Description",
-    },
-    "codelist_name_aliases": {
-        "Loop diuretics": "Loop diuretics Rx",
-        "Lithium medication": "Lithium Rx",
-        "Methrotrexate": "Methotrexate Rx",
-        "NSAID medication": "oral NSAID Rx",
-        "Non Aspirin antiplatelet": "Antiplatelet Rx without aspirin Rx",
-        "Non Selective Beta Blockers": "Non cardio-selective beta-blocker Rx",
-        "Aspirin & other antiplatelets": "aspirin + other antiplatelet Rx",
-        "PPIs and H2 blockers": "Ulcer healing drugs: PPI & H2 blockers Rx"
-    }
-}
+See additional documentation at codelists/scripts/README.md
 
 """
 import argparse
@@ -336,7 +259,7 @@ def parse_args():
     parser.add_argument(
         "--host",
         default="http://localhost:7000",
-        help="Host to use for API calls; https://www.opensafely.org for live prod run",
+        help="Host to use for API calls; https://www.opencodelists.org for live prod run",
     )
 
     arguments = parser.parse_args()

--- a/codelists/tests/test_import_codelists_from_xlsx.py
+++ b/codelists/tests/test_import_codelists_from_xlsx.py
@@ -35,18 +35,20 @@ def test_import_from_xlsx(
     url = live_server.url
     environ["API_TOKEN"] = organisation_user.api_token
 
-    initial_cl_count = Codelist.objects.count()
-    initial_clv_count = CodelistVersion.objects.count()
+    expected_cl_count = Codelist.objects.count()
+    expected_clv_count = CodelistVersion.objects.count()
 
     # dry_run is the default, and doesn't actually create anything
     main(FIXTURES_PATH / "codelists.xlsx", config, host=url)
-    assert Codelist.objects.count() == initial_cl_count
-    assert CodelistVersion.objects.count() == initial_clv_count
+    assert Codelist.objects.count() == expected_cl_count
+    assert CodelistVersion.objects.count() == expected_clv_count
 
     # importing xlsx file creates 2 new codelists
     main(FIXTURES_PATH / "codelists.xlsx", config, dry_run=False, host=url)
-    assert Codelist.objects.count() == initial_cl_count + 2
-    assert CodelistVersion.objects.count() == initial_clv_count + 2
+    expected_cl_count += 2
+    expected_clv_count += 2
+    assert Codelist.objects.count() == expected_cl_count
+    assert CodelistVersion.objects.count() == expected_clv_count
 
     # reimporting again creates new versions for the existing codelists
     main(
@@ -56,5 +58,20 @@ def test_import_from_xlsx(
         host=url,
         force_new_version=True,
     )
-    assert Codelist.objects.count() == initial_cl_count + 2
-    assert CodelistVersion.objects.count() == initial_clv_count + 4
+    expected_clv_count += 2
+    assert Codelist.objects.count() == expected_cl_count
+    assert CodelistVersion.objects.count() == expected_clv_count
+
+    # Limit to named codelists and reimport again; creates a new version
+    # for the named codelist only
+    config["limit_to_named_codelists"] = True
+    main(
+        FIXTURES_PATH / "codelists.xlsx",
+        config,
+        dry_run=False,
+        host=url,
+        force_new_version=True,
+    )
+    expected_clv_count += 1
+    assert Codelist.objects.count() == expected_cl_count
+    assert CodelistVersion.objects.count() == expected_clv_count


### PR DESCRIPTION
Update the xlsx import script:
- add some better error messaging
- add an extra config option so the import can be limited to specific named codelists
- move documentation from the script to a README and link to it from DEVELOPERS.md

This script was initially created for the PINCER codelists, using the format of their xlsx file. Updates are based on latest request to update PRIMIS vaccination uptake reporting codelists, which take a similar form (#1771)