### PR TITLE
Allow content to fill more of the viewport width

### DIFF
--- a/assets/src/scripts/components/CodelistBuilder.jsx
+++ b/assets/src/scripts/components/CodelistBuilder.jsx
@@ -151,7 +151,7 @@ class CodelistBuilder extends React.Component {
     return (
       <>
         <div className="row">
-          <div className="col-md-3 col-lg-2">
+          <div className="col-md-3">
             {this.props.isEditable && (
               <>
                 <this.ManagementForm complete={this.complete()} />
@@ -232,7 +232,7 @@ class CodelistBuilder extends React.Component {
             </ul>
           </div>
 
-          <div className="col-9 pl-5">
+          <div className="col-md-9 overflow-auto">
             <h4>{this.props.resultsHeading}</h4>
             <hr />
             <TreeTables

--- a/assets/src/styles/base.css
+++ b/assets/src/styles/base.css
@@ -86,3 +86,7 @@ a:focus {
     margin-left: 0.25rem;
   }
 }
+
+.max-w-screen-2xl {
+  max-width: 1536px;
+}

--- a/assets/src/styles/base.css
+++ b/assets/src/styles/base.css
@@ -90,3 +90,9 @@ a:focus {
 .max-w-screen-2xl {
   max-width: 1536px;
 }
+
+.break-word {
+  overflow-wrap: break-word;
+  word-wrap: break-word;
+  word-break: break-word;
+}

--- a/templates/base.html
+++ b/templates/base.html
@@ -60,15 +60,15 @@
               <a class="nav-link text-white" href="{% url 'organisations' %}">My organisations</a>
             </li>
             {% endif %}
-            <li class="nav-item dropdown">
-              <a class="nav-link dropdown-toggle text-white" href="#" id="navbarDropdown" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-                My account
-              </a>
-              <div class="dropdown-menu dropdown-menu-right" aria-labelledby="navbarDropdown">
-                <span class="dropdown-item text-secondary">Signed in as {{ request.user.username }}</span>
-                <div class="dropdown-divider"></div>
-                <a class="dropdown-item" href="{% url 'password_change' %}">Change password</a>
-                <a class="dropdown-item" href="{% url 'logout' %}">Sign Out</a>
+              <li class="nav-item dropdown">
+                <a class="nav-link dropdown-toggle text-white" href="#" id="navbarDropdown" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+                  My account
+                </a>
+                <div class="dropdown-menu dropdown-menu-right" aria-labelledby="navbarDropdown">
+                  <span class="dropdown-item text-secondary">Signed in as {{ request.user.username }}</span>
+                  <div class="dropdown-divider"></div>
+                  <a class="dropdown-item" href="{% url 'password_change' %}">Change password</a>
+                  <a class="dropdown-item" href="{% url 'logout' %}">Sign Out</a>
               </div>
             </li>
           {% else %}
@@ -83,18 +83,28 @@
       </div>
     </nav>
 
-    <main role="main" class="flex-shrink-0 container mb-5">
-      {% for message in messages %}
-      <div class="alert {{ message.tags }} alert-dismissible mt-3" role="alert">
-        <button type="button" class="close" data-dismiss="alert" aria-label="Close">
-          <span aria-hidden="true">&times;</span>
-        </button>
-        {{ message }}
-      </div>
-      {% endfor %}
+    <main role="main" class="flex-shrink-0 my-4">
+      {% if messages %}
+        <div class="container">
+          {% for message in messages %}
+            <div class="alert {{ message.tags }} alert-dismissible mt-3" role="alert">
+              <button type="button" class="close" data-dismiss="alert" aria-label="Close">
+                <span aria-hidden="true">&times;</span>
+              </button>
+              {{ message }}
+            </div>
+          {% endfor %}
+        </div>
+      {% endif %}
 
-      <div class="mt-4">
-        {% block content %} {% endblock %}
+      <div class="container">
+        {% block content %}
+        {% endblock %}
+      </div>
+
+      <div class="container-fluid max-w-screen-2xl">
+        {% block full_width_content %}
+        {% endblock %}
       </div>
     </main>
 

--- a/templates/base.html
+++ b/templates/base.html
@@ -31,35 +31,35 @@
     >
       <div class="mr-auto">
         <a class="navbar-brand" href="{% url 'codelists:index' %}"
-          >OpenCodelists</a
-        >
+        >OpenCodelists</a
+          >
 
-        <button
-          class="navbar-toggler"
-          type="button"
-          data-toggle="collapse"
-          data-target="#navbarSupportedContent"
-          aria-controls="navbarSupportedContent"
-          aria-expanded="false"
-          aria-label="Toggle navigation">
-          <span class="navbar-toggler-icon"></span>
-        </button>
-      </div>
+          <button
+            class="navbar-toggler"
+            type="button"
+            data-toggle="collapse"
+            data-target="#navbarSupportedContent"
+            aria-controls="navbarSupportedContent"
+            aria-expanded="false"
+            aria-label="Toggle navigation">
+            <span class="navbar-toggler-icon"></span>
+          </button>
+        </div>
 
-      <div class="collapse navbar-collapse" id="navbarSupportedContent">
-        <ul class="navbar-nav ml-auto">
-          <li class="navbar-nav nav-item">
-            <a class="nav-link text-white" href="{% url 'docs:index' %}">Docs</a>
-          </li>
-          {% if request.user.is_authenticated %}
+        <div class="collapse navbar-collapse" id="navbarSupportedContent">
+          <ul class="navbar-nav ml-auto">
             <li class="navbar-nav nav-item">
-              <a class="nav-link text-white" href="{% url 'user' request.user.username %}">My codelists</a>
+              <a class="nav-link text-white" href="{% url 'docs:index' %}">Docs</a>
             </li>
-            {% if user.memberships.exists %}
-            <li class="navbar-nav nav-item">
-              <a class="nav-link text-white" href="{% url 'organisations' %}">My organisations</a>
-            </li>
-            {% endif %}
+            {% if request.user.is_authenticated %}
+              <li class="navbar-nav nav-item">
+                <a class="nav-link text-white" href="{% url 'user' request.user.username %}">My codelists</a>
+              </li>
+              {% if user.memberships.exists %}
+                <li class="navbar-nav nav-item">
+                  <a class="nav-link text-white" href="{% url 'organisations' %}">My organisations</a>
+                </li>
+              {% endif %}
               <li class="nav-item dropdown">
                 <a class="nav-link dropdown-toggle text-white" href="#" id="navbarDropdown" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
                   My account
@@ -69,85 +69,85 @@
                   <div class="dropdown-divider"></div>
                   <a class="dropdown-item" href="{% url 'password_change' %}">Change password</a>
                   <a class="dropdown-item" href="{% url 'logout' %}">Sign Out</a>
-              </div>
-            </li>
-          {% else %}
-            <li class="navbar-nav nav-item">
-              <a class="nav-link text-white" href="{% url 'register' %}">Sign up</a>
-            </li>
-            <li class="navbar-nav nav-item">
-              <a class="nav-link text-white" href="{% url 'login' %}">Sign in</a>
-            </li>
-          {% endif %}
-        </ul>
-      </div>
-    </nav>
-
-    <main role="main" class="flex-shrink-0 my-4">
-      {% if messages %}
-        <div class="container">
-          {% for message in messages %}
-            <div class="alert {{ message.tags }} alert-dismissible mt-3" role="alert">
-              <button type="button" class="close" data-dismiss="alert" aria-label="Close">
-                <span aria-hidden="true">&times;</span>
-              </button>
-              {{ message }}
-            </div>
-          {% endfor %}
+                </div>
+              </li>
+            {% else %}
+              <li class="navbar-nav nav-item">
+                <a class="nav-link text-white" href="{% url 'register' %}">Sign up</a>
+              </li>
+              <li class="navbar-nav nav-item">
+                <a class="nav-link text-white" href="{% url 'login' %}">Sign in</a>
+              </li>
+            {% endif %}
+          </ul>
         </div>
-      {% endif %}
+      </nav>
 
-      <div class="container">
-        {% block content %}
-        {% endblock %}
-      </div>
+      <main role="main" class="flex-shrink-0 my-4">
+        {% if messages %}
+          <div class="container">
+            {% for message in messages %}
+              <div class="alert {{ message.tags }} alert-dismissible mt-3" role="alert">
+                <button type="button" class="close" data-dismiss="alert" aria-label="Close">
+                  <span aria-hidden="true">&times;</span>
+                </button>
+                {{ message }}
+              </div>
+            {% endfor %}
+          </div>
+        {% endif %}
 
-      <div class="container-fluid max-w-screen-2xl">
-        {% block full_width_content %}
-        {% endblock %}
-      </div>
-    </main>
+        <div class="container">
+          {% block content %}
+          {% endblock %}
+        </div>
 
-    <footer id="footer" class="border-top bg-light mt-auto py-5">
-      <div class="container">
-        <ul class="list-inline text-center d-flex flex-column flex-md-row justify-content-center mb-0 mb-md-3">
-          <li class="list-inline-item mb-3 mb-md-0 mr-0 mr-md-5">
-            <a href="{% url 'docs:index' %}">
-              Documentation
-            </a>
-          </li>
+        <div class="container-fluid max-w-screen-2xl">
+          {% block full_width_content %}
+          {% endblock %}
+        </div>
+      </main>
 
-          <li class="list-inline-item mb-3 mb-md-0 mr-0">
-            <a href="https://www.opensafely.org/">
-              OpenSAFELY
-            </a>
-          </li>
-        </ul>
+      <footer id="footer" class="border-top bg-light mt-auto py-5">
+        <div class="container">
+          <ul class="list-inline text-center d-flex flex-column flex-md-row justify-content-center mb-0 mb-md-3">
+            <li class="list-inline-item mb-3 mb-md-0 mr-0 mr-md-5">
+              <a href="{% url 'docs:index' %}">
+                Documentation
+              </a>
+            </li>
 
-        <ul class="list-inline text-center d-flex flex-column flex-md-row justify-content-center">
-          <li class="list-inline-item mb-3 mb-md-0 mr-0 mr-md-5">
-            <a href="https://www.bennett.ox.ac.uk/">
-              Bennett Institute for Applied Data Science
-            </a>
-          </li>
+            <li class="list-inline-item mb-3 mb-md-0 mr-0">
+              <a href="https://www.opensafely.org/">
+                OpenSAFELY
+              </a>
+            </li>
+          </ul>
 
-          <li class="list-inline-item mb-3 mb-md-0">
-            <a href="https://www.ox.ac.uk/">
-              University of Oxford
-            </a>
-          </li>
-        </ul>
+          <ul class="list-inline text-center d-flex flex-column flex-md-row justify-content-center">
+            <li class="list-inline-item mb-3 mb-md-0 mr-0 mr-md-5">
+              <a href="https://www.bennett.ox.ac.uk/">
+                Bennett Institute for Applied Data Science
+              </a>
+            </li>
 
-        <div class="row">
-          <div class="col-12 offset-md-1 col-md-10 offset-lg-2 col-lg-8 text-center mt-3 mb-0 small">
-            <p>© University of Oxford for the Bennett Institute for Applied Data Science 2022. This work may be copied freely for non-commercial research and study. If you wish to do any of the other acts restricted by the copyright you should apply in writing to <a href="mailto:team@opensafely.org">team@opensafely.org</a>.</p>
-            <p>SNOMED Clinical Terms® content © International Health Terminology Standards Development Organisation.</p>
-            <p>ICD-10 codes, terms and text © World Health Organization, Third Edition. 2007.</p>
+            <li class="list-inline-item mb-3 mb-md-0">
+              <a href="https://www.ox.ac.uk/">
+                University of Oxford
+              </a>
+            </li>
+          </ul>
+
+          <div class="row">
+            <div class="col-12 offset-md-1 col-md-10 offset-lg-2 col-lg-8 text-center mt-3 mb-0 small">
+              <p>© University of Oxford for the Bennett Institute for Applied Data Science 2022. This work may be copied freely for non-commercial research and study. If you wish to do any of the other acts restricted by the copyright you should apply in writing to <a href="mailto:team@opensafely.org">team@opensafely.org</a>.</p>
+              <p>SNOMED Clinical Terms® content © International Health Terminology Standards Development Organisation.</p>
+              <p>ICD-10 codes, terms and text © World Health Organization, Third Edition. 2007.</p>
+            </div>
           </div>
         </div>
-      </div>
-    </footer>
+      </footer>
 
-    {% block extra_js %}{% endblock %}
-  </body>
-</html>
+      {% block extra_js %}{% endblock %}
+    </body>
+  </html>

--- a/templates/builder/draft.html
+++ b/templates/builder/draft.html
@@ -5,42 +5,42 @@
 {% block title_extra %}: {{ codelist_name }} (Draft){% endblock %}
 
 {% block full_width_content %}
-<div class="border-bottom mb-3">
-  <h1 class="h3">{{ codelist_name }}</h1>
-  <p class="text-muted">This version is a draft</p>
-</div>
+  <div class="border-bottom mb-3">
+    <h1 class="h3">{{ codelist_name }}</h1>
+    <p class="text-muted">This version is a draft</p>
+  </div>
 
-<div class="overflow-hidden" id="codelist-builder-container"></div>
+  <div class="overflow-hidden" id="codelist-builder-container"></div>
 {% endblock %}
 
 {% block extra_js %}
-{{ results_heading|json_script:"results-heading" }}
-{{ searches|json_script:"searches" }}
-{{ filter|json_script:"filter" }}
-{{ tree_tables|json_script:"tree-tables" }}
-{{ code_to_term|json_script:"code-to-term" }}
-{{ code_to_status|json_script:"code-to-status" }}
-{{ all_codes|json_script:"all-codes" }}
-{{ included_codes|json_script:"included-codes" }}
-{{ excluded_codes|json_script:"excluded-codes" }}
-{{ parent_map|json_script:"parent-map" }}
-{{ child_map|json_script:"child-map" }}
-{{ is_editable|json_script:"is-editable" }}
-{{ draft_url|json_script:"draft-url" }}
-{{ update_url|json_script:"update-url" }}
-{{ search_url|json_script:"search-url" }}
-{{ versions|json_script:"versions" }}
-{{ metadata|json_script:"metadata" }}
+  {{ results_heading|json_script:"results-heading" }}
+  {{ searches|json_script:"searches" }}
+  {{ filter|json_script:"filter" }}
+  {{ tree_tables|json_script:"tree-tables" }}
+  {{ code_to_term|json_script:"code-to-term" }}
+  {{ code_to_status|json_script:"code-to-status" }}
+  {{ all_codes|json_script:"all-codes" }}
+  {{ included_codes|json_script:"included-codes" }}
+  {{ excluded_codes|json_script:"excluded-codes" }}
+  {{ parent_map|json_script:"parent-map" }}
+  {{ child_map|json_script:"child-map" }}
+  {{ is_editable|json_script:"is-editable" }}
+  {{ draft_url|json_script:"draft-url" }}
+  {{ update_url|json_script:"update-url" }}
+  {{ search_url|json_script:"search-url" }}
+  {{ versions|json_script:"versions" }}
+  {{ metadata|json_script:"metadata" }}
 
-{% if debug %}
-<script type="module" nonce="{{ request.csp_nonce }}">
-  import RefreshRuntime from 'http://localhost:5173/static/@react-refresh'
-  RefreshRuntime.injectIntoGlobalHook(window)
-  window.$RefreshReg$ = () => {}
-  window.$RefreshSig$ = () => (type) => type
-  window.__vite_plugin_react_preamble_installed__ = true
-</script>
-{% endif %}
+  {% if debug %}
+    <script type="module" nonce="{{ request.csp_nonce }}">
+      import RefreshRuntime from 'http://localhost:5173/static/@react-refresh'
+      RefreshRuntime.injectIntoGlobalHook(window)
+      window.$RefreshReg$ = () => {}
+      window.$RefreshSig$ = () => (type) => type
+      window.__vite_plugin_react_preamble_installed__ = true
+    </script>
+  {% endif %}
 
-{% vite_asset "assets/src/scripts/builder/index.jsx" %}
+  {% vite_asset "assets/src/scripts/builder/index.jsx" %}
 {% endblock %}

--- a/templates/builder/draft.html
+++ b/templates/builder/draft.html
@@ -2,12 +2,15 @@
 
 {% load django_vite %}
 
-{% block content %}
-<h3 class="mt-4">{{ codelist_name }}</h3>
-<p class="text-muted">This version is a draft</p>
-<hr />
+{% block title_extra %}: {{ codelist_name }} (Draft){% endblock %}
 
-<div id="codelist-builder-container"></div>
+{% block full_width_content %}
+<div class="border-bottom mb-3">
+  <h1 class="h3">{{ codelist_name }}</h1>
+  <p class="text-muted">This version is a draft</p>
+</div>
+
+<div class="overflow-hidden" id="codelist-builder-container"></div>
 {% endblock %}
 
 {% block extra_js %}

--- a/templates/codelists/version.html
+++ b/templates/codelists/version.html
@@ -4,33 +4,34 @@
 
 {% block title_extra %}: {{ codelist.name }}{% endblock %}
 
-{% block content %}
-<h1 class="h3 mt-4">{{ codelist.name }}</h1>
-{% if clv.is_under_review %}
-<p class="text-muted">This version is under review</p>
-{% endif %}
-<hr />
+{% block full_width_content %}
+  <div class="border-bottom mb-3">
+    <h1 class="h3">{{ codelist.name }}</h1>
+    {% if clv.is_under_review %}
+      <p class="text-muted">This version is under review</p>
+    {% endif %}
+  </div>
 
-<div class="row">
-  <div class="col-md-3 col-lg-2">
-    <form method="POST" action={{ clv.get_dmd_convert_url }}>
-      {% csrf_token %}
-      <div class="btn-group-vertical btn-block" role="group">
-        {% if clv.coding_system_id == "dmd" %}
-          {% if clv.downloadable %}
-            <a
-              href="{{ clv.get_download_url }}"
-              role="button"
-              class="btn btn-outline-primary btn-block"
-            >
-              Download CSV <small class="d-block">with mapped VMPs*</small>
-            </a>
+  <div class="row">
+    <div class="col-md-3">
+      <form action={{ clv.get_dmd_convert_url }} class="border-bottom pb-3 mb-3" method="POST">
+        {% csrf_token %}
+        <div class="btn-group-vertical btn-block" role="group">
+          {% if clv.coding_system_id == "dmd" %}
+            {% if clv.downloadable %}
+              <a
+                href="{{ clv.get_download_url }}"
+                role="button"
+                class="btn btn-outline-primary btn-block"
+              >
+                Download CSV <small class="d-block">with mapped VMPs*</small>
+              </a>
+            {% else %}
+              <div class="btn btn-outline-primary btn-block disabled">
+                Download CSV <small class="d-block">with mapped VMPs*</small>
+              </div>
+            {% endif %}
           {% else %}
-            <div class="btn btn-outline-primary btn-block disabled">
-              Download CSV <small class="d-block">with mapped VMPs*</small>
-            </div>
-          {% endif %}
-        {% else %}
             <a
               href="{{ clv.get_download_url }}"
               role="button"
@@ -38,118 +39,149 @@
             >
               Download CSV
             </a>
-        {% endif %}
-      {% if clv.coding_system_id == "dmd" %}
-      <a
-        href="{{ clv.get_download_url }}?omit-mapped-vmps"
-        role="button"
-        class="btn btn-outline-primary btn-block"
-      >
-        Download CSV <small class="d-block">original</small>
-      </a>
-      {% endif %}
-      {% if clv.codeset %}
-      <a
-        href="{{ clv.get_download_definition_url }}"
-        role="button"
-        class="btn btn-outline-primary btn-block"
-      >
-        Download definition
-      </a>
-      {% endif %}
-      {% if clv.coding_system_id == "bnf" %}
-        <a
-          href="{{ clv.get_dmd_download_url }}"
-          role="button"
-          class="btn btn-outline-primary btn-block"
-        >
-          Download dm+d
-        </a>
-        {% if user_can_edit %}
-          <button
-            type="submit"
-            role="button"
-            class="btn btn-outline-primary btn-block"
-            data-toggle="tooltip"
-            title="Convert this version to a new dm+d codelist">
-            Convert to dm+d
-          </button>
-        {% endif %}
-      {% endif %}
-    </div>
-    </form>
-
-    <hr />
-
-    <h2 class="sr-only">Codelist metadata</h2>
-    <dl>
-      <dt>
-        <h3 class="h6 font-weight-bold mb-1">Coding system</h3>
-      </dt>
-      <dd class="pb-2 border-bottom">{{ clv.coding_system.name }}</dd>
-
-      <dt>
-        <h3 class="h6 font-weight-bold">Coding system release</h3>
-      </dt>
-      <dd class="pb-2 border-bottom">{{ clv.coding_system.release_name }}</dd>
-
-      {% if clv.compatible_releases.exists %}
-        <details>
-          <summary>Show other compatible releases</summary>
-          <ul>
-            {% for release in clv.compatible_releases.all %}
-              <li><small>{{ release.release_name }} ({{ release.valid_from|date:'Y-m-d'}})</small></li>
-            {% endfor %}
-          </ul>
-        </details>
-      {% endif %}
-
-      {% if codelist.organisation %}
-      <dt>
-        <h3 class="h6 font-weight-bold">Organisation</h3>
-      </dt>
-      <dd class="pb-2 border-bottom">{{ codelist.organisation.name }}</dd>
-      {% endif %}
-
-      <dt>
-        <h3 class="h6 font-weight-bold">Codelist ID</h3>
-      </dt>
-      <dd class="text-break pb-2 border-bottom">{{ codelist.full_slug }}</dd>
-
-      {% if clv.tag %}
-      <dt>
-        <h3 class="h6 font-weight-bold">Version Tag</h3>
-      </dt>
-      <dd class="pb-2 border-bottom">{{ clv.tag }}</dd>
-      {% endif %}
-
-      <dt>
-        <h3 class="h6 font-weight-bold">Version ID</h3>
-      </dt>
-      <dd class="pb-2 border-bottom">{{ clv.hash }}</dd>
-    </dl>
-
-    {% if user_can_edit %}
-      <div class="btn-group-vertical btn-block" role="group">
-        <a
-          class="btn btn-outline-primary btn-block"
-          href="{{ codelist.get_update_url }}">
-          Edit metadata
-        </a>
-      </div>
-
-      <hr />
-
-      <form method="POST" action={{ clv.get_create_url }}>
-        {% csrf_token %}
-        <div class="btn-group-vertical btn-block" role="group">
-          {% if codelist.is_new_style %}
-            {% if can_create_new_version %}
-              <input type="hidden" name="coding_system_database_alias" value="" />
+          {% endif %}
+          {% if clv.coding_system_id == "dmd" %}
+            <a
+              href="{{ clv.get_download_url }}?omit-mapped-vmps"
+              role="button"
+              class="btn btn-outline-primary btn-block"
+            >
+              Download CSV <small class="d-block">original</small>
+            </a>
+          {% endif %}
+          {% if clv.codeset %}
+            <a
+              href="{{ clv.get_download_definition_url }}"
+              role="button"
+              class="btn btn-outline-primary btn-block"
+            >
+              Download definition
+            </a>
+          {% endif %}
+          {% if clv.coding_system_id == "bnf" %}
+            <a
+              href="{{ clv.get_dmd_download_url }}"
+              role="button"
+              class="btn btn-outline-primary btn-block"
+            >
+              Download dm+d
+            </a>
+            {% if user_can_edit %}
               <button
                 type="submit"
-                class="btn btn-outline-primary btn-block">
-                Create new version
+                role="button"
+                class="btn btn-outline-primary btn-block"
+                data-toggle="tooltip"
+                title="Convert this version to a new dm+d codelist">
+                Convert to dm+d
+              </button>
+            {% endif %}
+          {% endif %}
+        </div>
+      </form>
+
+      <h2 class="sr-only">Codelist metadata</h2>
+      <dl class="break-word">
+        <dt>
+          <h3 class="h6 font-weight-bold mb-1">Coding system</h3>
+        </dt>
+        <dd class="pb-2 border-bottom">{{ clv.coding_system.name }}</dd>
+
+        <dt>
+          <h3 class="h6 font-weight-bold">Coding system release</h3>
+        </dt>
+        <dd class="pb-2 border-bottom">{{ clv.coding_system.release_name }}</dd>
+
+        {% if clv.compatible_releases.exists %}
+          <details>
+            <summary>Show other compatible releases</summary>
+            <ul>
+              {% for release in clv.compatible_releases.all %}
+                <li><small>{{ release.release_name }} ({{ release.valid_from|date:'Y-m-d'}})</small></li>
+              {% endfor %}
+            </ul>
+          </details>
+        {% endif %}
+
+        {% if codelist.organisation %}
+          <dt>
+            <h3 class="h6 font-weight-bold">Organisation</h3>
+          </dt>
+          <dd class="pb-2 border-bottom">{{ codelist.organisation.name }}</dd>
+        {% endif %}
+
+        <dt>
+          <h3 class="h6 font-weight-bold">Codelist ID</h3>
+        </dt>
+        <dd class="pb-2 border-bottom">{{ codelist.full_slug }}</dd>
+
+        {% if clv.tag %}
+          <dt>
+            <h3 class="h6 font-weight-bold">Version Tag</h3>
+          </dt>
+          <dd class="pb-2 border-bottom">{{ clv.tag }}</dd>
+        {% endif %}
+
+        <dt>
+          <h3 class="h6 font-weight-bold">Version ID</h3>
+        </dt>
+        <dd class="pb-2 border-bottom">{{ clv.hash }}</dd>
+      </dl>
+
+      {% if user_can_edit %}
+        <div class="btn-group-vertical btn-block" role="group">
+          <a
+            class="btn btn-outline-primary btn-block"
+            href="{{ codelist.get_update_url }}">
+            Edit metadata
+          </a>
+        </div>
+
+        <hr />
+
+        <form method="POST" action={{ clv.get_create_url }}>
+          {% csrf_token %}
+          <div class="btn-group-vertical btn-block" role="group">
+            {% if codelist.is_new_style %}
+              {% if can_create_new_version %}
+                <input type="hidden" name="coding_system_database_alias" value="" />
+                <button
+                  type="submit"
+                  class="btn btn-outline-primary btn-block">
+                  Create new version
+                </button>
+              {% else %}
+                <button
+                  type="button"
+                  class="disabled btn btn-outline-secondary btn-block"
+                  aria-disabled="true"
+                  data-toggle="tooltip"
+                  title="This codelist already has a draft version">
+                  Create new version
+                </button>
+              {% endif %}
+            {% else %}
+              <a
+                class="btn btn-outline-primary btn-block"
+                href="{{ codelist.get_version_upload_url }}">
+                Upload new version
+              </a>
+            {% endif %}
+
+            {% if clv.is_under_review %}
+              <button
+                type="button"
+                class="btn btn-outline-primary btn-block"
+                data-toggle="modal"
+                data-target="#js-publish-version-form">
+                Publish version
+              </button>
+              <button
+                type="button"
+                class="btn btn-outline-primary btn-block"
+                data-toggle="modal"
+                data-target="#js-delete-version-form">
+                Delete version
               </button>
             {% else %}
               <button
@@ -157,150 +189,115 @@
                 class="disabled btn btn-outline-secondary btn-block"
                 aria-disabled="true"
                 data-toggle="tooltip"
-                title="This codelist already has a draft version">
-                Create new version
+                title="This version has already been published">
+                Publish version
+              </button>
+              <button
+                type="button"
+                class="disabled btn btn-outline-secondary btn-block"
+                aria-disabled="true"
+                data-toggle="tooltip"
+                title="This version has already been published, so cannot be deleted">
+                Delete version
               </button>
             {% endif %}
-          {% else %}
-          <a
-            class="btn btn-outline-primary btn-block"
-            href="{{ codelist.get_version_upload_url }}">
-            Upload new version
-          </a>
-          {% endif %}
+          </div>
+        </form>
+      {% endif %}
 
-          {% if clv.is_under_review %}
-            <button
-              type="button"
-              class="btn btn-outline-primary btn-block"
-              data-toggle="modal"
-              data-target="#js-publish-version-form">
-              Publish version
-            </button>
-            <button
-              type="button"
-              class="btn btn-outline-primary btn-block"
-              data-toggle="modal"
-              data-target="#js-delete-version-form">
-              Delete version
-            </button>
-          {% else %}
-            <button
-              type="button"
-              class="disabled btn btn-outline-secondary btn-block"
-              aria-disabled="true"
-              data-toggle="tooltip"
-              title="This version has already been published">
-              Publish version
-            </button>
-            <button
-              type="button"
-              class="disabled btn btn-outline-secondary btn-block"
-              aria-disabled="true"
-              data-toggle="tooltip"
-              title="This version has already been published, so cannot be deleted">
-              Delete version
-            </button>
-          {% endif %}
+      <div class="card">
+        <div class="card-header p-2">
+          <h2 class="h5 mb-0">Versions</h2>
         </div>
-      </form>
-    {% endif %}
+        <ul class="list-group list-group-flush sidebar-versions">
+          {% for version in versions %}
+            <li class="list-group-item px-2 py-3">
+              {% if version.is_under_review %}
+                <span class="badge badge-primary">Review</span>
+              {% elif version.is_draft %}
+                <span class="badge badge-primary">Draft</span>
+              {% endif %}
 
-    <hr />
-
-    <div class="card">
-      <div class="card-header px-2 py-3">
-        <h2 class="h5 mb-0">Versions</h2>
-      </div>
-      <ul class="list-group list-group-flush sidebar-versions">
-        {% for version in versions %}
-          <li class="list-group-item px-2 py-3">
-            {% if version.is_under_review %}
-              <span class="badge badge-primary">Review</span>
-            {% elif version.is_draft %}
-              <span class="badge badge-primary">Draft</span>
-            {% endif %}
-
-            <span class="d-block pb-1">
-              <code class="font-weight-bold text-body">
-                {% if version == clv %}
-                  {{ version.tag_or_hash }}
-                {% else %}
-                  <a class="text-monospace" href="{{ version.get_absolute_url }}">
+              <span class="d-block pb-1">
+                <code class="font-weight-bold text-body">
+                  {% if version == clv %}
                     {{ version.tag_or_hash }}
-                  </a>
-                {% endif %}
-              </code>
-            </span>
+                  {% else %}
+                    <a class="text-monospace" href="{{ version.get_absolute_url }}">
+                      {{ version.tag_or_hash }}
+                    </a>
+                  {% endif %}
+                </code>
+              </span>
 
-            <span class="updated d-block pt-1">
-              <span>
-                Updated:
+              <span class="updated d-block pt-1">
+                <span>
+                  Updated:
+                </span>
+                <span class="d-block">
+                  {{ version.updated_at | date:'Y-m-d H:i:s' }}
+                </span>
               </span>
-              <span class="d-block">
-                {{ version.updated_at | date:'Y-m-d H:i:s' }}
-              </span>
-            </span>
-          </li>
-        {% endfor %}
+            </li>
+          {% endfor %}
+        </ul>
+      </div>
+    </div>
+
+    <div class="col-md-9">
+      <ul id="tab-list" class="nav nav-tabs" role="tablist">
+        {% include "./_tab_nav.html" with label="About" tabname="about" active=True %}
+
+        {% include "./_tab_nav.html" with label="Full list" tabname="full-list" %}
+
+        {% if tree_tables %}
+          {% include "./_tab_nav.html" with label="Tree" tabname="tree" %}
+        {% endif %}
+
+        {% if search_results %}
+          {% include "./_tab_nav.html" with label="Searches" tabname="search-results" %}
+        {% endif %}
       </ul>
+
+      <div class="tab-content d-flex flex-column h-100">
+        {% include "./_tab_pane.html" with tabname="about" partial="codelists/_about_tab.html" active=True %}
+
+        {% include "./_tab_pane.html" with tabname="full-list" partial="codelists/_full_list_tab.html" %}
+
+        {% if tree_tables %}
+          {% include "./_tab_pane.html" with tabname="tree" partial="codelists/_tree_tables_tab.html" %}
+        {% endif %}
+
+        {% if search_results %}
+          {% include "./_tab_pane.html" with tabname="search-results" partial="codelists/_search_results_tab.html" %}
+        {% endif %}
+      </div>
     </div>
   </div>
 
-  <div class="col-md-9 col-lg-10">
-    <ul id="tab-list" class="nav nav-tabs" role="tablist">
-      {% include "./_tab_nav.html" with label="About" tabname="about" active=True %}
+  {% include "./_are_you_sure_modal.html" with action="publish" title="Publish Version" url=clv.get_publish_url message="Publishing a version is irreversible, and will delete any other draft versions or versions under review." submit_text="Publish" %}
 
-      {% include "./_tab_nav.html" with label="Full list" tabname="full-list" %}
-
-      {% if tree_tables %}
-      {% include "./_tab_nav.html" with label="Tree" tabname="tree" %}
-      {% endif %}
-
-      {% if search_results %}
-      {% include "./_tab_nav.html" with label="Searches" tabname="search-results" %}
-      {% endif %}
-    </ul>
-
-    <div class="tab-content d-flex flex-column h-100">
-      {% include "./_tab_pane.html" with tabname="about" partial="codelists/_about_tab.html" active=True %}
-
-      {% include "./_tab_pane.html" with tabname="full-list" partial="codelists/_full_list_tab.html" %}
-
-      {% if tree_tables %}
-      {% include "./_tab_pane.html" with tabname="tree" partial="codelists/_tree_tables_tab.html" %}
-      {% endif %}
-
-      {% if search_results %}
-      {% include "./_tab_pane.html" with tabname="search-results" partial="codelists/_search_results_tab.html" %}
-      {% endif %}
-    </div>
-  </div>
-</div>
-
-{% include "./_are_you_sure_modal.html" with action="publish" title="Publish Version" url=clv.get_publish_url message="Publishing a version is irreversible, and will delete any other draft versions or versions under review." submit_text="Publish" %}
-
-{% include "./_are_you_sure_modal.html" with action="delete" title="Delete Version" url=clv.get_delete_url message="Deleting a version is irreversible." submit_text="Delete" %}
+  {% include "./_are_you_sure_modal.html" with action="delete" title="Delete Version" url=clv.get_delete_url message="Deleting a version is irreversible." submit_text="Delete" %}
 
 {% endblock %}
 
 {% block extra_js %}
-{% vite_asset "assets/src/scripts/codelists-version.js" %}
+  {% vite_asset "assets/src/scripts/codelists-version.js" %}
 
-{{ child_map|json_script:"child-map" }}
-{{ parent_map|json_script:"parent-map" }}
-{{ tree_tables|json_script:"tree-tables" }}
-{{ code_to_term|json_script:"code-to-term" }}
-{{ code_to_status|json_script:"code-to-status" }}
+  {{ child_map|json_script:"child-map" }}
+  {{ parent_map|json_script:"parent-map" }}
+  {{ tree_tables|json_script:"tree-tables" }}
+  {{ code_to_term|json_script:"code-to-term" }}
+  {{ code_to_status|json_script:"code-to-status" }}
 
-{% if debug %}
-<script type="module" nonce="{{ request.csp_nonce }}">
-  import RefreshRuntime from 'http://localhost:5173/static/@react-refresh'
-  RefreshRuntime.injectIntoGlobalHook(window)
-  window.$RefreshReg$ = () => {}
-  window.$RefreshSig$ = () => (type) => type
-  window.__vite_plugin_react_preamble_installed__ = true
-</script>
-{% endif %}
-{% vite_asset "assets/src/scripts/tree/index.jsx" %}
+  {% if debug %}
+    <script type="module" nonce="{{ request.csp_nonce }}">
+      import RefreshRuntime from 'http://localhost:5173/static/@react-refresh'
+      RefreshRuntime.injectIntoGlobalHook(window)
+      window.$RefreshReg$ = () => {}
+      window.$RefreshSig$ = () => (type) => type
+      window.__vite_plugin_react_preamble_installed__ = true
+    </script>
+  {% endif %}
+  {% vite_asset "assets/src/scripts/tree/index.jsx" %}
 {% endblock %}

--- a/templates/codelists/version_diff.html
+++ b/templates/codelists/version_diff.html
@@ -6,7 +6,7 @@
 
 <div class="row">
         <div class="col-md-3 col-lg-2">
-                <dl>
+                <dl class="break-word">
                         <dt>LHS</dt>
                         <dd>{{ lhs.full_slug }}</dd>
                         <dt>RHS</dt>

--- a/templates/codelists/version_diff.html
+++ b/templates/codelists/version_diff.html
@@ -4,84 +4,84 @@
 {% block title_extra %}: Diff between two codelists{% endblock %}
 
 {% block full_width_content %}
-<h1 class="h3 border-bottom mb-3 pb-2">Diff view</h1>
+  <h1 class="h3 border-bottom mb-3 pb-2">Diff view</h1>
 
-<div class="row">
-        <div class="col-md-3">
-                <dl class="break-word">
-                        <dt>LHS</dt>
-                        <dd>{{ lhs.full_slug }}</dd>
-                        <dt>RHS</dt>
-                        <dd>{{ rhs.full_slug }}</dd>
-                        <dt>Coding System</dt>
-                        <dd>{{ lhs.coding_system.short_name }}</dd>
-                        <dt>LHS Coding System Release</dt>
-                        <dd>{{ lhs.coding_system.release }}</dd>
-                        <dt>RHS Coding System Release</dt>
-                        <dd>{{ rhs.coding_system.release }}</dd>
-                        <dt>Codes in LHS</dt>
-                        <dd>{{ lhs_codes|length }}</dd>
-                        <dt>Codes in LHS only</dt>
-                        <dd>{{ lhs_only_codes|length }}</dd>
-                        <dt>Codes in RHS</dt>
-                        <dd>{{ rhs_codes|length }}</dd>
-                        <dt>Codes in RHS only</dt>
-                        <dd>{{ rhs_only_codes|length }}</dd>
-                        <dt>Codes in common</dt>
-                        <dd>{{ common_codes|length }}</dd>
-                </dl>
-        </div>
-        <div class="col">
-                {% if lhs_only_codes %}
-                <h2>Codes in LHS only</h2>
-                <ul>
-                {% for record in lhs_only_summary %}
-                <li>
-                        {{ record.term }} (<code>{{ record.code }}</code>)
-                        {% if record.descendants %}with these descendants{% endif %}
-                </li>
-                <ul>
-                {% for descendant in record.descendants %}
+  <div class="row">
+    <div class="col-md-3">
+      <dl class="break-word">
+        <dt>LHS</dt>
+        <dd>{{ lhs.full_slug }}</dd>
+        <dt>RHS</dt>
+        <dd>{{ rhs.full_slug }}</dd>
+        <dt>Coding System</dt>
+        <dd>{{ lhs.coding_system.short_name }}</dd>
+        <dt>LHS Coding System Release</dt>
+        <dd>{{ lhs.coding_system.release }}</dd>
+        <dt>RHS Coding System Release</dt>
+        <dd>{{ rhs.coding_system.release }}</dd>
+        <dt>Codes in LHS</dt>
+        <dd>{{ lhs_codes|length }}</dd>
+        <dt>Codes in LHS only</dt>
+        <dd>{{ lhs_only_codes|length }}</dd>
+        <dt>Codes in RHS</dt>
+        <dd>{{ rhs_codes|length }}</dd>
+        <dt>Codes in RHS only</dt>
+        <dd>{{ rhs_only_codes|length }}</dd>
+        <dt>Codes in common</dt>
+        <dd>{{ common_codes|length }}</dd>
+      </dl>
+    </div>
+    <div class="col">
+      {% if lhs_only_codes %}
+        <h2>Codes in LHS only</h2>
+        <ul>
+          {% for record in lhs_only_summary %}
+            <li>
+              {{ record.term }} (<code>{{ record.code }}</code>)
+              {% if record.descendants %}with these descendants{% endif %}
+            </li>
+            <ul>
+              {% for descendant in record.descendants %}
                 <li>{{ descendant.term }} (<code>{{ descendant.code }}</code>)</li>
-                {% endfor %}
-                </ul>
-                {% endfor %}
-                </ul>
-                {% endif %}
+              {% endfor %}
+            </ul>
+          {% endfor %}
+        </ul>
+      {% endif %}
 
-                {% if rhs_only_codes %}
-                <h2>Codes in RHS only</h2>
-                <ul>
-                {% for record in rhs_only_summary %}
-                <li>
-                        {{ record.term }} (<code>{{ record.code }}</code>)
-                        {% if record.descendants %}with these descendants{% endif %}
-                </li>
-                <ul>
-                {% for descendant in record.descendants %}
+      {% if rhs_only_codes %}
+        <h2>Codes in RHS only</h2>
+        <ul>
+          {% for record in rhs_only_summary %}
+            <li>
+              {{ record.term }} (<code>{{ record.code }}</code>)
+              {% if record.descendants %}with these descendants{% endif %}
+            </li>
+            <ul>
+              {% for descendant in record.descendants %}
                 <li>{{ descendant.term }} (<code>{{ descendant.code }}</code>)</li>
-                {% endfor %}
-                </ul>
-                {% endfor %}
-                </ul>
-                {% endif %}
+              {% endfor %}
+            </ul>
+          {% endfor %}
+        </ul>
+      {% endif %}
 
-                <h2>Codes in common</h2>
-                <ul>
-                {% for record in common_summary %}
-                <li>
-                        {{ record.term }} (<code>{{ record.code }}</code>)
-                        {% if record.descendants %}with these descendants{% endif %}
-                </li>
-                <ul>
-                {% for descendant in record.descendants %}
-                <li>{{ descendant.term }} (<code>{{ descendant.code }}</code>)</li>
-                {% endfor %}
-                </ul>
-                {% endfor %}
-                </ul>
-        </div>
-</div>
+      <h2>Codes in common</h2>
+      <ul>
+        {% for record in common_summary %}
+          <li>
+            {{ record.term }} (<code>{{ record.code }}</code>)
+            {% if record.descendants %}with these descendants{% endif %}
+          </li>
+          <ul>
+            {% for descendant in record.descendants %}
+              <li>{{ descendant.term }} (<code>{{ descendant.code }}</code>)</li>
+            {% endfor %}
+          </ul>
+        {% endfor %}
+      </ul>
+    </div>
+  </div>
 
 
 {% endblock %}

--- a/templates/codelists/version_diff.html
+++ b/templates/codelists/version_diff.html
@@ -1,11 +1,13 @@
 {% extends 'base.html' %}
 {% load static %}
 
-{% block content %}
-<h1>Diff view</h1>
+{% block title_extra %}: Diff between two codelists{% endblock %}
+
+{% block full_width_content %}
+<h1 class="h3 border-bottom mb-3 pb-2">Diff view</h1>
 
 <div class="row">
-        <div class="col-md-3 col-lg-2">
+        <div class="col-md-3">
                 <dl class="break-word">
                         <dt>LHS</dt>
                         <dd>{{ lhs.full_slug }}</dd>

--- a/templates/codelists/version_diff.html
+++ b/templates/codelists/version_diff.html
@@ -31,6 +31,7 @@
         <dd>{{ common_codes|length }}</dd>
       </dl>
     </div>
+
     <div class="col">
       {% if lhs_only_codes %}
         <h2>Codes in LHS only</h2>
@@ -38,13 +39,15 @@
           {% for record in lhs_only_summary %}
             <li>
               {{ record.term }} (<code>{{ record.code }}</code>)
-              {% if record.descendants %}with these descendants{% endif %}
+              {% if record.descendants %}
+                with these descendants
+                <ul>
+                  {% for descendant in record.descendants %}
+                    <li>{{ descendant.term }} (<code>{{ descendant.code }}</code>)</li>
+                  {% endfor %}
+                </ul>
+              {% endif %}
             </li>
-            <ul>
-              {% for descendant in record.descendants %}
-                <li>{{ descendant.term }} (<code>{{ descendant.code }}</code>)</li>
-              {% endfor %}
-            </ul>
           {% endfor %}
         </ul>
       {% endif %}
@@ -55,13 +58,15 @@
           {% for record in rhs_only_summary %}
             <li>
               {{ record.term }} (<code>{{ record.code }}</code>)
-              {% if record.descendants %}with these descendants{% endif %}
+              {% if record.descendants %}
+                with these descendants
+                <ul>
+                  {% for descendant in record.descendants %}
+                    <li>{{ descendant.term }} (<code>{{ descendant.code }}</code>)</li>
+                  {% endfor %}
+                </ul>
+              {% endif %}
             </li>
-            <ul>
-              {% for descendant in record.descendants %}
-                <li>{{ descendant.term }} (<code>{{ descendant.code }}</code>)</li>
-              {% endfor %}
-            </ul>
           {% endfor %}
         </ul>
       {% endif %}
@@ -71,17 +76,17 @@
         {% for record in common_summary %}
           <li>
             {{ record.term }} (<code>{{ record.code }}</code>)
-            {% if record.descendants %}with these descendants{% endif %}
+            {% if record.descendants %}
+              with these descendants
+              <ul>
+                {% for descendant in record.descendants %}
+                  <li>{{ descendant.term }} (<code>{{ descendant.code }}</code>)</li>
+                {% endfor %}
+              </ul>
+            {% endif %}
           </li>
-          <ul>
-            {% for descendant in record.descendants %}
-              <li>{{ descendant.term }} (<code>{{ descendant.code }}</code>)</li>
-            {% endfor %}
-          </ul>
         {% endfor %}
       </ul>
     </div>
   </div>
-
-
 {% endblock %}


### PR DESCRIPTION
## Commits

- **Create full_width_content block**
  - This allows the normal content to fit to the Bootstrap standard container, whilst allowing wider content to extend to a maximum width of `1536px` (as per Tailwind CSS we use elsewhere)
- **Add break-word CSS utility**
  - Allow URLs and long strings without spaces to break over lines in the sidebar (see diff page images below)
- **Improve diff view layout**
  - Add a meta title
  - Use the wide container
  - Allow the left column to use more space at large screen widths
- **Update the codelist builder layout to full width**
  - Add a meta title
  - Use the wide container
  - Allow the left column to use more space at large screen widths
  - Allow right column to overflow in the X axis, rather than overflowing the page
  - Add break-word utility class
- **Update codelist version to full width**
  - Use the wide container
  - Allow the left column to use more space at large screen widths
  - Add break-word utility class
- **Use djhtml to format templates**
  - This is so that the templates use the same spacing for future diffs
  - We can add this to the `format` and `check` steps once the majority of templates have been updated
- **Fix invalid list item nesting in diff view**
  - List items were not correctly indented properly causing lots and lots of empty `<ul>`s to be generated
    - This ends up removing about 30% of the HTML nodes on the page
- **General**
  - Remove `<hr>` tags where possible
  - Fix whitespace issues

## Before

<img src="https://github.com/user-attachments/assets/c94e165f-a9f0-49cc-9613-eb4e7fd1e55e" width="600" />

<img src="https://github.com/user-attachments/assets/c6517dbb-5525-4143-a767-18dcfbd0bd21" width="600" />

<img src="https://github.com/user-attachments/assets/7fa82b07-ba6c-42e6-8e3b-197febe633c0" width="600" />

## After

<img src="https://github.com/user-attachments/assets/ea294808-6f79-4b48-96c6-5d6d31f312b1" width="600" />

<img src="https://github.com/user-attachments/assets/87bba0f8-8ef2-42da-9371-f2a7b8cf17e8" width="600" />

<img src="https://github.com/user-attachments/assets/2f0b1617-21a0-4cd3-89a9-098d17cf7ba4" width="600" />