### PR TITLE
Move the web health check to `app.json`

### DIFF
--- a/CHECKS
+++ b/CHECKS
@@ -1,6 +1,0 @@
-# Wait for 30 seconds to allow time for migrations, if necessary
-WAIT=30
-TIMEOUT=60
-ATTEMPTS=10
-
-http://localhost

--- a/app.json
+++ b/app.json
@@ -4,5 +4,25 @@
             "command": "/app/deploy/bin/backup.sh",
             "schedule": "00 01 * * *"
         }
-    ]
+    ],
+    "healthchecks": {
+        "web": [
+            {
+                "attempts": 10,
+                "description": "Check the root URL is available",
+                "httpHeaders": [
+                    {
+                        "name": "Host",
+                        "value": "localhost"
+                    }
+                ],
+                "initialDelay": 30,
+                "name": "Web health check",
+                "path": "/",
+                "port": 7000,
+                "timeout": 60,
+                "type": "startup"
+            }
+        ]
+    }
 }

--- a/app.json
+++ b/app.json
@@ -1,8 +1,8 @@
 {
     "cron": [
-      {
-        "command": "/app/deploy/bin/backup.sh",
-        "schedule": "00 01 * * *"
-      }
+        {
+            "command": "/app/deploy/bin/backup.sh",
+            "schedule": "00 01 * * *"
+        }
     ]
-  }
+}


### PR DESCRIPTION
Mostly, we port the web health check from `CHECKS` to `app.json`. We set the `Host` header to prevent Django from raising a `DisallowedHost` error.

Why would Django raise this error? The web health check is performed by invoking `curl` from the Dokku host; an internal IP is passed as the URL,[^1] which means that Cloudflare DNS and nginx are bypassed. The `ALLOWED_HOSTS` setting limits the hosts that Django will serve,[^2] but we don't know the internal IP in advance, so we can't add it to the `ALLOWED_HOSTS` setting. Consequently, we set the `Host` header.

Closes #1868

---

I think we can test these changes with the following, removing the need for a second (dummy) deployment.

```
dokku checks:run opencodelists
```

[^1]: https://dokku.com/docs/deployment/zero-downtime-deploys/
[^2]: https://docs.djangoproject.com/en/5.1/ref/settings/#allowed-hosts