### PR TITLE
Remove use of `subprocess` in test

### DIFF
--- a/opencodelists/management/commands/import_coding_system_data.py
+++ b/opencodelists/management/commands/import_coding_system_data.py
@@ -9,7 +9,7 @@ from codelists.coding_systems import CODING_SYSTEMS
 from coding_systems.versioning.models import CodingSystemRelease
 
 
-def valid_from(input_date):
+def date_yymmdd(input_date):
     try:
         return datetime.strptime(input_date, "%Y-%m-%d").date()
     except ValueError:
@@ -42,7 +42,7 @@ class Command(BaseCommand):
         )
         parser.add_argument(
             "--valid-from",
-            type=valid_from,
+            type=date_yymmdd,
             help="For coding system imports: date the release is valid from, in YYYY-MM-DD format",
             required=True,
         )

--- a/opencodelists/tests/test_import_coding_system_data.py
+++ b/opencodelists/tests/test_import_coding_system_data.py
@@ -1,4 +1,3 @@
-import subprocess
 from datetime import date
 from unittest.mock import patch
 
@@ -91,30 +90,20 @@ def test_calls_import_data_function_coding_system_force_overwrite(
 
 
 @pytest.mark.parametrize(
-    "input_date,returncode,error",
+    "input_date,error",
     [
-        ("2020-1", 2, "Not a valid date (YYYY-MM-DD): 2020-1"),
-        ("20201101", 2, "Not a valid date (YYYY-MM-DD): 20201101"),
-        ("Nov", 2, "Not a valid date (YYYY-MM-DD): Nov"),
-        (("20200231", 2, "Not a valid date (YYYY-MM-DD): 20200231")),
+        ("2020-1", "Not a valid date \\(YYYY-MM-DD\\): 2020-1"),
+        ("20201101", "Not a valid date \\(YYYY-MM-DD\\): 20201101"),
+        ("Nov", "Not a valid date \\(YYYY-MM-DD\\): Nov"),
+        (("20200231", "Not a valid date \\(YYYY-MM-DD\\): 20200231")),
     ],
 )
-def test_valid_from_validation(capfd, input_date, returncode, error):
-    ret = subprocess.run(
-        [
-            "python",
-            "manage.py",
+def test_valid_from_validation(input_date, error):
+    with pytest.raises(CommandError, match=error):
+        call_command(
             "import_coding_system_data",
             "snomedct",
             "/tmp",
-            "--release",
-            "v1",
-            "--valid-from",
-            input_date,
-        ],
-        check=False,
-    )
-    assert ret.returncode == returncode
-    cap = capfd.readouterr()
-    assert error in cap.err
-    assert cap.out == ""
+            release_name="v1",
+            valid_from=input_date,
+        )

--- a/opencodelists/tests/test_import_coding_system_data.py
+++ b/opencodelists/tests/test_import_coding_system_data.py
@@ -99,6 +99,10 @@ def test_calls_import_data_function_coding_system_force_overwrite(
     ],
 )
 def test_valid_from_validation(input_date, error_regex):
+    """Test that an exception is raised when an invalid date is passed as the
+    valid_from arg.
+
+    Successful parsing of valid_from dates covered by other tests."""
     with pytest.raises(CommandError, match=error_regex):
         call_command(
             "import_coding_system_data",

--- a/opencodelists/tests/test_import_coding_system_data.py
+++ b/opencodelists/tests/test_import_coding_system_data.py
@@ -90,7 +90,7 @@ def test_calls_import_data_function_coding_system_force_overwrite(
 
 
 @pytest.mark.parametrize(
-    "input_date,error",
+    "input_date,error_regex",
     [
         ("2020-1", "Not a valid date \\(YYYY-MM-DD\\): 2020-1"),
         ("20201101", "Not a valid date \\(YYYY-MM-DD\\): 20201101"),
@@ -98,8 +98,8 @@ def test_calls_import_data_function_coding_system_force_overwrite(
         (("20200231", "Not a valid date \\(YYYY-MM-DD\\): 20200231")),
     ],
 )
-def test_valid_from_validation(input_date, error):
-    with pytest.raises(CommandError, match=error):
+def test_valid_from_validation(input_date, error_regex):
+    with pytest.raises(CommandError, match=error_regex):
         call_command(
             "import_coding_system_data",
             "snomedct",


### PR DESCRIPTION
Using `call_command` is better than `subprocess` because it’s simpler, faster, more readable, and doesn’t rely on `python` being available. In most cases, test cases should not use `subprocess` unless testing integration with external tools or the shell.  This change aligns the test with the rest of the module and codebase.

Also made some minor readability tweaks.