### PR TITLE
Report rows imported in import mapping command

### DIFF
--- a/mappings/__init__.py
+++ b/mappings/__init__.py
@@ -1,0 +1,10 @@
+from . import bnfdmd, ctv3sctmap2, dmdvmpprevmap
+
+
+mappings = {
+    "bnfdmd": bnfdmd,
+    "ctv3sctmap2": ctv3sctmap2,
+    "dmdvmpprevmap": dmdvmpprevmap,
+}
+
+__all__ = ["mappings"]

--- a/mappings/bnfdmd/README
+++ b/mappings/bnfdmd/README
@@ -14,7 +14,7 @@ xlsx file.
 
 To import the data, unzip the file and run:
 
-    ./manage.py import_mapping_data mappings.bnfdmd path/to/xlsx/file
+    ./manage.py import_mapping_data bnfdmd path/to/xlsx/file
 
 As a simple post-import check, you could compare the count of the imported mappings:
 

--- a/mappings/bnfdmd/README
+++ b/mappings/bnfdmd/README
@@ -16,12 +16,9 @@ To import the data, unzip the file and run:
 
     ./manage.py import_mapping_data bnfdmd path/to/xlsx/file
 
-As a simple post-import check, you could compare the count of the imported mappings:
-
->>> from mappings.bnfdmd.models import Mapping
->>> Mapping.objects.count()
-
-against the number of the corresponding rows of the spreadsheet which have both a BNF and DMD code.
+As a simple post-import check, you could compare the reported number of rows
+imported against the number of the corresponding rows of the spreadsheet which
+have both a BNF and DMD code.
 
 [0] https://www.bennett.ox.ac.uk/blog/2019/08/what-is-the-dm-d-the-nhs-dictionary-of-medicines-and-devices/
 [1] https://www.bennett.ox.ac.uk/blog/2022/11/difference-between-bnf-dm-d-and-snomed-ct-codes/

--- a/mappings/dmdvmpprevmap/README
+++ b/mappings/dmdvmpprevmap/README
@@ -1,5 +1,5 @@
 DM+D VMP Previous Mappings
----------------------------
+--------------------------
 
 dm+d VMP ids sometimes change.  In a single dm+d release, each VMP record may
 have a vmp_prev attribute, which indicates the id that this VMP used to be
@@ -20,5 +20,5 @@ imported.
 If the historical data needs to be re-imported, it can be run with:
 
     dokku run opencodelists python manage.py \
-    import_mapping_data mappings.dmdvmpprevmap \
+    import_mapping_data dmdvmpprevmap \
     /storage/data/dmdvmpprevmap/dmd_vpid_vpidprev_mapping_20221208.csv.gz

--- a/opencodelists/management/commands/import_mapping_data.py
+++ b/opencodelists/management/commands/import_mapping_data.py
@@ -12,8 +12,8 @@ class Command(BaseCommand):
         parser.add_argument(
             "source",
             help=(
-                "File or dir that defines the mapping, see import_data.py in "
-                "the mapping's package to understand how it is used"
+                "File or dir that defines the mapping, see README and/or "
+                "import_data.py in the mapping's package for more info"
             ),
         )
 

--- a/opencodelists/management/commands/import_mapping_data.py
+++ b/opencodelists/management/commands/import_mapping_data.py
@@ -18,6 +18,13 @@ class Command(BaseCommand):
         )
 
     def handle(self, mapping, source, **kwargs):
+        self.stdout.write(
+            f"Importing {mapping} mapping, this may take a few seconds..."
+        )
         mapping_import_data_module = import_module(f"mappings.{mapping}.import_data")
-        import_data = getattr(mapping_import_data_module , "import_data")
+        import_data = getattr(mapping_import_data_module, "import_data")
         import_data(source)
+
+        mapping_models_module = import_module(f"mappings.{mapping}.models")
+        mapping_model = getattr(mapping_models_module, "Mapping")
+        self.stdout.write(f"Imported {mapping_model.objects.count()} rows")

--- a/opencodelists/management/commands/import_mapping_data.py
+++ b/opencodelists/management/commands/import_mapping_data.py
@@ -1,4 +1,4 @@
-import importlib
+from importlib import import_module
 
 from django.core.management import BaseCommand
 
@@ -7,10 +7,17 @@ from mappings import mappings
 
 class Command(BaseCommand):
     def add_arguments(self, parser):
-        parser.add_argument("dataset", choices=mappings.keys())
-        parser.add_argument("release_dir")
+        parser.description = "Import a coding system mapping"
+        parser.add_argument("mapping", choices=mappings.keys(), help="Mapping name")
+        parser.add_argument(
+            "source",
+            help=(
+                "File or dir that defines the mapping, see import_data.py in "
+                "the mapping's package to understand how it is used"
+            ),
+        )
 
-    def handle(self, dataset, release_dir, **kwargs):
-        mod = importlib.import_module(f"mappings.{dataset}.import_data")
-        fn = getattr(mod, "import_data")
-        fn(release_dir)
+    def handle(self, mapping, source, **kwargs):
+        mapping_import_data_module = import_module(f"mappings.{mapping}.import_data")
+        import_data = getattr(mapping_import_data_module , "import_data")
+        import_data(source)

--- a/opencodelists/management/commands/import_mapping_data.py
+++ b/opencodelists/management/commands/import_mapping_data.py
@@ -1,17 +1,15 @@
-import glob
 import os
 from importlib import import_module
+from pathlib import Path
 
 from django.core.management import BaseCommand
 
 
 def possible_modules():
-    paths = glob.glob("mappings/**/import_data.py", recursive=True)
-    mods = []
-    for path in paths:
-        head, _ = os.path.split(path)
-        mods.append(head.replace(os.sep, "."))
-    return mods
+    return [
+        str(path.parent).replace(os.sep, ".")
+        for path in Path("mappings").rglob("import_data.py")
+    ]
 
 
 class Command(BaseCommand):

--- a/opencodelists/management/commands/import_mapping_data.py
+++ b/opencodelists/management/commands/import_mapping_data.py
@@ -1,23 +1,16 @@
-import os
-from importlib import import_module
-from pathlib import Path
+import importlib
 
 from django.core.management import BaseCommand
 
-
-def possible_modules():
-    return [
-        str(path.parent).replace(os.sep, ".")
-        for path in Path("mappings").rglob("import_data.py")
-    ]
+from mappings import mappings
 
 
 class Command(BaseCommand):
     def add_arguments(self, parser):
-        parser.add_argument("dataset", choices=possible_modules())
+        parser.add_argument("dataset", choices=mappings.keys())
         parser.add_argument("release_dir")
 
     def handle(self, dataset, release_dir, **kwargs):
-        mod = import_module(dataset + ".import_data")
+        mod = importlib.import_module(f"mappings.{dataset}.import_data")
         fn = getattr(mod, "import_data")
         fn(release_dir)

--- a/opencodelists/tests/test_import_mapping_data.py
+++ b/opencodelists/tests/test_import_mapping_data.py
@@ -5,13 +5,13 @@ from django.core.management import CommandError, call_command
 
 
 def test_unknown_mapping_module(tmpdir):
-    with pytest.raises(CommandError, match="invalid choice: 'mappings.unknown'"):
-        call_command("import_mapping_data", "mappings.unknown", tmpdir)
+    with pytest.raises(CommandError, match="invalid choice: 'unknown'"):
+        call_command("import_mapping_data", "unknown", tmpdir)
 
 
 @patch("mappings.bnfdmd.import_data.import_data")
 def test_calls_import_data_function_non_coding_system_import(mock_import_data, tmpdir):
     # A non-coding system import doesn't require the extra args
-    call_command("import_mapping_data", "mappings.bnfdmd", tmpdir)
+    call_command("import_mapping_data", "bnfdmd", tmpdir)
     mock_import_data.assert_called_once()
     mock_import_data.assert_called_with(str(tmpdir))


### PR DESCRIPTION
Provide some feedback on how many rows are imported. This is useful as a cross-check against the number of mappings in the source file(s).

Also tidy up the simplicity, readability and documentation of this command.

First commit ("List available mappings in mappings.mappings.") has some accidental changes to `import_mapping_data.py` -- please ignore, this was WIP simplification of the `possible_modules` function I realized could go away altogether. Beware `git add -u`...