### PR TITLE
Add custom error page templates

### DIFF
--- a/opencodelists/settings.py
+++ b/opencodelists/settings.py
@@ -63,6 +63,9 @@ if IN_PRODUCTION:
 # https://docs.djangoproject.com/en/4.0/ref/settings/#std:setting-CSRF_TRUSTED_ORIGINS
 CSRF_TRUSTED_ORIGINS = BASE_URLS
 
+# CSRF error view
+# https://docs.djangoproject.com/en/4.1/ref/settings/#csrf-failure-view
+CSRF_FAILURE_VIEW = "opencodelists.views.errors.csrf_failure"
 
 # Application definition
 

--- a/opencodelists/urls.py
+++ b/opencodelists/urls.py
@@ -4,6 +4,7 @@ from django.urls import include, path
 from django.views.generic import RedirectView
 
 from . import views
+from .views.errors import bad_request, page_not_found, permission_denied, server_error
 
 
 users_patterns = [
@@ -43,6 +44,10 @@ urlpatterns = [
     path("conversions/", include("conversions.urls")),
     path("coding-systems/", include("coding_systems.versioning.urls")),
     path("docs/", include("userdocs.urls")),
+    path("400", bad_request, name="bad_request"),
+    path("403", permission_denied, name="permission_denied"),
+    path("404", page_not_found, name="page_not_found"),
+    path("500", server_error, name="server_error"),
     path("health-check/", views.health_check, name="health-check"),
     *debug_toolbar_urls,
     path("robots.txt", RedirectView.as_view(url=settings.STATIC_URL + "robots.txt")),

--- a/opencodelists/urls.py
+++ b/opencodelists/urls.py
@@ -7,6 +7,11 @@ from . import views
 from .views.errors import bad_request, page_not_found, permission_denied, server_error
 
 
+handler400 = bad_request
+handler403 = permission_denied
+handler404 = page_not_found
+handler500 = server_error
+
 users_patterns = [
     path("<username>/", views.user, name="user"),
     path(

--- a/opencodelists/views/errors.py
+++ b/opencodelists/views/errors.py
@@ -1,0 +1,66 @@
+from django.template.response import TemplateResponse
+
+
+def bad_request(request, exception=None):
+    return TemplateResponse(
+        request,
+        "error.html",
+        status=400,
+        context={
+            "error_code": "400",
+            "error_name": "Bad request",
+            "error_message": "An error has occurred displaying this page.",
+        },
+    )
+
+
+def csrf_failure(request, reason=""):
+    return TemplateResponse(
+        request,
+        "error.html",
+        status=400,
+        context={
+            "error_code": "CSRF",
+            "error_name": "CSRF Failed",
+            "error_message": "The form was not able to submit.",
+        },
+    )
+
+
+def page_not_found(request, exception=None):
+    return TemplateResponse(
+        request,
+        "error.html",
+        status=404,
+        context={
+            "error_code": "404",
+            "error_name": "Page not found",
+            "error_message": "Please check the URL in the address bar.",
+        },
+    )
+
+
+def permission_denied(request, exception=None):
+    return TemplateResponse(
+        request,
+        "error.html",
+        status=403,
+        context={
+            "error_code": "403",
+            "error_name": "Permission denied",
+            "error_message": "You do not have permission to access this page.",
+        },
+    )
+
+
+def server_error(request):
+    return TemplateResponse(
+        request,
+        "error.html",
+        status=500,
+        context={
+            "error_code": "500",
+            "error_name": "Server error",
+            "error_message": "An error has occurred displaying this page.",
+        },
+    )

--- a/templates/error.html
+++ b/templates/error.html
@@ -1,0 +1,18 @@
+{% extends "base.html" %}
+
+{% block content %}
+  <h1 class="display-4">
+    {{ error_code }}:
+    {{ error_name }}
+  </h1>
+  <p class="lead">
+    {{ error_message }}
+  </p>
+  <hr class="my-4">
+  <a class="btn btn-primary text-decoration-none" href="{% url 'codelists:index' %}" role="button">
+    Go to the home page
+  </a>
+  <a class="btn btn-secondary text-decoration-none" href="mailto:tech@opensafely.org" role="button">
+    Contact support
+  </a>
+{% endblock %}

--- a/templates/error.html
+++ b/templates/error.html
@@ -1,5 +1,7 @@
 {% extends "base.html" %}
 
+{% block title_extra %}: {{ error_name }}{% endblock %}
+
 {% block content %}
   <h1 class="display-4">
     {{ error_code }}:


### PR DESCRIPTION
Closes #2168

- Adds custom error pages
- Link to the home page and to contact support

## Before

<img src="https://github.com/user-attachments/assets/c5fe29ca-8891-452e-8916-c6e075c0262e" width="800" />


## After

<img src="https://github.com/user-attachments/assets/6f559a9e-d060-4032-82fc-2b957bac5479" width="800" />