### PR TITLE
Automate downloading of bnf dmd mappings

### DIFF
--- a/coding_systems/dmd/tests/test_import_latest_dmd_data.py
+++ b/coding_systems/dmd/tests/test_import_latest_dmd_data.py
@@ -43,6 +43,6 @@ def test_calls_import_release_function_coding_system_release_already_exists(
     assert error.value.code == 1
     captured = capsys.readouterr()
     assert (
-        "A dmd coding system release already exists for the latest release (1.0.0) "
+        "A coding_systems.dmd coding system release already exists for the latest release (1.0.0) "
         "and valid from date (2022-10-01)." in captured.out
     )

--- a/deploy/bin/import_latest_bnfdmd_cronfile
+++ b/deploy/bin/import_latest_bnfdmd_cronfile
@@ -1,0 +1,10 @@
+# /etc/cron.d/dokku-opencodelists-import-latest-bnfdmd
+# cron job to import latest bnf to dm+d mapping release
+# update SLACK_WEBHOOK_URL and SLACK_TEAM_WEBHOOK_URL with relevant channel url
+
+PATH=/usr/local/bin:/usr/bin:/bin
+SHELL=/bin/bash
+SLACK_WEBHOOK_URL=dummy-url
+SLACK_TEAM_WEBHOOK_URL=dummy-url
+
+5 23 * * 5 dokku /var/lib/dokku/data/storage/opencodelists/import_latest_release.sh mappings.bnfdmd

--- a/mappings/bnfdmd/data_downloader.py
+++ b/mappings/bnfdmd/data_downloader.py
@@ -1,0 +1,130 @@
+import glob
+import os
+import re
+from datetime import datetime
+from pathlib import Path
+from urllib.parse import unquote, urljoin, urlparse
+
+import requests
+import structlog
+from bs4 import BeautifulSoup
+
+
+logger = structlog.get_logger()
+
+
+# modelled after coding_systems/base/trud_utils.py::TrudDownloader @ 979d995
+
+
+class Downloader:
+    def __init__(self, release_dir):
+        self.url = "https://www.nhsbsa.nhs.uk/prescription-data/understanding-our-data/bnf-snomed-mapping"
+        self.release_dir = release_dir
+
+    def get_releases(self):
+        # adapted from OpenPrescribing:
+        # https://github.com/ebmdatalab/openprescribing/blob/main/openprescribing/dmd/management/commands/fetch_bnf_snomed_mapping.py
+        filename_re = re.compile(
+            r"^BNF Snomed Mapping data (?P<date>20\d{6})\.zip$", re.IGNORECASE
+        )
+        datepat = re.compile(r"\w+ \d{4}")
+        datefmt = "%B %Y"
+
+        rsp = requests.get(self.url)
+        rsp.raise_for_status()
+        doc = BeautifulSoup(rsp.text, "html.parser")
+
+        matches = []
+        for a_tag in doc.find_all("a", href=True):
+            if a_tag.text.startswith("\xa0"):
+                continue
+            url = urljoin(self.url, a_tag["href"])
+            filename = Path(unquote(urlparse(url).path)).name
+            match = filename_re.match(filename)
+            if match:
+                inner_text = a_tag.text
+                while not (
+                    valid_from := datepat.search(inner_text.replace("\xa0", " "))
+                ):
+                    # sometimes "valid from" inner text is across adjacent elements
+                    inner_text += a_tag.next_sibling()[0].text
+                valid_from = datetime.strptime(valid_from.group(), datefmt)
+                matches.append((match.group("date"), url, filename, valid_from))
+
+        if not matches:
+            raise RuntimeError(f"Found no URLs matching {filename_re} at {self.url}")
+
+        # Sort by release date and get the latest
+        matches.sort()
+
+        return matches
+
+    def get_latest_release(self):
+        return self.get_releases()[-1]
+
+    def get_release_metadata(self, release):
+        datestamp, url, filename, valid_from = release
+
+        return {
+            "release": datestamp,
+            "valid_from": valid_from,
+            "url": url,
+            "filename": filename,
+            "release_name": datestamp,
+        }
+
+    def get_latest_release_metadata(self):
+        latest = self.get_latest_release()
+        return self.get_release_metadata(latest)
+
+    def download_release(self, release_name, valid_from):
+        """
+        Download a release that matches the specified release_name and valid_from values
+        """
+        logger.info(
+            "Attempting to download release from NHS BSA",
+            release=release_name,
+            valid_from=valid_from,
+        )
+
+        releases = self.get_releases()
+        release_metadata = (self.get_release_metadata(release) for release in releases)
+
+        match_found = False
+        for metadata in release_metadata:
+            if (
+                metadata.get("release_name") == release_name
+                and metadata.get("valid_from") == valid_from
+            ):
+                match_found = True
+                break
+
+        if not match_found:
+            raise ValueError(
+                f"No matching release found for release {release_name}, valid from {valid_from}"
+            )
+
+        local_download_filepath = Path(self.release_dir) / metadata["filename"]
+        self.get_file(metadata["url"], local_download_filepath)
+
+        return local_download_filepath
+
+    def get_file(self, url, filepath):
+        logger.info("Starting download", download_filepath=filepath)
+        with requests.get(url, stream=True) as resp:
+            resp.raise_for_status()
+            with open(filepath, "wb") as f:
+                for chunk in resp.iter_content(chunk_size=8192):
+                    f.write(chunk)
+        logger.info("Download complete", download_filepath=filepath)
+
+    def download_latest_release(self):
+        metadata = self.get_latest_release_metadata()
+
+        if glob.glob(os.path.join(self.release_dir, metadata["filename"])):
+            return
+
+        local_download_filepath = Path(self.release_dir) / metadata["filename"]
+        self.get_file(metadata["url"], local_download_filepath)
+
+        return local_download_filepath, metadata

--- a/mappings/bnfdmd/import_data.py
+++ b/mappings/bnfdmd/import_data.py
@@ -1,7 +1,15 @@
+import os
+from tempfile import TemporaryDirectory
+from zipfile import ZipFile
+
+import structlog
 from django.db import transaction
 from openpyxl import load_workbook
 
 from .models import Mapping
+
+
+logger = structlog.get_logger()
 
 
 def import_data(filename):
@@ -35,3 +43,11 @@ def import_data(filename):
             Mapping(dmd_code=r[0], dmd_type=r[1], bnf_concept_id=r[2])
             for r in load_records()
         )
+
+
+def import_release(release_zipfile):
+    with TemporaryDirectory() as tempdir:
+        release_zip = ZipFile(str(release_zipfile))
+        logger.info("Extracting", release_zip=release_zip.filename)
+        release_zip.extractall(path=tempdir)
+        import_data(os.path.join(tempdir, release_zipfile.replace(".zip", ".xlsx")))

--- a/mappings/bnfdmd/tests/conftest.py
+++ b/mappings/bnfdmd/tests/conftest.py
@@ -1,0 +1,33 @@
+from unittest.mock import patch
+
+import pytest
+import responses
+
+
+def add_response(rsps, filename, release_date):
+    rsps.add(
+        responses.GET,
+        "https://www.nhsbsa.nhs.uk/prescription-data/understanding-our-data/bnf-snomed-mapping",
+        body=f"""
+            <p><a href="/sites/default/files/{release_date}/{filename.replace(' ','%20')}">January 2024 (ZIP file: 16.76MB)</a></p>
+            <p><a href="/sites/default/files/2023-01/BNF%20Snomed%20Mapping%20data%2020230116.zip">January 2023 (ZIP file: 16.76MB)</a></p>
+        """,
+        status=200,
+    )
+
+
+@pytest.fixture
+def mocked_responses():
+    with responses.RequestsMock() as rsps:
+        yield rsps
+
+
+@pytest.fixture
+def mock_data_download(mocked_responses):
+    filename = "BNF%20Snomed%20Mapping%20data%2020240101.zip"
+    add_response(mocked_responses, filename, "2024-01")
+    with patch(
+        "mappings.bnfdmd.data_downloader.Downloader.get_file",
+        return_value=filename,
+    ):
+        yield

--- a/mappings/bnfdmd/tests/test_import_latest_data.py
+++ b/mappings/bnfdmd/tests/test_import_latest_data.py
@@ -1,0 +1,22 @@
+import datetime
+from pathlib import Path
+from unittest.mock import patch
+
+from django.core.management import call_command
+
+
+@patch("mappings.bnfdmd.import_data.import_release")
+def test_calls_import_release_function_with_extracted_release_metadata(
+    mock_import_release, tmpdir, mock_data_download
+):
+    call_command(
+        "import_latest_data",
+        "mappings.bnfdmd",
+        tmpdir,
+    )
+    mock_import_release.assert_called_once()
+    mock_import_release.assert_called_with(
+        Path(tmpdir) / "BNF Snomed Mapping data 20240101.zip",
+        "20240101",
+        datetime.datetime(2024, 1, 1, 0, 0),
+    )

--- a/opencodelists/management/commands/import_latest_data.py
+++ b/opencodelists/management/commands/import_latest_data.py
@@ -8,19 +8,21 @@ class Command(BaseCommand):
     def add_arguments(self, parser):
         parser.add_argument(
             "coding_system_id",
-            help="Coding system to import",
-            choices=["dmd", "snomedct"],
+            help="Coding system or mappings to import",
+            choices=["dmd", "snomedct", "mappings.bnfdmd"],
         )
         parser.add_argument(
             "release_dir", help="Path to local release directory to download raw data"
         )
 
     def handle(self, coding_system_id, release_dir, **kwargs):
-        downloader_module_path = f"coding_systems.{coding_system_id}.data_downloader"
+        if "." not in coding_system_id:
+            coding_system_id = "coding_systems." + coding_system_id
+        downloader_module_path = f"{coding_system_id}.data_downloader"
         downloader_module = import_module(downloader_module_path)
         downloader_cls = downloader_module.Downloader
 
-        import_module_path = f"coding_systems.{coding_system_id}.import_data"
+        import_module_path = f"{coding_system_id}.import_data"
         importer_module = import_module(import_module_path)
         import_fn = importer_module.import_release
 

--- a/requirements.prod.in
+++ b/requirements.prod.in
@@ -4,6 +4,7 @@
 # pip-compile --generate-hashes --output-file=requirements.prod.txt requirements.prod.in
 
 antlr4-python3-runtime
+beautifulsoup4
 bleach
 crispy-bootstrap4
 django

--- a/requirements.prod.txt
+++ b/requirements.prod.txt
@@ -21,6 +21,10 @@ backoff==2.2.1 \
     # via
     #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
+beautifulsoup4==4.12.3 \
+    --hash=sha256:74e3d1928edc070d21748185c46e3fb33490f22f52a3addee9aee0f4f7781051 \
+    --hash=sha256:b80878c9f40111313e55da8ba20bdba06d8fa3969fc68304167741bbf9e082ed
+    # via -r requirements.prod.in
 bleach==6.2.0 \
     --hash=sha256:117d9c6097a7c3d22fd578fcd8d35ff1e125df6736f554da4e432fdd63f31e5e \
     --hash=sha256:123e894118b8a599fd80d3ec1a6d4cc7ce4e5882b1317a7e1ba69b56e95f991f
@@ -618,6 +622,10 @@ six==1.16.0 \
     # via
     #   furl
     #   orderedmultidict
+soupsieve==2.6 \
+    --hash=sha256:e2e68417777af359ec65daac1057404a3c8a5455bb8abc36f1a9866ab1a51abb \
+    --hash=sha256:e72c4ff06e4fb6e4b5a9f0f55fe6e81514581fca1515028625d0f299c602ccc9
+    # via beautifulsoup4
 sqlean-py==3.47.0 \
     --hash=sha256:10439eb85bdcae30227b6a73fe05c354820fa073e6fdd2eda46f8fa805de313b \
     --hash=sha256:14f9e9616023e29b3248805bab3d8248d905d4e0bb779aeea211a55b2df87652 \
@@ -771,9 +779,9 @@ zipp==3.15.0 \
     # via importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:
-setuptools==70.3.0 \
-    --hash=sha256:f171bab1dfbc86b132997f26a119f6056a57950d058587841a0082e8830f9dc5 \
-    --hash=sha256:fe384da74336c398e0d956d1cae0669bc02eed936cdb1d49b57de1990dc11ffc
+setuptools==75.6.0 \
+    --hash=sha256:8199222558df7c86216af4f84c30e9b34a61d8ba19366cc914424cdbd28252f6 \
+    --hash=sha256:ce74b49e8f7110f9bf04883b730f4765b774ef3ef28f722cce7c273d253aaf7d
     # via
     #   opentelemetry-api
     #   opentelemetry-instrumentation


### PR DESCRIPTION
This PR largely makes use of pre-existing mechanisms to automatically download and load the BNF to dm+d mappings from the NHSBSA website.

The structure of the downloader largely mirrors that of those for the dm+d and SNOMED CT downloaders, as does the means of calling it and the scheduling of this call.

The web scraping code is mostly taken from OpenPrescribing with a couple of additions to parse the "valid from" date and to conform to the above described downloader pattern.

Some of this functionality (parsing of extra metadata and the ability to download multiple/specific releases of the mapping other than the latest) is not yet used, and so arguably could be removed until such time as we start showing the mapping metadata to users in the frontend and/or storing multiple versions of the mapping as per the coding systems.

Fixes #2099 