### PR TITLE
Fix heading structure on the Codelist page

### DIFF
--- a/templates/codelists/_about_tab.html
+++ b/templates/codelists/_about_tab.html
@@ -1,18 +1,19 @@
 {% load markdown_filter %}
 
 <div class="tab-about h-100 d-flex flex-column">
+  <h2 class="sr-only">About</h2>
   {% if codelist.description %}
-  <h4>Description</h4>
+  <h3 class="h4">Description</h3>
   <p>{{ codelist.description|markdown_filter|safe }}</p>
   {% endif %}
 
   {% if codelist.methodology %}
-  <h4>Methodology</h4>
+  <h3 class="h4">Methodology</h3>
   <p>{{ codelist.methodology|markdown_filter|safe }}</p>
   {% endif %}
 
   {% if references %}
-  <h4>References</h4>
+  <h3 class="h4">References</h3>
   <ul>
     {% for reference in references %}
     <li><a href="{{ reference.url }}">{{ reference.text }}</a></li>
@@ -23,7 +24,7 @@
   {% endif %}
 
   {% if signoffs %}
-  <h4>Signed off by</h4>
+  <h3 class="h4">Signed off by</h3>
   <ul>
     {% for signoff in signoffs %}
     <li>

--- a/templates/codelists/version.html
+++ b/templates/codelists/version.html
@@ -5,7 +5,7 @@
 {% block title_extra %}: {{ codelist.name }}{% endblock %}
 
 {% block content %}
-<h3 class="mt-4">{{ codelist.name }}</h3>
+<h1 class="h3 mt-4">{{ codelist.name }}</h1>
 {% if clv.is_under_review %}
 <p class="text-muted">This version is under review</p>
 {% endif %}
@@ -81,12 +81,17 @@
 
     <hr />
 
+    <h2 class="sr-only">Codelist metadata</h2>
     <dl>
-      <dt>Coding system</dt>
-      <dd>{{ clv.coding_system.name }}</dd>
+      <dt>
+        <h3 class="h6 font-weight-bold mb-1">Coding system</h3>
+      </dt>
+      <dd class="pb-2 border-bottom">{{ clv.coding_system.name }}</dd>
 
-      <dt>Coding system release</dt>
-      <dd>{{ clv.coding_system.release_name }}</dd>
+      <dt>
+        <h3 class="h6 font-weight-bold">Coding system release</h3>
+      </dt>
+      <dd class="pb-2 border-bottom">{{ clv.coding_system.release_name }}</dd>
 
       {% if clv.compatible_releases.exists %}
         <details>
@@ -100,25 +105,31 @@
       {% endif %}
 
       {% if codelist.organisation %}
-      <dt>Organisation</dt>
-      <dd>{{ codelist.organisation.name }}</dd>
+      <dt>
+        <h3 class="h6 font-weight-bold">Organisation</h3>
+      </dt>
+      <dd class="pb-2 border-bottom">{{ codelist.organisation.name }}</dd>
       {% endif %}
 
-      <dt>Codelist ID</dt>
-      <dd class="text-break">{{ codelist.full_slug }}</dd>
+      <dt>
+        <h3 class="h6 font-weight-bold">Codelist ID</h3>
+      </dt>
+      <dd class="text-break pb-2 border-bottom">{{ codelist.full_slug }}</dd>
 
       {% if clv.tag %}
-      <dt>Version Tag</dt>
-      <dd>{{ clv.tag }}</dd>
+      <dt>
+        <h3 class="h6 font-weight-bold">Version Tag</h3>
+      </dt>
+      <dd class="pb-2 border-bottom">{{ clv.tag }}</dd>
       {% endif %}
 
-      <dt>Version ID</dt>
-      <dd>{{ clv.hash }}</dd>
+      <dt>
+        <h3 class="h6 font-weight-bold">Version ID</h3>
+      </dt>
+      <dd class="pb-2 border-bottom">{{ clv.hash }}</dd>
     </dl>
 
     {% if user_can_edit %}
-      <hr />
-
       <div class="btn-group-vertical btn-block" role="group">
         <a
           class="btn btn-outline-primary btn-block"

--- a/templates/codelists/version.html
+++ b/templates/codelists/version.html
@@ -23,11 +23,11 @@
               role="button"
               class="btn btn-outline-primary btn-block"
             >
-              Download CSV (with mapped VMPs)*
+              Download CSV <small class="d-block">with mapped VMPs*</small>
             </a>
           {% else %}
             <div class="btn btn-outline-primary btn-block disabled">
-              Download CSV (with mapped VMPs)*
+              Download CSV <small class="d-block">with mapped VMPs*</small>
             </div>
           {% endif %}
         {% else %}
@@ -45,7 +45,7 @@
         role="button"
         class="btn btn-outline-primary btn-block"
       >
-        Download CSV (original)
+        Download CSV <small class="d-block">original</small>
       </a>
       {% endif %}
       {% if clv.codeset %}


### PR DESCRIPTION
The current heading structure does not correctly reflect the content on the page, and misses multiple headings.

This PR makes sure that top-level headings are used on the page, and on the "About" tab.

## Before

![](https://github.com/user-attachments/assets/1cc892cd-c945-4262-891c-59c4f296779d)

## After
![](https://github.com/user-attachments/assets/db47ae0f-6fda-4804-acf0-171e3d24031b)
