### PR TITLE
Include `format` in `check` command in `justfile`

### DIFF
--- a/justfile
+++ b/justfile
@@ -131,14 +131,16 @@ test-py *ARGS: devenv
 # Run all the tests
 test: assets-test test-py
 
+# Run formatting checks
 format *args=".": devenv
     $BIN/ruff format --check {{ args }}
 
+# Run linting checks (unused variables etc.)
 ruff *args=".": devenv
     $BIN/ruff check {{ args }}
 
 # run the various dev checks but does not change any files
-check *args: devenv ruff
+check *args: devenv ruff format
 
 # fix formatting and import sort ordering
 fix: devenv


### PR DESCRIPTION
This ensures that the pre-commit hook that runs `check` will prevent committing without running `fix` first to get the formatting right. Otherwise you can commit and push changes then run CI on a PR only to find it has formatting issues. This happened to me several times and it's annoying! Better to catch locally before committing. This is in line with what we do in job-server.