### PR TITLE
Improve the layout of the auth forms

### DIFF
--- a/assets/src/styles/base.css
+++ b/assets/src/styles/base.css
@@ -72,3 +72,17 @@ a:focus {
   border-top: 1px dotted #ddd;
   font-size: 0.9rem;
 }
+
+.auth-form {
+  margin-bottom: 2rem;
+  max-width: 30rem;
+
+  & label {
+    font-weight: bold;
+  }
+
+  & .asteriskField {
+    color: red;
+    margin-left: 0.25rem;
+  }
+}

--- a/templates/registration/login.html
+++ b/templates/registration/login.html
@@ -2,14 +2,17 @@
 
 {% load crispy_forms_tags %}
 
-{% block content %}
+{% block title_extra %}: Sign in{% endblock %}
 
+{% block content %}
 <div class="mt-3">
+    <h1>Sign in</h1>
+    <p class="lead">Sign in to your OpenCodelists account.</p>
     {% if next %}
         <p>Please log in to see this page.</p>
     {% endif %}
 
-    <form method="post" action="{% url 'login' %}">
+    <form class="auth-form" method="post" action="{% url 'login' %}">
         {% csrf_token %}
         {{ form|crispy }}
 
@@ -18,7 +21,10 @@
         <button class="btn btn-primary" type="submit">Sign in</button>
     </form>
 
-    <a href="{% url 'password_reset' %}">Forgot password?</a>
+    <p>
+        Don't have an account
+        <a href="{% url 'register' %}">sign up now &rarr;</a>
+    </p>
+    <p><a href="{% url 'password_reset' %}">Forgot password?</a></p>
 </div>
-
 {% endblock %}

--- a/templates/registration/password_change_done.html
+++ b/templates/registration/password_change_done.html
@@ -1,9 +1,13 @@
 {% extends 'base.html' %}
 
-{% block content %}
+{% block title_extra %}: Change password{% endblock %}
 
-<div class="mt-3">
-    <h1>{{ title }}</h1>
-    <p>Your password was changed.</p>
+{% block content %}
+<div class="mt-3 col-lg-9 col-xl-8">
+    <h1>Change password</h1>
+    <p class="lead">Your password was changed</p>
+    <p>
+        <a href="{% url 'codelists:index' %}">Go to the home page &rarr;</a>
+    </p>
 </div>
 {% endblock %}

--- a/templates/registration/password_change_form.html
+++ b/templates/registration/password_change_form.html
@@ -2,11 +2,13 @@
 
 {% load crispy_forms_tags %}
 
-{% block content %}
+{% block title_extra %}: Change password{% endblock %}
 
+{% block content %}
 <div class="mt-3">
-    <h1>{{ title }}</h1>
-    <form method="post">
+    <h1>Change password</h1>
+
+    <form class="auth-form" method="post">
         {% csrf_token %}
         {{ form|crispy }}
 

--- a/templates/registration/password_reset_complete.html
+++ b/templates/registration/password_reset_complete.html
@@ -2,14 +2,14 @@
 
 {% load crispy_forms_tags %}
 
+{% block title_extra %}: Password reset{% endblock %}
+
 {% block content %}
-
-<div class="mt-3">
-    <h1>{{ title }}</h1>
-
-    <p>Your password has been set.  You may go ahead and sign in now.</p>
-
-    <p><a href="{{ login_url }}">Sign in</a></p>
-
+<div class="mt-3 col-lg-9 col-xl-8">
+    <h1>Password reset</h1>
+    <p class="lead">Your password has been set.</p>
+    <p>
+        <a href="{{ login_url }}">Sign in &rarr;</a>
+    </p>
 </div>
 {% endblock %}

--- a/templates/registration/password_reset_confirm.html
+++ b/templates/registration/password_reset_confirm.html
@@ -2,26 +2,31 @@
 
 {% load crispy_forms_tags %}
 
+{% block title_extra %}: Enter a new password{% endblock %}
+
 {% block content %}
 
 <div class="mt-3">
-    <h1>{{ title }}</h1>
+    <h1>Enter a new password</h1>
 
     {% if validlink %}
+        <p class="lead">
+            Please enter your new password twice so we can verify you typed it in correctly.
+        </p>
 
-    <p>Please enter your new password twice so we can verify you typed it in correctly.</p>
+        <form class="auth-form" method="post">
+            {% csrf_token %}
+            {{ form|crispy }}
 
-    <form method="post">
-        {% csrf_token %}
-        {{ form|crispy }}
-        <button class="btn btn-primary" type="submit">Change my password</button>
-    </form>
-
+            <button class="btn btn-primary" type="submit">Change password</button>
+        </form>
     {% else %}
-
-    <p>The password reset link was invalid, possibly because it has already been used.
-        Please request a new <a href="{% url 'password_reset' %}">password reset</a>.</p>
-
+        <p class="lead">The password reset link was invalid, possibly because it has already been used.</p>
+        <p>
+            <a href="{% url 'password_reset' %}">
+                Request a new password reset email &rarr;
+            </a>
+            </p>
     {% endif %}
 </div>
 {% endblock %}

--- a/templates/registration/password_reset_done.html
+++ b/templates/registration/password_reset_done.html
@@ -2,14 +2,12 @@
 
 {% load crispy_forms_tags %}
 
+{% block title_extra %}: Password reset{% endblock %}
+
 {% block content %}
-
-<div class="mt-3">
-    <h1>{{ title }}</h1>
-
+<div class="mt-3 col-lg-9 col-xl-8">
+    <h1>Password reset</h1>
     <p>We’ve emailed you instructions for setting your password, if an account exists with the email you entered. You should receive them shortly.</p>
-
     <p>If you don’t receive an email, please make sure you’ve entered the address you registered with, and check your spam folder.</p>
-
 </div>
 {% endblock %}

--- a/templates/registration/password_reset_form.html
+++ b/templates/registration/password_reset_form.html
@@ -2,15 +2,19 @@
 
 {% load crispy_forms_tags %}
 
+{% block title_extra %}: Reset password{% endblock %}
+
 {% block content %}
-
 <div class="mt-3">
-    <h1>{{ title }}</h1>
-    <p>Forgotten your password? Enter your email address below, and we’ll email instructions for setting a new one.</p>
+    <h1>Reset password</h1>
+    <p class="lead">
+        Enter your email and we'll send you a link to reset your password.
+    </p>
 
-    <form method="post">
+    <form class="auth-form" method="post">
         {% csrf_token %}
         {{ form|crispy }}
+
         <button class="btn btn-primary" type="submit">Reset my password</button>
     </form>
 </div>

--- a/templates/registration/register.html
+++ b/templates/registration/register.html
@@ -2,11 +2,16 @@
 
 {% load crispy_forms_tags %}
 
+{% block title_extra %}: Sign up{% endblock %}
+
 {% block content %}
-
 <div class="mt-3">
+    <h1>Sign up</h1>
+    <p class="lead">
+        Create an OpenCodelists user account
+    </p>
 
-    <form method="post" action="{% url 'register' %}">
+    <form class="auth-form" method="post" action="{% url 'register' %}">
         {% csrf_token %}
         {{ form|crispy }}
 


### PR DESCRIPTION
During the workshop I noticed how these pages:

- Have no meta title
- Mostly have no on-page title
- Do not accurately describe the page
- Do not bold the labels in the forms
- Have full-width input boxes
- Do not make the asterisk red in the label

So I set about making some small simple fixes for these issues.

## Links

You can preview the pages on production using these links, and then change the URL for `http://localhost:7000` to view the local updated version.

- [Sign in](https://www.opencodelists.org/accounts/login/)
- [Sign up](https://www.opencodelists.org/accounts/register/)
- [Change password](https://www.opencodelists.org/accounts/password_change/)
- [Change password - done](https://www.opencodelists.org/accounts/password_change/done/)
- [Password reset - request](https://www.opencodelists.org/accounts/password_reset/)
- [Password reset - sent](https://www.opencodelists.org/accounts/password_reset/done/)
- [Password reset page (you will need to request a reset to see this page)](https://www.opencodelists.org/accounts/reset/<uidb64>/<token>/)
- [Password reset - done](https://www.opencodelists.org/accounts/reset/done/)

## Examples

Example screenshots of the sign in and sign up pages.

### Before

<img src="https://github.com/user-attachments/assets/668abf33-3f62-44f8-9e7d-7de2675fbf4c" width="1024" />
<img src="https://github.com/user-attachments/assets/501a087b-e469-4b64-95be-a103fc0c5e29" width="1024" />

### After

<img src="https://github.com/user-attachments/assets/c9c2883b-8b13-4a11-8e8d-6a79dbd20c39" width="1024" />
<img src="https://github.com/user-attachments/assets/a3e01088-aec5-4e8c-9b1b-faef39ad33da" width="1024" />
