### PR TITLE
Add updated date to codelist version template

### DIFF
--- a/assets/src/styles/base.css
+++ b/assets/src/styles/base.css
@@ -73,3 +73,12 @@ a:focus {
     margin: 0 auto;
   }
 }
+
+.sidebar-versions code {
+  font-size: 1.1rem;
+}
+
+.sidebar-versions .updated {
+  border-top: 1px dotted #ddd;
+  font-size: 0.9rem;
+}

--- a/templates/codelists/version.html
+++ b/templates/codelists/version.html
@@ -197,24 +197,43 @@
 
     <hr />
 
-    <h6>Versions</h6>
-    <ul class="pl-3">
-      {% for version in versions %}
-      <li>
-        {% if version == clv %}
-        {{ version.tag_or_hash }}
-        {% else %}
-        <a href="{{ version.get_absolute_url }}">{{ version.tag_or_hash }}</a>
-        {% endif %}
-        {% if version.is_under_review %}
-        <span class="badge badge-primary">Review</span>
-        {% elif version.is_draft %}
-        <span class="badge badge-primary">Draft</span>
-        {% endif %}
-        <span>(updated {{ version.updated_at | date:'Y-m-d H:i:s' }})</span>
-      </li>
-      {% endfor %}
-    </ul>
+    <div class="card">
+      <div class="card-header px-2 py-3">
+        <h2 class="h5 mb-0">Versions</h2>
+      </div>
+      <ul class="list-group list-group-flush sidebar-versions">
+        {% for version in versions %}
+          <li class="list-group-item px-2 py-3">
+            {% if version.is_under_review %}
+              <span class="badge badge-primary">Review</span>
+            {% elif version.is_draft %}
+              <span class="badge badge-primary">Draft</span>
+            {% endif %}
+
+            <span class="d-block pb-1">
+              <code class="font-weight-bold text-body">
+                {% if version == clv %}
+                  {{ version.tag_or_hash }}
+                {% else %}
+                  <a class="text-monospace" href="{{ version.get_absolute_url }}">
+                    {{ version.tag_or_hash }}
+                  </a>
+                {% endif %}
+              </code>
+            </span>
+
+            <span class="updated d-block pt-1">
+              <span>
+                Updated:
+              </span>
+              <span class="d-block">
+                {{ version.updated_at | date:'Y-m-d H:i:s' }}
+              </span>
+            </span>
+          </li>
+        {% endfor %}
+      </ul>
+    </div>
   </div>
 
   <div class="col-md-9 col-lg-10">

--- a/templates/codelists/version.html
+++ b/templates/codelists/version.html
@@ -211,6 +211,7 @@
         {% elif version.is_draft %}
         <span class="badge badge-primary">Draft</span>
         {% endif %}
+        <span>(updated {{ version.updated_at | date:'Y-m-d H:i:s' }})</span>
       </li>
       {% endfor %}
     </ul>


### PR DESCRIPTION
Fixes #2106 

The codelist versions are rendered in date creation order, but this is not always obvious to users.
Even then, we do not surface the creation of modification date anywhere.

For a user, trying to find a version of a codelist at a particular point in time, this change provides the neccesary information.


![image](https://github.com/user-attachments/assets/a07736c1-7369-4260-933d-a3ab2fba1b22)
