### PR TITLE
Update CDN linked assets

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -2,22 +2,10 @@
 <html lang="en" class="h-100">
   <head>
     <meta charset="utf-8" />
-    <meta
-      name="viewport"
-      content="width=device-width, initial-scale=1, shrink-to-fit=no"
-    />
-    <link
-      rel="stylesheet"
-      href="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/4.6.0/css/bootstrap.min.css"
-      integrity="sha512-P5MgMn1jBN01asBgU0z60Qk4QxiXo86+wlFahKrsQf37c9cro517WzVSPPV1tDKzhku2iJ2FVgL67wG03SGnNA=="
-      crossorigin="anonymous"
-      referrerpolicy="no-referrer"
-    />
-    <link
-      rel="stylesheet"
-      type="text/css"
-      href="https://cdn.datatables.net/1.10.20/css/dataTables.bootstrap4.min.css"
-    />
+    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
+
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/bootstrap/4.6.2/css/bootstrap.min.css" integrity="sha512-rt/SrQ4UNIaGfDyEXZtNcyWvQeOq0QLygHluFQcSjaGB04IxWhal71tKuzP6K8eYXYB6vJV4pHkXcmFGGQ1/0w==" crossorigin="anonymous" referrerpolicy="no-referrer" />
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/datatables/1.10.20/css/dataTables.bootstrap4.min.css" integrity="sha512-4o2NtfcBGIT0SbOTpWLYovl07cIaliKIQpUXvEPvyOgBF/01xY1TXm5F1B+X48/zhhFLIw2oBTsE0rjcwEOwJQ==" crossorigin="anonymous" referrerpolicy="no-referrer" />
 
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link rel="preload" as="style" href="https://fonts.googleapis.com/css2?family=Public+Sans:wght@400;500;600;700&display=swap" />
@@ -176,34 +164,6 @@
       <div class="mt-4">
         {% block content %} {% endblock %}
       </div>
-
-      <script
-        src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.5.1/jquery.slim.min.js"
-        integrity="sha512-/DXTXr6nQodMUiq+IUJYCt2PPOUjrHJ9wFrqpJ3XkgPNOZVfMok7cRw6CSxyCQxXn6ozlESsSh1/sMCTF1rL/g=="
-        crossorigin="anonymous"
-        referrerpolicy="no-referrer"
-      ></script>
-
-      <script
-        src="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/4.6.0/js/bootstrap.bundle.min.js"
-        integrity="sha512-wV7Yj1alIZDqZFCUQJy85VN+qvEIly93fIQAN7iqDFCPEucLCeNFz4r35FCo9s6WrpdDQPi80xbljXB8Bjtvcg=="
-        crossorigin="anonymous"
-        referrerpolicy="no-referrer"
-      ></script>
-
-      <script
-        type="text/javascript"
-        charset="utf8"
-        src="https://cdn.datatables.net/1.10.20/js/jquery.dataTables.min.js"
-      ></script>
-
-      <script
-        type="text/javascript"
-        charset="utf8"
-        src="https://cdn.datatables.net/1.10.20/js/dataTables.bootstrap4.min.js"
-      ></script>
-
-      {% block extra_js %}{% endblock %}
     </main>
 
     <footer id="footer" class="border-top bg-light mt-auto py-5">
@@ -245,5 +205,11 @@
         </div>
       </div>
     </footer>
+
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.5.1/jquery.slim.js" integrity="sha512-1lagjLfnC1I0iqH9plHYIUq3vDMfjhZsLy9elfK89RBcpcRcx4l+kRJBSnHh2Mh6kLxRHoObD1M5UTUbgFy6nA==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/bootstrap/4.6.2/js/bootstrap.bundle.min.js" integrity="sha512-igl8WEUuas9k5dtnhKqyyld6TzzRjvMqLC79jkgT3z02FvJyHAuUtyemm/P/jYSne1xwFI06ezQxEwweaiV7VA==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/datatables/1.10.20/js/jquery.dataTables.min.js" integrity="sha512-hX6rgGqXX6Ajh6Y+bZ+P/0ZkUBl3fQMY6I1B51h5NDOu7XE1lVgdf2VqygjozLX8AufHvWAzOuC0WVMb4wJX4w==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/datatables/1.10.20/js/dataTables.bootstrap4.min.js" integrity="sha512-T970v+zvIZu3UugrSpRoyYt0K0VknTDg2G0/hH7ZmeNjMAfymSRoY+CajxepI0k6VMFBXxgsBhk4W2r7NFg6ag==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
+    {% block extra_js %}{% endblock %}
   </body>
 </html>

--- a/templates/base.html
+++ b/templates/base.html
@@ -5,7 +5,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
 
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/bootstrap/4.6.2/css/bootstrap.min.css" integrity="sha512-rt/SrQ4UNIaGfDyEXZtNcyWvQeOq0QLygHluFQcSjaGB04IxWhal71tKuzP6K8eYXYB6vJV4pHkXcmFGGQ1/0w==" crossorigin="anonymous" referrerpolicy="no-referrer" />
-    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/datatables/1.10.20/css/dataTables.bootstrap4.min.css" integrity="sha512-4o2NtfcBGIT0SbOTpWLYovl07cIaliKIQpUXvEPvyOgBF/01xY1TXm5F1B+X48/zhhFLIw2oBTsE0rjcwEOwJQ==" crossorigin="anonymous" referrerpolicy="no-referrer" />
 
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link rel="preload" as="style" href="https://fonts.googleapis.com/css2?family=Public+Sans:wght@400;500;600;700&display=swap" />
@@ -208,8 +207,6 @@
 
     <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.5.1/jquery.slim.js" integrity="sha512-1lagjLfnC1I0iqH9plHYIUq3vDMfjhZsLy9elfK89RBcpcRcx4l+kRJBSnHh2Mh6kLxRHoObD1M5UTUbgFy6nA==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/bootstrap/4.6.2/js/bootstrap.bundle.min.js" integrity="sha512-igl8WEUuas9k5dtnhKqyyld6TzzRjvMqLC79jkgT3z02FvJyHAuUtyemm/P/jYSne1xwFI06ezQxEwweaiV7VA==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/datatables/1.10.20/js/jquery.dataTables.min.js" integrity="sha512-hX6rgGqXX6Ajh6Y+bZ+P/0ZkUBl3fQMY6I1B51h5NDOu7XE1lVgdf2VqygjozLX8AufHvWAzOuC0WVMb4wJX4w==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/datatables/1.10.20/js/dataTables.bootstrap4.min.js" integrity="sha512-T970v+zvIZu3UugrSpRoyYt0K0VknTDg2G0/hH7ZmeNjMAfymSRoY+CajxepI0k6VMFBXxgsBhk4W2r7NFg6ag==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
     {% block extra_js %}{% endblock %}
   </body>
 </html>

--- a/templates/codelists/index.html
+++ b/templates/codelists/index.html
@@ -2,30 +2,21 @@
 {% load markdown_filter %}
 
 {% block extra_styles %}
-<style>
-@media (max-width: 768px) {
-  .video-container {
-    margin: 0 1rem 1rem 1rem;
-    overflow: hidden;
-    position: relative;
-    width:100%;
-  }
-
-  .video-container::after {
-    content: '';
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/lite-youtube-embed/0.3.0/lite-yt-embed.min.css" integrity="sha512-F+q2wTRzuK17yqnrP7XZ2R1jvzJiVVUUZW9wqDIMhiZFlsP5TTvGZtPQbwS1v+ZUp3JR4CDK1Tai6Gvvh7c2Fg==" crossorigin="anonymous" referrerpolicy="no-referrer" />
+  <style>
+  .youtube-embed {
     display: block;
-    padding-top: 56.25%;
-  }
+    padding-block-end: 1rem;
 
-  .video-container iframe {
-    height: 100%;
-    left: 0;
-    position: absolute;
-    top: 0;
-    width: 100%;
+    &:not(:first-child) {
+      padding-block-start: 1rem;
+    }
+
+    lite-youtube {
+      margin: 0 auto;
+    }
   }
-}
-</style>
+  </style>
 {% endblock %}
 
 {% block content %}
@@ -41,11 +32,19 @@
   </div>
 
   <div class="row my-2">
-    <div class="col-md-6 video-container">
-      <iframe width="550px" height="300px" src="https://www.youtube.com/embed/ayRtpbcPFLA?list=PLE66rRIHuZxzSkFz8CthPQngqXIZiPlwq" title="YouTube video player" frameborder="0" allowfullscreen></iframe>
+    <div class="col-md-6">
+      <div class="youtube-embed">
+        <lite-youtube
+          videoid="ayRtpbcPFLA"
+          params="controls=1&rel=0&enablejsapi=1"
+        ></lite-youtube>
+      </div>
     </div>
-    <div class="col-md-6 video-container">
-      <iframe width="550px" height="300px" src="https://www.youtube.com/embed/t-A2kWHZ5lA?list=PLE66rRIHuZxzSkFz8CthPQngqXIZiPlwq" title="YouTube video player" frameborder="0" allowfullscreen></iframe>
+    <div class="col-md-6">
+      <lite-youtube
+        videoid="t-A2kWHZ5lA"
+        params="controls=1&rel=0&enablejsapi=1"
+      ></lite-youtube>
     </div>
   </div>
 
@@ -87,3 +86,7 @@
 
 </div>
 {% endblock %}
+
+{% block extra_js %}
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/lite-youtube-embed/0.3.0/lite-yt-embed.min.js" integrity="sha512-mnzNl5OgPbvEh4byaFsFh3bYSHnAvcgo4v+0yShBsFYcXps4E0p+8a1KHzgLajw50+kZEwZKuMFu8bhLZkiGlQ==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
+{% endblock extra_js %}

--- a/templates/codelists/version.html
+++ b/templates/codelists/version.html
@@ -4,6 +4,10 @@
 
 {% block title_extra %}: {{ codelist.name }}{% endblock %}
 
+{% block extra_styles %}
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/datatables/1.10.20/css/dataTables.bootstrap4.min.css" integrity="sha512-4o2NtfcBGIT0SbOTpWLYovl07cIaliKIQpUXvEPvyOgBF/01xY1TXm5F1B+X48/zhhFLIw2oBTsE0rjcwEOwJQ==" crossorigin="anonymous" referrerpolicy="no-referrer" />
+{% endblock extra_styles %}
+
 {% block content %}
 <h3 class="mt-4">{{ codelist.name }}</h3>
 {% if clv.is_under_review %}
@@ -253,6 +257,8 @@
 {% endblock %}
 
 {% block extra_js %}
+<script src="https://cdnjs.cloudflare.com/ajax/libs/datatables/1.10.20/js/jquery.dataTables.min.js" integrity="sha512-hX6rgGqXX6Ajh6Y+bZ+P/0ZkUBl3fQMY6I1B51h5NDOu7XE1lVgdf2VqygjozLX8AufHvWAzOuC0WVMb4wJX4w==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/datatables/1.10.20/js/dataTables.bootstrap4.min.js" integrity="sha512-T970v+zvIZu3UugrSpRoyYt0K0VknTDg2G0/hH7ZmeNjMAfymSRoY+CajxepI0k6VMFBXxgsBhk4W2r7NFg6ag==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
 <script type="text/javascript">
   $(document).ready(function () {
     $('#js-codelist-table').DataTable({


### PR DESCRIPTION
- Use lite-yt-embed to show home page videos 
- Replace cdn.datatables.net with cdnjs.cloudflare.com
- Move datatables assets to version template (the only place they are used)