### PR TITLE
Upgrade `whitenoise` from 6.5.0 to 6.8.2

### DIFF
--- a/requirements.prod.in
+++ b/requirements.prod.in
@@ -24,7 +24,9 @@ openpyxl
 opentelemetry-exporter-otlp
 opentelemetry-instrumentation-django
 opentelemetry-sdk
-whitenoise
+# Serves static files. Dependabot wasn't updating past 6.3.0 for
+# unclear reasons, and we want fix #612 from 6.8.0.
+whitenoise>=6.8.0
 sentry-sdk
 sqlean.py
 structlog

--- a/requirements.prod.txt
+++ b/requirements.prod.txt
@@ -636,9 +636,9 @@ webencodings==0.5.1 \
     --hash=sha256:a0af1213f3c2226497a97e2b3aa01a7e4bee4f403f95be16fc9acd2947514a78 \
     --hash=sha256:b36a1c245f2d304965eb4e0a82848379241dc04b865afcc4aab16748587e1923
     # via bleach
-whitenoise==6.5.0 \
-    --hash=sha256:15fe60546ac975b58e357ccaeb165a4ca2d0ab697e48450b8f0307ca368195a8 \
-    --hash=sha256:16468e9ad2189f09f4a8c635a9031cc9bb2cdbc8e5e53365407acf99f7ade9ec
+whitenoise==6.8.2 \
+    --hash=sha256:486bd7267a375fa9650b136daaec156ac572971acc8bf99add90817a530dd1d4 \
+    --hash=sha256:df12dce147a043d1956d81d288c6f0044147c6d2ab9726e5772ac50fb45d2280
     # via -r requirements.prod.in
 wrapt==1.15.0 \
     --hash=sha256:02fce1852f755f44f95af51f69d22e45080102e9d00258053b79367d07af39c0 \


### PR DESCRIPTION
We suspect whitenoise PR #612 may resolve an issue with the database connection intermittently and randomly closing during requests observed in production.

For some reason, Dependabot did not automatically make this upgrade, but it appears to work without issue in local testing.

See [Job Server #4742](https://github.com/opensafely-core/job-server/pull/4742) for info on investigation done.