### PR TITLE
Update slack webhook for data import failures

### DIFF
--- a/deploy/bin/import_latest_dmd_cronfile
+++ b/deploy/bin/import_latest_dmd_cronfile
@@ -1,11 +1,10 @@
 # /etc/cron.d/dokku-opencodelists-import-latest-dmd
 # cron job to import latest dm+d releases
-# update SLACK_WEBHOOK_URL and SLACK_DATATEAM_WEBHOOK_URL with relevant channel url
-#(#tech-noise, #team-data)
+# update SLACK_WEBHOOK_URL and SLACK_TEAM_WEBHOOK_URL with relevant channel url
 
 PATH=/usr/local/bin:/usr/bin:/bin
 SHELL=/bin/bash
 SLACK_WEBHOOK_URL=dummy-url
-SLACK_DATATEAM_WEBHOOK_URL=dummy-url
+SLACK_TEAM_WEBHOOK_URL=dummy-url
 
 5 23 * * 1 dokku /var/lib/dokku/data/storage/opencodelists/import_latest_release.sh dmd

--- a/deploy/bin/import_latest_release.sh
+++ b/deploy/bin/import_latest_release.sh
@@ -17,7 +17,12 @@ set -euo pipefail
 
 # This script should be copied to /var/lib/dokku/data/storage/opencodelists/import_latest_release.sh
 # on dokku3 and run using the cronfile at opencodelists/deploy/bin/import_latest_dmd_cron
-# SLACK_WEBHOOK_URL and SLACK_DATATEAM_WEBHOOK_URL is an environment variable set in the cronfile on dokku3
+
+# SLACK_WEBHOOK_URL and SLACK_TEAM_WEBHOOK_URL are environment variables set in the cronfile on dokku3
+# General notification messages (import start, complete etc) are posted to the
+# SLACK_WEBHOOK_URL channel (#tech-noise).  Failures are posted to the
+# SLACK_TEAM_WEBHOOK_URL. This should be set to the channel for the team responsible
+# for OpenCodelists.
 
 CODING_SYSTEM=$1
 
@@ -68,7 +73,7 @@ function post_success_message_and_cleanup() {
 function post_failure_message_and_cleanup() {
   # restart app
   /usr/bin/dokku ps:restart opencodelists
-  # Report and notify data team in slack
+  # Report and notify team in slack
   failure_message_text="\
 Latest ${CODING_SYSTEM} release failed to import to OpenCodelists.\n \
 Check logs on dokku3 at ${LOG_FILE}\n \
@@ -79,7 +84,7 @@ import_coding_system_data ${CODING_SYSTEM} ${DOWNLOAD_DIR} \
 --release <release name> \
 --valid-from <YYYY-MM-DD> \
 --force && dokku ps:restart opencodelists\`\`\`"
-  post_to_slack "${failure_message_text}" "${SLACK_DATATEAM_WEBHOOK_URL}"
+  post_to_slack "${failure_message_text}" "${SLACK_TEAM_WEBHOOK_URL}"
 }
 
 

--- a/deploy/bin/import_latest_snomedct_cronfile
+++ b/deploy/bin/import_latest_snomedct_cronfile
@@ -1,11 +1,10 @@
 # /etc/cron.d/dokku-opencodelists-import-latest-snomedct
 # cron job to import latest snomedct releases
-# update SLACK_WEBHOOK_URL and SLACK_DATATEAM_WEBHOOK_URL with relevant channel url
-#(#tech-noise, #team-data)
+# update SLACK_WEBHOOK_URL and SLACK_TEAM_WEBHOOK_URL with relevant channel url
 
 PATH=/usr/local/bin:/usr/bin:/bin
 SHELL=/bin/bash
 SLACK_WEBHOOK_URL=dummy-url
-SLACK_DATATEAM_WEBHOOK_URL=dummy-url
+SLACK_TEAM_WEBHOOK_URL=dummy-url
 
 5 23 * * 2 dokku /var/lib/dokku/data/storage/opencodelists/import_latest_release.sh snomedct


### PR DESCRIPTION
Update webhooks to post failure notifications to the team responsible.

The actual webhook is an environment variable specified in the cronfile on dokku3; I've changed the name of the variable so it doesn't reference the specific team, so that in the event that we change teams/team names again, we just need to update the env var content.

See https://github.com/ebmdatalab/sysadmin/issues/313