### PR TITLE
Ensure prod smoketest can create/read db file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ static/dist/js
 staticfiles/
 /assets/dist
 /docker/docker-staticfiles/*
+docker/storage

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -35,7 +35,9 @@ services:
       - DATABASE_DIR=/storage
       - DATABASE_URL=sqlite:////storage/db.sqlite3
     volumes:
-      - ../db.sqlite3:/storage/db.sqlite3
+      # mount local directory for db path for use in tests;
+      # this is created with the correct permissions in `just docker/serve`
+      - "../docker/storage:/storage"
 
   node-assets:
     extends:

--- a/docker/justfile
+++ b/docker/justfile
@@ -53,6 +53,13 @@ test: test-js test-py
 
 # run dev server in docker container
 serve env="dev" *args="":
+    #!/usr/bin/env bash
+    if [ "$env" = "prod" ]; then
+        echo foo
+        SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+        mkdir "$SCRIPT_DIR/storage"
+        sudo chown 10003:10003 "$SCRIPT_DIR/storage"
+    fi
     docker-compose up {{ args }} {{ env }}
 
 

--- a/docker/justfile
+++ b/docker/justfile
@@ -51,15 +51,19 @@ test-js:
 
 test: test-js test-py
 
-# run dev server in docker container
-serve env="dev" *args="":
+_create_storage env:
     #!/usr/bin/env bash
-    if [ "$env" = "prod" ]; then
-        echo foo
-        SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+    set -euo pipefail
+
+    if [ "{{ env }}" = "prod" ]; then
+        SCRIPT_DIR={{justfile_directory()}}
         mkdir "$SCRIPT_DIR/storage"
         sudo chown 10003:10003 "$SCRIPT_DIR/storage"
     fi
+
+
+# run dev server in docker container
+serve env="dev" *args="": (_create_storage env)
     docker-compose up {{ args }} {{ env }}
 
 


### PR DESCRIPTION
In actual prod, we mount a volume that is owned by the non-root docker user. In the prod smoketest, we need to make sure that the volume mounted in is also owned by the non-root user. The db doesn't exist at this stage, so it will be created in the test.