### PR TITLE
Make DB backup symlink relative

### DIFF
--- a/deploy/bin/backup.sh
+++ b/deploy/bin/backup.sh
@@ -14,13 +14,16 @@ BACKUP_DIR="$ORIGINAL_BACKUP_DIR/backup/db"
 mkdir "$BACKUP_DIR" -p
 
 # Take a datestamped backup.
-BACKUP_FILENAME="$BACKUP_DIR/$(date +%F)-db.sqlite3"
-sqlite3 "$REPO_ROOT/db.sqlite3" ".backup $BACKUP_FILENAME"
+BACKUP_FILENAME="$(date +%F)-db.sqlite3"
+BACKUP_FILEPATH="$BACKUP_DIR/$BACKUP_FILENAME"
+sqlite3 "$REPO_ROOT/db.sqlite3" ".backup $BACKUP_FILEPATH"
 
 # Compress the latest backup.
-gzip -f "$BACKUP_FILENAME"
+gzip -f "$BACKUP_FILEPATH"
 
 # Symlink to the new latest backup to make it easy to discover.
+# Make the target a relative path -- an absolute one won't mean the same thing
+# in the host file system if executed inside a container as we expect.
 ln -sf "$BACKUP_FILENAME.gz" "$BACKUP_DIR/latest-db.sqlite3.gz"
 
 # Keep only the last 30 days of backups.


### PR DESCRIPTION
Refines #2214 and partially addresses #2151.

Make the target a relative path -- an absolute one won't mean the same thing in the host file system if executed inside a container as we expect.

For example, when this ran in production as scheduled the first time I realized the symlink refers to `/storage/` which doesn't work in the host file system -- and therefore can't be easily used over SCP for example:

```
mikerkelly@dokku3:~$ ls /var/lib/dokku/data/storage/opencodelists/backup/db/ -lrth
total 4.0K
-rw-r--r-- 1 opencodelists opencodelists 114 Dec 12 01:00 2024-12-12-db.sqlite3.gz
lrwxrwxrwx 1 opencodelists opencodelists  43 Dec 12 01:00 latest-db.sqlite3.gz -> /storage/backup/db/2024-12-12-db.sqlite3.gz

```

Be slightly more precise about what's a file "name" vs file "path".