### PR TITLE
Allow `ALLOWED_HOSTS` to match any host

### DIFF
--- a/opencodelists/settings.py
+++ b/opencodelists/settings.py
@@ -18,7 +18,6 @@ from pathlib import Path
 import sentry_sdk
 from django.contrib.messages import constants as messages
 from environs import Env
-from furl import furl
 from sentry_sdk.integrations.django import DjangoIntegration
 from sentry_sdk.integrations.logging import ignore_logger
 
@@ -47,10 +46,8 @@ DEBUG = env.bool("DEBUG", False)
 DEBUG_TOOLBAR = env.bool("DJANGO_DEBUG_TOOLBAR", default=False)
 
 BASE_URLS = env.list("BASE_URLS", [])
-# note localhost is required on production for dokku checks
-BASE_URLS += ["http://localhost:7000"]
 
-ALLOWED_HOSTS = [furl(base_url).host for base_url in BASE_URLS]
+ALLOWED_HOSTS = ["*"]
 
 IN_PRODUCTION = env.bool("IN_PRODUCTION", False)
 


### PR DESCRIPTION
The app needs to accept incoming connections from an internal IP address to run the health checks given by `app.json`. However, this internal IP address could change. Dokku-provided nginx decides which incoming connections make it to the app,[^1][^2] so we rely on it (rather than on Django) for host header validation.

For more information, see the equivalent commit in job-server ([2b30ddc09][]), Django's "[ALLOWED_HOSTS][]" documentation, and Dokku's "[Nginx Proxy][]" documentation.

This PR is required by #2129, which was reverted by #2139. After we merge it, we should either cherry-pick from the former or revert the latter.

[^1]: To see the configuration, run `dokku nginx:show-config opencodelists`.
[^2]: https://bennettoxford.slack.com/archives/C069SADHP1Q/p1731673151406709?thread_ts=1731669625.535539&cid=C069SADHP1Q

[2b30ddc09]: https://github.com/opensafely-core/job-server/commit/2b30ddc09
[ALLOWED_HOSTS]: https://docs.djangoproject.com/en/5.1/ref/settings/#allowed-hosts
[Nginx Proxy]: https://dokku.com/docs/networking/proxies/nginx/