### PR TITLE
Make django-debug-toolbar a development dependency

### DIFF
--- a/DEVELOPERS.md
+++ b/DEVELOPERS.md
@@ -82,7 +82,7 @@ See https://github.com/Schniz/fnm#installation.
 
 The development server can be run locally, as described below, or in [docker](#using-docker-for-development-and-tests).
 
-To use Django Debug Toolbar in development, set `DDT_ENABLED`.
+To use Django Debug Toolbar in development, set `DJANGO_DEBUG_TOOLBAR`.
 It is not enabled by default because it adds tens of seconds to the load time of some pages.
 
 #### Set up/update local dev environment

--- a/dotenv-sample
+++ b/dotenv-sample
@@ -2,7 +2,7 @@ IN_PRODUCTION=False
 DEBUG=True
 BASE_URLS=http://localhost:7000,http://127.0.0.1:7000
 SECRET_KEY=dummy-secret
-DDT_ENABLED=False
+DJANGO_DEBUG_TOOLBAR=False
 SENTRY_DSN=
 OTEL_EXPORTER_OTLP_ENDPOINT="https://api.honeycomb.io"
 OTEL_EXPORTER_OTLP_HEADERS="x-honeycomb-team=VALIDKEY1234,x-honeycomb-dataset=opencodelists"

--- a/opencodelists/settings.py
+++ b/opencodelists/settings.py
@@ -44,6 +44,8 @@ SECRET_KEY = env.str("SECRET_KEY")
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = env.bool("DEBUG", False)
 
+DEBUG_TOOLBAR = env.bool("DJANGO_DEBUG_TOOLBAR", default=False)
+
 BASE_URLS = env.list("BASE_URLS", [])
 # note localhost is required on production for dokku checks
 BASE_URLS += ["http://localhost:7000"]
@@ -83,7 +85,6 @@ INSTALLED_APPS = [
     "crispy_forms",
     "crispy_bootstrap4",
     "django_extensions",
-    "debug_toolbar",
     "rest_framework",
     "rest_framework.authtoken",
     "taggit",
@@ -107,14 +108,12 @@ MIDDLEWARE = [
     "django.contrib.auth.middleware.AuthenticationMiddleware",
     "django.contrib.messages.middleware.MessageMiddleware",
     "django.middleware.clickjacking.XFrameOptionsMiddleware",
-    "debug_toolbar.middleware.DebugToolbarMiddleware",
     "django_structlog.middlewares.RequestMiddleware",
 ]
 
-if not env.bool("DDT_ENABLED", False):
-    # Django Debug Toolbar adds 77s to the load time of a large codelist!
-    INSTALLED_APPS.remove("debug_toolbar")
-    MIDDLEWARE.remove("debug_toolbar.middleware.DebugToolbarMiddleware")
+if DEBUG_TOOLBAR:
+    INSTALLED_APPS.append("debug_toolbar")
+    MIDDLEWARE.append("debug_toolbar.middleware.DebugToolbarMiddleware")
 
 ROOT_URLCONF = "opencodelists.urls"
 

--- a/opencodelists/urls.py
+++ b/opencodelists/urls.py
@@ -1,4 +1,3 @@
-import debug_toolbar
 from django.conf import settings
 from django.contrib import admin
 from django.urls import include, path
@@ -26,6 +25,11 @@ organisations_patterns = [
     path("", views.organisations, name="organisations"),
 ]
 
+if settings.DEBUG_TOOLBAR:  # pragma: no cover
+    debug_toolbar_urls = [path("__debug__/", include("debug_toolbar.urls"))]
+else:
+    debug_toolbar_urls = []
+
 urlpatterns = [
     path("", include("codelists.urls")),
     path("api/v1/", include("codelists.api_urls")),
@@ -39,6 +43,6 @@ urlpatterns = [
     path("conversions/", include("conversions.urls")),
     path("coding-systems/", include("coding_systems.versioning.urls")),
     path("docs/", include("userdocs.urls")),
-    path("__debug__/", include(debug_toolbar.urls)),
+    *debug_toolbar_urls,
     path("robots.txt", RedirectView.as_view(url=settings.STATIC_URL + "robots.txt")),
 ]

--- a/requirements.dev.in
+++ b/requirements.dev.in
@@ -4,6 +4,8 @@
 # To generate a requirements file that includes both prod and dev requirements, run:
 # pip-compile --generate-hashes --output-file=requirements.dev.txt requirements.dev.in
 
+django-debug-toolbar
+
 # test
 hypothesis
 pytest-cov

--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -4,6 +4,12 @@
 #
 #    pip-compile --allow-unsafe --generate-hashes --output-file=requirements.dev.txt requirements.dev.in
 #
+asgiref==3.6.0 \
+    --hash=sha256:71e68008da809b957b7ee4b43dbccff33d1b23519fb8344e33f049897077afac \
+    --hash=sha256:9567dfe7bd8d3c8c892227827c41cce860b368104c3431da67a0c5a65a949506
+    # via
+    #   -c requirements.prod.txt
+    #   django
 attrs==23.2.0 \
     --hash=sha256:935dc3b529c262f6cf76e50877d35a4bd3c1de194fd41f47a2b7ae8f19971f30 \
     --hash=sha256:99b87a485a5820b23b879f04c2305b44b951b502fd64be915879d77a7e8fc6f1
@@ -327,6 +333,16 @@ distlib==0.3.8 \
     --hash=sha256:034db59a0b96f8ca18035f36290806a9a6e6bd9d1ff91e45a7f172eb17e51784 \
     --hash=sha256:1530ea13e350031b6312d8580ddb6b27a104275a31106523b8f123787f494f64
     # via virtualenv
+django==4.2.4 \
+    --hash=sha256:7e4225ec065e0f354ccf7349a22d209de09cc1c074832be9eb84c51c1799c432 \
+    --hash=sha256:860ae6a138a238fc4f22c99b52f3ead982bb4b1aad8c0122bcd8c8a3a02e409d
+    # via
+    #   -c requirements.prod.txt
+    #   django-debug-toolbar
+django-debug-toolbar==4.3.0 \
+    --hash=sha256:0b0dddee5ea29b9cb678593bc0d7a6d76b21d7799cb68e091a2148341a80f3c4 \
+    --hash=sha256:e09b7dcb8417b743234dfc57c95a7c1d1d87a88844abd13b4c5387f807b31bf6
+    # via -r requirements.dev.in
 filelock==3.13.4 \
     --hash=sha256:404e5e9253aa60ad457cae1be07c0f0ca90a63931200a47d9b6a6af84fd7b45f \
     --hash=sha256:d13f466618bfde72bd2c18255e269f72542c6e70e7bac83a0232d6b1cc5c8cf4
@@ -627,6 +643,8 @@ sqlparse==0.4.4 \
     --hash=sha256:d446183e84b8349fa3061f0fe7f06ca94ba65b426946ffebe6e3e8295332420c
     # via
     #   -c requirements.prod.txt
+    #   django
+    #   django-debug-toolbar
     #   litecli
 tabulate[widechars]==0.9.0 \
     --hash=sha256:0095b12bf5966de529c0feb1fa08671671b3368eec77d7ef7ab114be2c068b3c \

--- a/requirements.prod.in
+++ b/requirements.prod.in
@@ -11,7 +11,6 @@ djangorestframework
 django-anymail[mailgun]
 django-crispy-forms
 django-cors-headers
-django-debug-toolbar
 django-extensions
 django-structlog
 django-taggit

--- a/requirements.prod.txt
+++ b/requirements.prod.txt
@@ -225,7 +225,6 @@ django==4.2.4 \
     #   django-anymail
     #   django-cors-headers
     #   django-crispy-forms
-    #   django-debug-toolbar
     #   django-extensions
     #   django-structlog
     #   django-taggit
@@ -249,10 +248,6 @@ django-crispy-forms==2.1 \
     # via
     #   -r requirements.prod.in
     #   crispy-bootstrap4
-django-debug-toolbar==4.2.0 \
-    --hash=sha256:af99128c06e8e794479e65ab62cc6c7d1e74e1c19beb44dcbf9bad7a9c017327 \
-    --hash=sha256:bc7fdaafafcdedefcc67a4a5ad9dac96efd6e41db15bc74d402a54a2ba4854dc
-    # via -r requirements.prod.in
 django-extensions==3.2.3 \
     --hash=sha256:44d27919d04e23b3f40231c4ab7af4e61ce832ef46d610cc650d53e68328410a \
     --hash=sha256:9600b7562f79a92cbf1fde6403c04fee314608fefbb595502e34383ae8203401
@@ -613,9 +608,7 @@ sqlean-py==3.45.1 \
 sqlparse==0.4.4 \
     --hash=sha256:5430a4fe2ac7d0f93e66f1efc6e1338a41884b7ddf2a350cedd20ccc4d9d28f3 \
     --hash=sha256:d446183e84b8349fa3061f0fe7f06ca94ba65b426946ffebe6e3e8295332420c
-    # via
-    #   django
-    #   django-debug-toolbar
+    # via django
 structlog==24.1.0 \
     --hash=sha256:3f6efe7d25fab6e86f277713c218044669906537bb717c1807a09d46bca0714d \
     --hash=sha256:41a09886e4d55df25bdcb9b5c9674bccfab723ff43e0a86a1b7b236be8e57b16


### PR DESCRIPTION
and rename `DDT_ENABLED` environment variable to `DJANGO_DEBUG_TOOLBAR`, matching our other Django projects.

Closes #2023