### PR TITLE
Unit test and fix bnfdmd downloader

### DIFF
--- a/mappings/bnfdmd/data_downloader.py
+++ b/mappings/bnfdmd/data_downloader.py
@@ -124,7 +124,7 @@ class Downloader:
         metadata = self.get_latest_release_metadata()
 
         if glob.glob(os.path.join(self.release_dir, metadata["filename"])):
-            return
+            raise ValueError("Latest release already exists")
 
         local_download_filepath = Path(self.release_dir) / metadata["filename"]
         self.get_file(metadata["url"], local_download_filepath)

--- a/mappings/bnfdmd/tests/conftest.py
+++ b/mappings/bnfdmd/tests/conftest.py
@@ -1,5 +1,6 @@
 from pathlib import Path
 from unittest.mock import patch
+from urllib.parse import quote
 
 import pytest
 import responses
@@ -12,31 +13,43 @@ MOCK_BNFDMD_IMPORT_DATA_PATH = (
     / "BNF Snomed Mapping data 20241119.zip"
 )
 
-
-def add_response(rsps, filename, release_date):
-    rsps.add(
-        responses.GET,
-        "https://www.nhsbsa.nhs.uk/prescription-data/understanding-our-data/bnf-snomed-mapping",
-        body=f"""
-            <p><a href="/sites/default/files/{release_date}/{filename.replace(' ','%20')}">January 2024 (ZIP file: 16.76MB)</a></p>
-            <p><a href="/sites/default/files/2023-01/BNF%20Snomed%20Mapping%20data%2020230116.zip">January 2023 (ZIP file: 16.76MB)</a></p>
-        """,
-        status=200,
-    )
+MOCK_FILENAME = "BNF Snomed Mapping data 20240101.zip"
+MOCK_QUOTED_FILENAME = quote(MOCK_FILENAME)
+MOCK_FILEPATH = f"2024-01/{MOCK_QUOTED_FILENAME}"
 
 
 @pytest.fixture
-def mocked_responses():
+def mocked_responses_homepage_zipfile(mocked_responses_homepage):
+    with MOCK_BNFDMD_IMPORT_DATA_PATH.open("rb") as f:
+        mocked_responses_homepage.add(
+            responses.GET,
+            f"https://www.nhsbsa.nhs.uk/sites/default/files/{MOCK_FILEPATH}",
+            content_type="application/zip",
+            body=f,
+            status=200,
+        )
+        yield mocked_responses_homepage
+
+
+@pytest.fixture
+def mocked_responses_homepage():
     with responses.RequestsMock() as rsps:
+        rsps.add(
+            responses.GET,
+            "https://www.nhsbsa.nhs.uk/prescription-data/understanding-our-data/bnf-snomed-mapping",
+            body=f"""
+            <p><a href="/sites/default/files/{MOCK_FILEPATH}">January 2024 (ZIP file: 16.76MB)</a></p>
+            <p><a href="/sites/default/files/2023-01/BNF%20Snomed%20Mapping%20data%2020230116.zip">January 2023 (ZIP file: 16.76MB)</a></p>
+        """,
+            status=200,
+        )
         yield rsps
 
 
 @pytest.fixture
-def mock_data_download(mocked_responses):
-    filename = "BNF%20Snomed%20Mapping%20data%2020240101.zip"
-    add_response(mocked_responses, filename, "2024-01")
+def mock_data_download(mocked_responses_homepage):
     with patch(
         "mappings.bnfdmd.data_downloader.Downloader.get_file",
-        return_value=filename,
+        return_value=MOCK_QUOTED_FILENAME,
     ):
         yield

--- a/mappings/bnfdmd/tests/test_data_downloader.py
+++ b/mappings/bnfdmd/tests/test_data_downloader.py
@@ -1,0 +1,19 @@
+import pytest
+
+from mappings.bnfdmd.data_downloader import Downloader
+
+from .conftest import MOCK_FILENAME
+
+
+def test_download_latest_release(mocked_responses_homepage_zipfile, tmp_path):
+    downloader = Downloader(tmp_path)
+    release_zipfile_path, _ = downloader.download_latest_release()
+    assert release_zipfile_path.exists()
+    assert release_zipfile_path.name == MOCK_FILENAME
+
+
+def test_get_latest_release_with_existing(mocked_responses_homepage, tmp_path):
+    (tmp_path / MOCK_FILENAME).touch()
+    downloader = Downloader(tmp_path)
+    with pytest.raises(ValueError, match="Latest release already exists"):
+        downloader.download_latest_release()


### PR DESCRIPTION
download_latest_release() is the entry point for
the Downloader class that is called by the
import_latest_data management command.

This adds unit tests of that entry point given
that the latest mapping file has and has not
already been downloaded.

In case of the latter, the aforementioned
management command expects a ValueError to be
raised, this adds a test for that condition and a
fix such that the test passes.

[Sentry link for originating issue](https://ebm-datalab.sentry.io/issues/6157385078/?alert_rule_id=1877862&alert_type=issue&notification_uuid=cc036dbc-02c1-4ad9-bac6-8d0272d6e44c&project=5248013&referrer=slack)