### PR TITLE
Use encodeURI to interpret passed URL strings

### DIFF
--- a/assets/src/scripts/components/CodelistBuilder.jsx
+++ b/assets/src/scripts/components/CodelistBuilder.jsx
@@ -174,7 +174,7 @@ class CodelistBuilder extends React.Component {
                   {this.props.searches.some((search) => search.active) ? (
                     <a
                       className="list-group-item list-group-item-action py-1 font-italic"
-                      href={this.props.draftURL}
+                      href={encodeURI(this.props.draftURL)}
                     >
                       show all
                     </a>

--- a/assets/src/scripts/components/Search.jsx
+++ b/assets/src/scripts/components/Search.jsx
@@ -37,7 +37,7 @@ function Search({ search }) {
           ? "list-group-item list-group-item-action active py-1 px-2"
           : "list-group-item list-group-item-action py-1 px-2 "
       }
-      href={search.url}
+      href={encodeURI(search.url)}
     >
       {search.term_or_code}
     </a>

--- a/assets/src/scripts/components/SearchForm.jsx
+++ b/assets/src/scripts/components/SearchForm.jsx
@@ -4,7 +4,7 @@ import { getCookie } from "../_utils";
 
 function SearchForm({ codingSystemName, searchURL }) {
   return (
-    <form action={searchURL} method="post">
+    <form action={encodeURI(searchURL)} method="post">
       <div className="form-group">
         <input
           name="csrfmiddlewaretoken"

--- a/assets/src/scripts/components/Version.jsx
+++ b/assets/src/scripts/components/Version.jsx
@@ -7,7 +7,7 @@ function Version({ version }) {
       {version.current ? (
         version.tag_or_hash
       ) : (
-        <a href={version.url}>{version.tag_or_hash}</a>
+        <a href={encodeURI(version.url)}>{version.tag_or_hash}</a>
       )}
 
       {version.status === "draft" ? (


### PR DESCRIPTION
Fixes DOM text reinterpreted as HTML issues found by CodeQL.

> The encodeURI() function encodes a [URI](https://developer.mozilla.org/en-US/docs/Glossary/URI) by replacing each instance of certain characters by one, two, three, or four escape sequences representing the [UTF-8](https://developer.mozilla.org/en-US/docs/Glossary/UTF-8) encoding of the character (will only be four escape sequences for characters composed of two surrogate characters).
>
> &mdash; [MDN Source](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/encodeURI)