### PR TITLE
Switch from Dependabot to update-dependencies-action

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,19 +1,6 @@
 version: 2
 
 updates:
-  - package-ecosystem: "pip"
-    directory: "/"
-    schedule:
-      interval: "weekly"
-      day: "monday"
-      time: "08:00"
-      timezone: "Europe/London"
-    open-pull-requests-limit: 20
-    # Can remove the ignore for pip upgrades when this pip-tools issue is resolved:
-    # https://github.com/jazzband/pip-tools/issues/2131
-    ignore:
-      - dependency-name: "pip"
-        versions: [ ">=24.3" ]
   - package-ecosystem: "npm"
     directory: "/"
     schedule:

--- a/.github/workflows/update-python-dependencies.yml
+++ b/.github/workflows/update-python-dependencies.yml
@@ -1,0 +1,26 @@
+name: Update Python dependencies
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron:  "12 6 * * *"
+
+jobs:
+  update-dependencies:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - uses: "opensafely-core/setup-action@v1"
+      with:
+        python-version: "3.12"
+        install-just: true
+
+    - uses: actions/create-github-app-token@v1
+      id: generate-token
+      with:
+        app-id: 1031449  # opensafely-core Create PR app
+        private-key: ${{ secrets.CREATE_PR_APP_PRIVATE_KEY }}
+
+    - uses: opensafely-core/update-dependencies-action@v1
+      with:
+        token: ${{ steps.generate-token.outputs.token }}

--- a/.github/workflows/update-python-dependencies.yml
+++ b/.github/workflows/update-python-dependencies.yml
@@ -3,7 +3,7 @@ name: Update Python dependencies
 on:
   workflow_dispatch:
   schedule:
-    - cron:  "12 6 * * *"
+    - cron:  "12 6 * * 1"
 
 jobs:
   update-dependencies:

--- a/justfile
+++ b/justfile
@@ -115,6 +115,14 @@ upgrade env package="": virtualenv
     FORCE=true {{ just_executable() }} requirements-{{ env }} $opts
 
 
+# Upgrade all dev and prod dependencies.
+# This is the default input command to update-dependencies action
+# https://github.com/opensafely-core/update-dependencies-action
+update-dependencies:
+    just upgrade prod
+    just upgrade dev
+
+
 # *ARGS is variadic, 0 or more. This allows us to do `just test -k match`, for example.
 # Run the python tests
 test-py *ARGS: devenv

--- a/requirements.prod.in
+++ b/requirements.prod.in
@@ -7,7 +7,7 @@ antlr4-python3-runtime
 beautifulsoup4
 bleach
 crispy-bootstrap4
-django
+django~=4.2
 djangorestframework
 django-anymail[mailgun]
 django-crispy-forms


### PR DESCRIPTION
Fixes #2165.

This also pins Django to 4.2 LTS, for now, until we resolve issues in upgrading and test a later release.