### PR TITLE
Increase timeout to 45s

### DIFF
--- a/opencodelists/settings.py
+++ b/opencodelists/settings.py
@@ -148,7 +148,7 @@ WSGI_APPLICATION = "opencodelists.wsgi.application"
 # from coding_systems.versioning.apps)
 DATABASES = {
     "default": env.dj_db_url("DATABASE_URL", "sqlite:///db.sqlite3"),
-    "OPTIONS": {"timeout": 30},
+    "OPTIONS": {"timeout": 45},
 }
 
 DATABASE_DIR = Path(


### PR DESCRIPTION
Several users have experienced `OperationalError`s because the database has been locked. Whilst these errors relate to the builder, it's proving hard to recreate them locally. It's not the case, for example, that making many updates to a single codelist in a short space of time locks the database.

Finding the route cause of the errors will take time. However, given that the error has occurred 55 times in the last 30 days, increasing the timeout from 30s to 45s and monitoring the errors seems reasonable.

Thanks to @emprestige for reporting the errors in the first instance.

Closes #1811