### PR TITLE
Take backups via `sqlite ".backup"`

### DIFF
--- a/DEPLOY.md
+++ b/DEPLOY.md
@@ -66,7 +66,7 @@ Check cron tasks:
 dokku$ dokku cron:list opencodelists
 ```
 
-Backups are saved to `/var/lib/dokku/data/storage/opencodelists` on dokku3.
+Backups are saved to `/var/lib/dokku/data/storage/opencodelists/backup` on dokku3.
 
 ### Manually deploying
 

--- a/deploy/bin/backup.sh
+++ b/deploy/bin/backup.sh
@@ -1,17 +1,32 @@
 #!/bin/bash
 
-set -euo pipefail
+set -euxo pipefail
 
+# We are changing the backup format and where they are stored. We want to
+# retain 30 days of backups across both locations and formats. Once there
+# are none of the old format remaining, this can be updated to just refer
+# to the new location.
 REPO_ROOT="/app"
-BACKUP_DIR="/storage"
+ORIGINAL_BACKUP_DIR="/storage"
+BACKUP_DIR="$ORIGINAL_BACKUP_DIR/backup/db"
 
-python \
-"$REPO_ROOT"/manage.py \
-dumpdata \
-builder codelists opencodelists \
---indent 2 \
---verbosity 0 \
---output "${BACKUP_DIR}/core-data-$(date +%F).json.gz"
+# Make the backup dir if it doesn't exist.
+mkdir "$BACKUP_DIR" -p
 
-# Keep only the last 30 backups
-find "$BACKUP_DIR" -name "core-data-*.json.gz" | sort | head -n -30 | xargs rm
+# Take a datestamped backup.
+BACKUP_FILENAME="$BACKUP_DIR/$(date +%F)-db.sqlite3"
+sqlite3 "$REPO_ROOT/db.sqlite3" ".backup $BACKUP_FILENAME"
+
+# Compress the latest backup.
+gzip -f "$BACKUP_FILENAME"
+
+# Symlink to the new latest backup to make it easy to discover.
+ln -sf "$BACKUP_FILENAME.gz" "$BACKUP_DIR/latest-db.sqlite3.gz"
+
+# Keep only the last 30 days of backups.
+# For now, apply this to both the original backup dir with backups based on the
+# Django dumpdata management command and the new dir with backups based on
+# sqlite .backup. Once there are none of the former remaining, the first line can be
+# removed, along with most of this comment.
+find "$ORIGINAL_BACKUP_DIR" -name "core-data-*.json.gz" -type f -mtime +30 -exec rm {} \;
+find "$BACKUP_DIR" -name "*-db.sqlite3.gz" -type f -mtime +30 -exec rm {} \;


### PR DESCRIPTION
Partially addresses #2151. ADR about the core backup strategy will be in a separate PR.

Taking backups via the sqlite CLI is simple and clean. We can restore from them.

We haven't been able to locally restore from the `dumpdata` fixtures-based backups. For now, keep the old-format backups just in case we want to try again to restore from them. After 30 days of creating new backups we can update the script to not consider the old format and location.

See [these comments](https://github.com/opensafely-core/opencodelists/issues/2151#issuecomment-2517804854) about the execution time and file system space requirements.