### PR TITLE
Bump python-dotenv from 1.0.0 to 1.0.1

### DIFF
--- a/requirements.prod.txt
+++ b/requirements.prod.txt
@@ -590,9 +590,9 @@ protobuf==4.22.1 \
     # via
     #   googleapis-common-protos
     #   opentelemetry-proto
-python-dotenv==1.0.0 \
-    --hash=sha256:a8df96034aae6d2d50a4ebe8216326c61c3eb64836776504fcca410e5937a3ba \
-    --hash=sha256:f5971a9226b701070a4bf2c38c89e5a3f0d64de8debda981d1db98583009122a
+python-dotenv==1.0.1 \
+    --hash=sha256:e324ee90a023d808f1959c46bcbc04446a10ced277783dc6ee09987c37ec10ca \
+    --hash=sha256:f7b63ef50f1b690dddf550d03497b66d609393b40b564ed0d674909a68ebf16a
     # via environs
 python-ipware==3.0.0 \
     --hash=sha256:9117b1c4dddcb5d5ca49e6a9617de2fc66aec2ef35394563ac4eecabdf58c062 \


### PR DESCRIPTION
This is a transitive dependency of environs, which we've already updated.