### PR TITLE
Fix location of DB to take backup from

### DIFF
--- a/deploy/bin/backup.sh
+++ b/deploy/bin/backup.sh
@@ -9,13 +9,16 @@ BACKUP_DIR="$STORAGE_ROOT/backup/db"
 mkdir "$BACKUP_DIR" -p
 
 # Take a datestamped backup.
-BACKUP_FILENAME="$BACKUP_DIR/$(date +%F)-db.sqlite3"
-sqlite3 "$STORAGE_ROOT/db.sqlite3" ".backup $BACKUP_FILENAME"
+BACKUP_FILENAME="$(date +%F)-db.sqlite3"
+BACKUP_FILEPATH="$BACKUP_DIR/$BACKUP_FILENAME"
+sqlite3 "$STORAGE_ROOT/db.sqlite3" ".backup $BACKUP_FILEPATH"
 
 # Compress the latest backup.
-gzip -f "$BACKUP_FILENAME"
+gzip -f "$BACKUP_FILEPATH"
 
 # Symlink to the new latest backup to make it easy to discover.
+# Make the target a relative path -- an absolute one won't mean the same thing
+# in the host file system if executed inside a container as we expect.
 ln -sf "$BACKUP_FILENAME.gz" "$BACKUP_DIR/latest-db.sqlite3.gz"
 
 # Keep only the last 30 days of backups.

--- a/deploy/bin/backup.sh
+++ b/deploy/bin/backup.sh
@@ -2,20 +2,15 @@
 
 set -euxo pipefail
 
-# We are changing the backup format and where they are stored. We want to
-# retain 30 days of backups across both locations and formats. Once there
-# are none of the old format remaining, this can be updated to just refer
-# to the new location.
-REPO_ROOT="/app"
-ORIGINAL_BACKUP_DIR="/storage"
-BACKUP_DIR="$ORIGINAL_BACKUP_DIR/backup/db"
+STORAGE_ROOT="/storage"
+BACKUP_DIR="$STORAGE_ROOT/backup/db"
 
 # Make the backup dir if it doesn't exist.
 mkdir "$BACKUP_DIR" -p
 
 # Take a datestamped backup.
 BACKUP_FILENAME="$BACKUP_DIR/$(date +%F)-db.sqlite3"
-sqlite3 "$REPO_ROOT/db.sqlite3" ".backup $BACKUP_FILENAME"
+sqlite3 "$STORAGE_ROOT/db.sqlite3" ".backup $BACKUP_FILENAME"
 
 # Compress the latest backup.
 gzip -f "$BACKUP_FILENAME"
@@ -28,5 +23,5 @@ ln -sf "$BACKUP_FILENAME.gz" "$BACKUP_DIR/latest-db.sqlite3.gz"
 # Django dumpdata management command and the new dir with backups based on
 # sqlite .backup. Once there are none of the former remaining, the first line can be
 # removed, along with most of this comment.
-find "$ORIGINAL_BACKUP_DIR" -name "core-data-*.json.gz" -type f -mtime +30 -exec rm {} \;
+find "$STORAGE_ROOT" -name "core-data-*.json.gz" -type f -mtime +30 -exec rm {} \;
 find "$BACKUP_DIR" -name "*-db.sqlite3.gz" -type f -mtime +30 -exec rm {} \;

--- a/deploy/bin/backup.sh
+++ b/deploy/bin/backup.sh
@@ -2,8 +2,8 @@
 
 set -euxo pipefail
 
-STORAGE_ROOT="/storage"
-BACKUP_DIR="$STORAGE_ROOT/backup/db"
+# DATABASE_DIR is configured via dokku (see DEPLOY.md)
+BACKUP_DIR="$DATABASE_DIR/backup/db"
 
 # Make the backup dir if it doesn't exist.
 mkdir "$BACKUP_DIR" -p
@@ -11,7 +11,7 @@ mkdir "$BACKUP_DIR" -p
 # Take a datestamped backup.
 BACKUP_FILENAME="$(date +%F)-db.sqlite3"
 BACKUP_FILEPATH="$BACKUP_DIR/$BACKUP_FILENAME"
-sqlite3 "$STORAGE_ROOT/db.sqlite3" ".backup $BACKUP_FILEPATH"
+sqlite3 "$DATABASE_DIR/db.sqlite3" ".backup $BACKUP_FILEPATH"
 
 # Compress the latest backup.
 gzip -f "$BACKUP_FILEPATH"
@@ -26,5 +26,5 @@ ln -sf "$BACKUP_FILENAME.gz" "$BACKUP_DIR/latest-db.sqlite3.gz"
 # Django dumpdata management command and the new dir with backups based on
 # sqlite .backup. Once there are none of the former remaining, the first line can be
 # removed, along with most of this comment.
-find "$STORAGE_ROOT" -name "core-data-*.json.gz" -type f -mtime +30 -exec rm {} \;
+find "$DATABASE_DIR" -name "core-data-*.json.gz" -type f -mtime +30 -exec rm {} \;
 find "$BACKUP_DIR" -name "*-db.sqlite3.gz" -type f -mtime +30 -exec rm {} \;


### PR DESCRIPTION
Fixes #2214, which was broken. 

Within the container, /app/db.sqlite3 is an apparently empty DB, /storage/db.sqlite3 is the actual app DB of several GB. I'm not sure why the former exists. But this script was backing that up, not the intended DB.

For example, when this ran in production as scheduled the first time the produced backup file is only a few tens of bytes in size.

```
mikerkelly@dokku3:~$ ls /var/lib/dokku/data/storage/opencodelists/backup/db/ -lrth
total 4.0K
-rw-r--r-- 1 opencodelists opencodelists 114 Dec 12 01:00 2024-12-12-db.sqlite3.gz
```