### PR TITLE
Tidy some stray references to CodingSystemVersion.

### DIFF
--- a/coding_systems/versioning/tests/test_database_routing.py
+++ b/coding_systems/versioning/tests/test_database_routing.py
@@ -28,7 +28,7 @@ def test_coding_system_routing_errors_if_no_using_db_specified(coding_system):
 
 def test_mismatched_coding_system_database_relations(coding_systems_tmp_path):
     # Relations are only allowed if the database matches
-    # (Note Mapping instances are an exception; see db_utils.CodingSystemVersionRouter)
+    # (Note Mapping instances are an exception; see db_utils.CodingSystemReleaseRouter)
 
     # make another ctv3 db connection
     CodingSystemRelease.objects.create(

--- a/opencodelists/tests/fixtures.py
+++ b/opencodelists/tests/fixtures.py
@@ -167,7 +167,7 @@ def build_fixture(fixture_name):
 @pytest.fixture(scope="session")
 def setup_coding_systems(django_db_setup, django_db_blocker):
     with django_db_blocker.unblock():
-        # load the CodingSystemVersions needed for the snomed and dmd fixtures
+        # load the CodingSystemReleases needed for the snomed and dmd fixtures
         call_command(
             "loaddata",
             CODING_SYSTEM_RELEASES_FIXTURES_PATH / "coding_system_releases.json",


### PR DESCRIPTION
Tidy up some stray references to make it clearer to what they refer. CodingSystemVersion was re-named to CodingSystemRelease in migration [`coding_systems/versioning/migrations/0002_rename_codingsystemversion_codingsystemrelease.py`](https://github.com/opensafely-core/opencodelists/blob/main/coding_systems/versioning/migrations/0002_rename_codingsystemversion_codingsystemrelease.py).