### PR TITLE
Improve logging for automated imports

### DIFF
--- a/deploy/bin/import_latest_release.sh
+++ b/deploy/bin/import_latest_release.sh
@@ -45,11 +45,11 @@ function post_to_slack() {
   "${webhook_url}"
 }
 
-
 function run_dokku_import_command () {
+  # pipe the output via sed to remove ansi escape sequences
   /usr/bin/dokku run opencodelists \
       python "$REPO_ROOT"/manage.py \
-      import_latest_data "${CODING_SYSTEM}" "${DOWNLOAD_DIR}" > "${LOG_FILE}" 2>&1
+      import_latest_data "${CODING_SYSTEM}" "${DOWNLOAD_DIR}" |& sed 's/\x1b\[[0-9;]*[mGKHF]//g' > "${LOG_FILE}"
 }
 
 

--- a/opencodelists/management/commands/import_latest_data.py
+++ b/opencodelists/management/commands/import_latest_data.py
@@ -38,6 +38,9 @@ class Command(BaseCommand):
 
         release_name = metadata["release_name"]
         valid_from = metadata["valid_from"]
+        self.stdout.write(
+            f'STARTING IMPORT: RELEASE NAME "{release_name}"; VALID FROM "{valid_from}"'
+        )
         import_fn(release_zipfile_path, release_name, valid_from)
 
         self.stdout.write(


### PR DESCRIPTION
Fixes some annoyances with the logging for dm+d and snomed imports that run overnight.

1) we were getting horrible escape sequences in the output. I couldn't figure out why - structlog's formatter has colour fomatting turned off on prod, so it doesn't seem to be that. Some was definitely from the output of django commands, which are supposed to also turn off colour formatting when redirecting to a file, but didn't seem to. This now pipes it through sed to remove them.

2) If dm+d imports fail, which they do every so often, it's usually because it was killed for some reason, and it's (so far) always just needed re-run. We helpfully post the command you need to rerun it to slack along with the failure message, but we weren't reporting the values for "release name" and "valid from" early enough to be useful.  