### PR TITLE
Add custom endpoint for dokku healthchecks

### DIFF
--- a/app.json
+++ b/app.json
@@ -18,7 +18,7 @@
                 ],
                 "initialDelay": 30,
                 "name": "Web health check",
-                "path": "/",
+                "path": "/health-check",
                 "port": 7000,
                 "timeout": 60,
                 "type": "startup"

--- a/opencodelists/tests/views/test_health_check.py
+++ b/opencodelists/tests/views/test_health_check.py
@@ -1,0 +1,3 @@
+def test_health_check_successful(client):
+    response = client.get("/health-check/")
+    assert response.status_code == 200

--- a/opencodelists/urls.py
+++ b/opencodelists/urls.py
@@ -43,6 +43,7 @@ urlpatterns = [
     path("conversions/", include("conversions.urls")),
     path("coding-systems/", include("coding_systems.versioning.urls")),
     path("docs/", include("userdocs.urls")),
+    path("health-check/", views.health_check, name="health-check"),
     *debug_toolbar_urls,
     path("robots.txt", RedirectView.as_view(url=settings.STATIC_URL + "robots.txt")),
 ]

--- a/opencodelists/views/__init__.py
+++ b/opencodelists/views/__init__.py
@@ -1,3 +1,4 @@
+from .health_check import health_check
 from .organisations import organisation_members, organisations
 from .register import register
 from .user import user

--- a/opencodelists/views/health_check.py
+++ b/opencodelists/views/health_check.py
@@ -1,0 +1,5 @@
+from django.http import HttpResponse
+
+
+def health_check(request):
+    return HttpResponse()


### PR DESCRIPTION
When we deply OpenCodelists, Dokku starts each container and performs a health check to ensure the container has come up properly before routing traffic to it. These health checks are customisable (see [docs](https://dokku.com/docs/deployment/zero-downtime-deploys/)). Dokku only uses this health check when deploying new containers, it does not use it once the container has been deployed (we do have Freshping checking the site every few minutes though to make sure it's still working okay).

This change moves away from using the homepage as the health check endpoint and to a specific endpoint that will return 200 when the app starts and nothing else. Using the homepage as a health check is slower and makes a number of database connections, whereas this in theory decouples the app health check from the database.

Closes #2154

See https://github.com/opensafely-core/job-server/commit/717946f18