### PR TITLE
Set fetch depth in deploy job 

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -153,7 +153,7 @@ jobs:
             ssh -o "UserKnownHostsFile=/dev/null" -o "StrictHostKeyChecking=no" dokku@dokku3.ebmdatalab.net git:from-image opencodelists $SHA
 
       - name: Create Sentry release
-        uses: getsentry/action-release@e769183448303de84c5a06aaaddf9da7be26d6c7
+        uses: getsentry/action-release@e769183448303de84c5a06aaaddf9da7be26d6c7  # v1.7.0
         env:
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_RELEASE_INTEGRATION_TOKEN }}
           SENTRY_ORG: ebm-datalab

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -114,6 +114,9 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
       - uses: opensafely-core/setup-action@v1
         with:
           install-just: true


### PR DESCRIPTION
This is an attempt to fix the currently failing "Create Sentry release" step.