### PR TITLE
Update to Django 5.1

### DIFF
--- a/codelists/migrations/0016_auto_20201116_1754.py
+++ b/codelists/migrations/0016_auto_20201116_1754.py
@@ -13,7 +13,7 @@ class Migration(migrations.Migration):
         migrations.AddConstraint(
             model_name="codelist",
             constraint=models.CheckConstraint(
-                check=models.Q(
+                condition=models.Q(
                     models.Q(
                         ("organisation_id__isnull", False), ("user_id__isnull", True)
                     ),

--- a/codelists/migrations/0030_auto_20210412_0947.py
+++ b/codelists/migrations/0030_auto_20210412_0947.py
@@ -23,7 +23,7 @@ class Migration(migrations.Migration):
         migrations.AddConstraint(
             model_name="search",
             constraint=models.CheckConstraint(
-                check=models.Q(
+                condition=models.Q(
                     models.Q(("code__isnull", True), ("term__isnull", False)),
                     models.Q(("code__isnull", False), ("term__isnull", True)),
                     _connector="OR",

--- a/codelists/migrations/0033_auto_20210429_1029.py
+++ b/codelists/migrations/0033_auto_20210429_1029.py
@@ -62,7 +62,7 @@ class Migration(migrations.Migration):
         migrations.AddConstraint(
             model_name="handle",
             constraint=models.CheckConstraint(
-                check=models.Q(
+                condition=models.Q(
                     models.Q(
                         ("organisation_id__isnull", False), ("user_id__isnull", True)
                     ),

--- a/codelists/models.py
+++ b/codelists/models.py
@@ -231,7 +231,7 @@ class Handle(models.Model):
         constraints = [
             models.CheckConstraint(
                 name="%(app_label)s_%(class)s_organisation_xor_user",
-                check=(
+                condition=(
                     models.Q(organisation_id__isnull=False, user_id__isnull=True)
                     | models.Q(user_id__isnull=False, organisation_id__isnull=True)
                 ),
@@ -963,7 +963,7 @@ class Search(models.Model):
         constraints = [
             models.CheckConstraint(
                 name="%(app_label)s_%(class)s_term_xor_code",
-                check=(
+                condition=(
                     models.Q(term__isnull=False, code__isnull=True)
                     | models.Q(code__isnull=False, term__isnull=True)
                 ),

--- a/coding_systems/base/tests/dynamic_db_classes.py
+++ b/coding_systems/base/tests/dynamic_db_classes.py
@@ -1,0 +1,126 @@
+import pytest
+from django.test import TestCase
+
+from codelists.coding_systems import CODING_SYSTEMS
+
+
+class DynamicDatabaseTestCase(TestCase):
+    """A `django.test.TestCase` subclass to facilitate use of a dynamically
+    created database.
+
+    This class is necessary because some coding system tests currently use
+    dynamically created databases at test time. Django 5.1 changed its behaviour
+    such that the databases to be used must be specified when defining the test,
+    and raises a `DatabaseOperationForbidden` error when accessing non-specified
+    database.
+
+    This class therefore allows additional database aliases to be specified,
+    and modifies the `databases` attribute accordingly.
+
+    For a more in-depth discussion, refer to the relevant issue:
+    https://github.com/opensafely-core/opencodelists/issues/2115
+
+    Also see the Django pull request that changed the Django behaviour:
+    https://github.com/django/django/pull/17639
+
+    import_data_path: name of the path to import data used, str or None
+    """
+
+    @property
+    def db_alias(self):
+        """The database alias that needs to be accessed in this test class, str."""
+        raise NotImplementedError(
+            "This test class requires a database alias to be set."
+        )
+
+    import_data_path = None
+
+    def add_to_testcase_allowed_db_aliases(self, *db_aliases):
+        """Add database names to the test instance's allowed database aliases.
+
+        This mutates the *class* state by changing the `databases` attribute.
+        The `databases` attribute determines which databases
+        the `SimpleTestCase.ensure_connection_patch_method` allow connections to.
+
+        This is used to allow access to dynamically generated databases that
+        are creating during, and accessed in, tests.
+
+        Note that we cannot patch this directly in a test case:
+        pytest constructs its own dynamic test class based on the test case
+        class defined in the test module, rather than instantiating an instance
+        of that class directly.
+
+        On first run, the originally allowed databases are recorded,
+        for later restoration with `restore_original_testcase_db_aliases`.
+
+        See https://docs.djangoproject.com/en/5.1/topics/testing/tools/#multi-database-support
+        for details of the `databases` attribute being modified."""
+        try:
+            getattr(self, "original_databases")
+        except AttributeError:
+            # Record the original state, so we can later restore it.
+            self.original_databases = type(self).databases
+
+        type(self).databases |= frozenset({*db_aliases})
+
+    def restore_original_testcase_db_aliases(self):
+        """Restore the original `databases` attribute on the test case.
+
+        `add_to_testcase_allowed_db_aliases` must have been run at least once.
+
+        This removes any dynamic database that we have added to the test class.
+        Django doesn't know how to roll back when the transaction wrapping the
+        test case ends.
+
+        It is not necessary to remove the database as the temp dir is scoped
+        by test case."""
+        type(self).databases = self.original_databases
+
+    def setUp(self):
+        super().setUp()
+
+        self.add_to_testcase_allowed_db_aliases(self, self.db_alias)
+
+    def tearDown(self):
+        self.restore_original_testcase_db_aliases()
+
+        super().tearDown()
+
+
+class DynamicDatabaseTestCaseWithTmpPath(DynamicDatabaseTestCase):
+    """A DynamicDatabaseTestCase subclass to facilitate use of a dynamically created database,
+    for a subset of the coding systems tests that use the
+    `coding_systems_tmp_path fixture` in `conftest.py`.
+
+    That fixture creates temporary directories for *all* coding systems.
+
+    coding_system_subpath_name: name of the coding system, that should be the same
+    as the temporary database subpath in use for the test, str or None
+    """
+
+    @property
+    def coding_system_subpath_name(self):
+        # The db_alias that will be added temporarily to the DB.
+        raise NotImplementedError(
+            "This test class requires a coding system subpath name to be set."
+        )
+
+    @pytest.fixture(autouse=True)
+    def _get_tmp_path(self, coding_systems_tmp_path):
+        """Runs the fixture that creates a temporary path."""
+
+        # The `coding_systems_tmp_path_fixture` creates directories
+        # based on CODING_SYSTEMS.keys().
+        # We can catch if a test has which paths are not allowed.
+        allowed_coding_systems = CODING_SYSTEMS.keys()
+        if self.coding_system_subpath_name not in allowed_coding_systems:
+            raise ValueError(
+                "The specified coding_system_subpath is not found in codelists.coding_systems.CODING_SYSTEMS."
+            )
+
+        self.coding_systems_tmp_path = coding_systems_tmp_path
+        self.expected_db_path = (
+            self.coding_systems_tmp_path
+            / f"{self.coding_system_subpath_name}"
+            / f"{self.db_alias}.sqlite3"
+        )

--- a/coding_systems/base/tests/test_import_data_utils.py
+++ b/coding_systems/base/tests/test_import_data_utils.py
@@ -9,13 +9,14 @@ from codelists.coding_systems import CODING_SYSTEMS
 from codelists.hierarchy import Hierarchy
 from codelists.models import Status
 from coding_systems.base.import_data_utils import update_codelist_version_compatibility
+from coding_systems.base.tests.dynamic_db_classes import DynamicDatabaseTestCase
 from coding_systems.bnf.models import Concept
 from coding_systems.conftest import mock_migrate_coding_system
 from coding_systems.versioning.models import CodingSystemRelease, ReleaseState
 
 
 @pytest.fixture
-def bnf_csr():
+def _bnf_csr():
     def _csr(valid_from=datetime(2022, 11, 1)):
         return CodingSystemRelease.objects.create(
             coding_system="bnf",
@@ -28,13 +29,93 @@ def bnf_csr():
 
 
 @pytest.fixture
-def bnf_review_version_with_search(bnf_version_with_search):
+def _bnf_review_version_with_search(bnf_version_with_search):
     bnf_version_with_search.status = Status.UNDER_REVIEW
     bnf_version_with_search.save()
     yield bnf_version_with_search
 
 
-def setup_db(csr, exclude_last_concept=False):
+class BaseCodingSystemDynamicDatabaseTestCase(DynamicDatabaseTestCase):
+    @pytest.fixture
+    def _get_bnf_release(self, _bnf_release):
+        self.bnf_release = _bnf_release
+
+    @pytest.fixture
+    def _bnf_release(self, _bnf_csr):
+        # This addition of a allowed database alias needs to be done
+        # *before* the class's setUp() runs.
+        # This fixture is run before setUp() and
+        # other fixtures required by this fixture access the database.
+        self.add_to_testcase_allowed_db_aliases(self.db_alias)
+
+        # setup the database as a duplicate of the fixture one
+        csr = _bnf_csr()
+        _setup_db(csr)
+        yield csr
+        _cleanup_db(csr)
+
+    @pytest.fixture
+    def _get_bnf_release_excl_last_concept(self, _bnf_release_excl_last_concept):
+        self.bnf_release = _bnf_release_excl_last_concept
+
+    @pytest.fixture
+    def _bnf_release_excl_last_concept(self, _bnf_csr):
+        # This addition of a allowed database alias needs to be done
+        # *before* the class's setUp() runs.
+        # This fixture is run before setUp() and
+        # other fixtures required by this fixture access the database.
+        self.add_to_testcase_allowed_db_aliases(self.db_alias)
+
+        # setup the database as a duplicate of the fixture one, omitting the last concept
+        csr = _bnf_csr(datetime(2022, 10, 1))
+        _setup_db(csr, exclude_last_concept=True)
+        yield csr
+        _cleanup_db(csr)
+
+    @pytest.fixture
+    def _bnf_releases(self, _bnf_csr):
+        db_alias_additions = [
+            "bnf_import-data_20190101",
+            "bnf_import-data_20220901",
+            "bnf_import-data_20221201",
+        ]
+        # This addition of a allowed database alias needs to be done
+        # *before* the class's setUp() runs.
+        # This fixture is run before setUp() and
+        # other fixtures required by this fixture access the database.
+        self.add_to_testcase_allowed_db_aliases(*db_alias_additions)
+
+        # setup multiple databases as duplicates of the fixture one, with different dates
+
+        # earlier than the release the codelist versions are created with
+        csr_20190101 = _bnf_csr(datetime(2019, 1, 1))
+        _setup_db(csr_20190101)
+        # earlier than bnf_release_excl_last_concept
+        csr_20220901 = _bnf_csr(datetime(2022, 9, 1))
+        _setup_db(csr_20220901)
+        # later than bnf_release_excl_last_concept
+        csr_20221201 = _bnf_csr(datetime(2022, 12, 1))
+        _setup_db(csr_20221201)
+
+        yield
+
+        for csr in [csr_20190101, csr_20220901, csr_20221201]:
+            _cleanup_db(csr)
+
+    @pytest.fixture
+    def _get_bnf_version_with_search(self, bnf_version_with_search):
+        self.bnf_version_with_search = bnf_version_with_search
+
+    @pytest.fixture
+    def _get_bnf_review_version_with_search(self, _bnf_review_version_with_search):
+        self.bnf_review_version_with_search = _bnf_review_version_with_search
+
+    @pytest.fixture
+    def _get_bnf_version_asthma(self, bnf_version_asthma):
+        self.bnf_version_asthma = bnf_version_asthma
+
+
+def _setup_db(csr, exclude_last_concept=False):
     # At this point, the test databases have been configured as in-memory sqlite dbs
     # we copy the default db config and update the name (which in tests is something
     # like "file:memorydb_default?mode=memory&cache=shared" rather than a path to a
@@ -59,166 +140,158 @@ def setup_db(csr, exclude_last_concept=False):
         )
 
 
-def cleanup_db(csr):
+def _cleanup_db(csr):
     # The in-memory db doesn't get automatically removed, so manually drop the
     # tables for the next test
     with connections[csr.database_alias].cursor() as cursor:
         cursor.execute("DROP TABLE bnf_concept")
 
 
-@pytest.fixture
-def bnf_release(bnf_csr):
-    # setup the database as a duplicate of the fixture one
-    csr = bnf_csr()
-    setup_db(csr)
-    yield csr
-    cleanup_db(csr)
-
-
-@pytest.fixture
-def bnf_release_excl_last_concept(bnf_csr):
-    # setup the database as a duplicate of the fixture one, omitting the last concept
-    csr = bnf_csr(datetime(2022, 10, 1))
-    setup_db(csr, exclude_last_concept=True)
-    yield csr
-    cleanup_db(csr)
-
-
-@pytest.fixture
-def bnf_releases(bnf_csr):
-    # setup multiple databases as duplicates of the fixture one, with different dates
-
-    # earlier than the release the codelist versions are created with
-    csr_20190101 = bnf_csr(datetime(2019, 1, 1))
-    setup_db(csr_20190101)
-    # earlier than bnf_release_excl_last_concept
-    csr_20220901 = bnf_csr(datetime(2022, 9, 1))
-    setup_db(csr_20220901)
-    # later than bnf_release_excl_last_concept
-    csr_20221201 = bnf_csr(datetime(2022, 12, 1))
-    setup_db(csr_20221201)
-
-    yield
-
-    for csr in [csr_20190101, csr_20220901, csr_20221201]:
-        cleanup_db(csr)
-
-
-def test_update_codelist_version_compatibility_no_searches(
-    bnf_version_asthma, coding_systems_tmp_path, bnf_release
+class TestUpdateCodelistVersionCompatibilityNoSearches(
+    BaseCodingSystemDynamicDatabaseTestCase
 ):
-    # Draft versions are not checked for compatibility; this version is under review
-    assert bnf_version_asthma.status == Status.PUBLISHED
-    update_codelist_version_compatibility("bnf", bnf_release.database_alias)
-    # this version has no searches, but its hierarchy is identical
-    assert bnf_version_asthma.compatible_releases.exists()
+    db_alias = "bnf_import-data_20221101"
+
+    @pytest.mark.usefixtures("_get_bnf_release", "_get_bnf_version_asthma")
+    def test_update_codelist_version_compatibility_no_searches(self):
+        # Draft versions are not checked for compatibility; this version is under review
+        assert self.bnf_version_asthma.status == Status.PUBLISHED
+        update_codelist_version_compatibility("bnf", self.bnf_release.database_alias)
+        # this version has no searches, but its hierarchy is identical
+        assert self.bnf_version_asthma.compatible_releases.exists()
 
 
-def test_update_codelist_draft_version_excluded(
-    bnf_version_with_search, coding_systems_tmp_path, bnf_release
+class TestUpdateCodelistVersionDraftVersionExcluded(
+    BaseCodingSystemDynamicDatabaseTestCase
 ):
-    assert bnf_version_with_search.status == Status.DRAFT
-    update_codelist_version_compatibility("bnf", bnf_release.database_alias)
-    # this version has an identical hierarchy, and its search will return the same
-    # results with the new release, so it is compatible
-    assert not bnf_version_with_search.compatible_releases.exists()
+    db_alias = "bnf_import-data_20221101"
+
+    @pytest.mark.usefixtures("_get_bnf_release", "_get_bnf_version_with_search")
+    def test_update_codelist_draft_version_excluded(self):
+        assert self.bnf_version_with_search.status == Status.DRAFT
+        update_codelist_version_compatibility("bnf", self.bnf_release.database_alias)
+        # this version has an identical hierarchy, and its search will return the same
+        # results with the new release, so it is compatible
+        assert not self.bnf_version_with_search.compatible_releases.exists()
 
 
-def test_update_codelist_version_with_search(
-    bnf_review_version_with_search, coding_systems_tmp_path, bnf_release
+class TestUpdateCodelistVersionWithSearch(BaseCodingSystemDynamicDatabaseTestCase):
+    db_alias = "bnf_import-data_20221101"
+
+    @pytest.mark.usefixtures("_get_bnf_release", "_get_bnf_review_version_with_search")
+    def test_update_codelist_version_with_search(self):
+        assert self.bnf_review_version_with_search.status == Status.UNDER_REVIEW
+        update_codelist_version_compatibility("bnf", self.bnf_release.database_alias)
+        # this version has an identical hierarchy, and its search will return the same
+        # results with the new release, so it is compatible
+        assert (
+            self.bnf_review_version_with_search.compatible_releases.first()
+            == self.bnf_release
+        )
+
+
+class TestUpdateCodelistVersionCompatibilityWithMismatchedSearch(
+    BaseCodingSystemDynamicDatabaseTestCase
 ):
-    assert bnf_review_version_with_search.status == Status.UNDER_REVIEW
-    update_codelist_version_compatibility("bnf", bnf_release.database_alias)
-    # this version has an identical hierarchy, and its search will return the same
-    # results with the new release, so it is compatible
-    assert bnf_review_version_with_search.compatible_releases.first() == bnf_release
+    db_alias = "bnf_import-data_20221001"
 
-
-def test_update_codelist_version_compatibility_with_mismatched_search(
-    bnf_review_version_with_search,
-    coding_systems_tmp_path,
-    bnf_release_excl_last_concept,
-):
-    # setup the db, but omit the last Concept from the existing db, so the search
-    # will return different results
-    update_codelist_version_compatibility(
-        "bnf", bnf_release_excl_last_concept.database_alias
+    @pytest.mark.usefixtures(
+        "_get_bnf_release_excl_last_concept", "_get_bnf_review_version_with_search"
     )
-    # this version has a search, but the new release returns different results,
-    # so it is not compatible
-    assert not bnf_review_version_with_search.compatible_releases.exists()
+    def test_update_codelist_version_compatibility_with_mismatched_search(self):
+        # setup the db, but omit the last Concept from the existing db, so the search
+        # will return different results
+        update_codelist_version_compatibility("bnf", self.bnf_release.database_alias)
+        # this version has a search, but the new release returns different results,
+        # so it is not compatible
+        assert not self.bnf_review_version_with_search.compatible_releases.exists()
 
 
-def test_update_codelist_version_compatibility_with_search_but_mismatched_hierarchy(
-    bnf_review_version_with_search,
-    coding_systems_tmp_path,
-    bnf_release_excl_last_concept,
+class TestUpdateCodelistVersionCompatibilityWithSearchButMismatchedHierarchy(
+    BaseCodingSystemDynamicDatabaseTestCase
 ):
-    # setup the db, but omit the last Concept from the existing db
-    # Modify the search so that it returns just one code; the hierarchy will differ but
-    # search results will remain the same
-    bnf_review_version_with_search.searches.all().delete()
-    create_search(
-        draft=bnf_review_version_with_search,
-        code="0301012A0AAABAB",
-        codes=["0301012A0AAABAB"],
+    db_alias = "bnf_import-data_20221001"
+
+    @pytest.mark.usefixtures(
+        "_get_bnf_release_excl_last_concept", "_get_bnf_review_version_with_search"
     )
+    def test_update_codelist_version_compatibility_with_search_but_mismatched_hierarchy(
+        self,
+    ):
+        # setup the db, but omit the last Concept from the existing db
+        # Modify the search so that it returns just one code; the hierarchy will differ but
+        # search results will remain the same
+        self.bnf_review_version_with_search.searches.all().delete()
+        create_search(
+            draft=self.bnf_review_version_with_search,
+            code="0301012A0AAABAB",
+            codes=["0301012A0AAABAB"],
+        )
 
-    existing_hierarchy = bnf_review_version_with_search.hierarchy
-    hierarchy_with_new_release = Hierarchy.from_codes(
-        coding_system=CODING_SYSTEMS["bnf"](
-            database_alias=bnf_release_excl_last_concept.database_alias
-        ),
-        codes=["0301012A0AAABAB"],
-    )
-    assert existing_hierarchy.nodes != hierarchy_with_new_release.nodes
+        existing_hierarchy = self.bnf_review_version_with_search.hierarchy
+        hierarchy_with_new_release = Hierarchy.from_codes(
+            coding_system=CODING_SYSTEMS["bnf"](
+                database_alias=self.bnf_release.database_alias
+            ),
+            codes=["0301012A0AAABAB"],
+        )
+        assert existing_hierarchy.nodes != hierarchy_with_new_release.nodes
 
-    update_codelist_version_compatibility(
-        "bnf", bnf_release_excl_last_concept.database_alias
-    )
-    # this version has a search that returns identical results in the new release
-    # but the hierarchies differ, so it is not compatible
-    assert not bnf_review_version_with_search.compatible_releases.exists()
+        update_codelist_version_compatibility("bnf", self.bnf_release.database_alias)
+        # this version has a search that returns identical results in the new release
+        # but the hierarchies differ, so it is not compatible
+        assert not self.bnf_review_version_with_search.compatible_releases.exists()
 
 
-def test_save_codelist_draft_updates_compatibility(
-    bnf_version_with_search, coding_systems_tmp_path, bnf_release
+class TestSaveCodelistDraftUpdatesCompatibility(
+    BaseCodingSystemDynamicDatabaseTestCase
 ):
-    assert bnf_version_with_search.status == Status.DRAFT
-    assert not bnf_version_with_search.compatible_releases.exists()
-    save_draft_for_review(draft=bnf_version_with_search)
+    db_alias = "bnf_import-data_20221001"
 
-    assert bnf_version_with_search.compatible_releases.exists()
+    @pytest.mark.usefixtures("_get_bnf_release", "_get_bnf_version_with_search")
+    def test_save_codelist_draft_updates_compatibility(self):
+        assert self.bnf_version_with_search.status == Status.DRAFT
+        assert not self.bnf_version_with_search.compatible_releases.exists()
+        save_draft_for_review(draft=self.bnf_version_with_search)
+
+        assert self.bnf_version_with_search.compatible_releases.exists()
 
 
-def test_save_codelist_draft_updates_compatibility_multiple_releases(
-    bnf_version_with_search,
-    coding_systems_tmp_path,
-    bnf_releases,
-    bnf_release_excl_last_concept,
+# This test is particularly unusual compared with the other coding systems
+# tests that use dynamic databases, in that multiple databases are used.
+class TestSaveCodelistDraftUpdatesCompatibilityMultipleReleases(
+    BaseCodingSystemDynamicDatabaseTestCase
 ):
-    # In this test, we have a draft created with release `bnf_test_20200101`
-    # The `bnf_releases` fixture gives us 3 other releases, which are duplicates
-    # of the data in `bnf_test_20200101`, so would all be compatible
-    # These have dates 20190901, 20221001, 20221201
-    # bnf_release_excl_last_concept is not compatible, and has date 20221101
+    db_alias = "bnf_import-data_20190101"
 
-    # When the draft version is saved for review, releases with more recent valid_from
-    # dates are checked for compatibility in order from oldest to newest. If a release
-    # is found to be incompatible, no later releases are checked.
-    #
-    # i.e. for this draft, releases are checked in this order:
-    # (bnf_import-data_20190901 is skipped because it's earlier than the draft's cs release)
-    # 1) bnf_import-data_20220901: compatible
-    # 2) bnf_import-data_20221101: incompatible
-    # 3) bnf_import-data_20221201: compatible (but later than an incompatible release, so not checked)
-
-    assert bnf_version_with_search.status == Status.DRAFT
-    assert not bnf_version_with_search.compatible_releases.exists()
-    save_draft_for_review(draft=bnf_version_with_search)
-
-    assert bnf_version_with_search.compatible_releases.count() == 1
-    assert (
-        bnf_version_with_search.compatible_releases.first().database_alias
-        == "bnf_import-data_20220901"
+    @pytest.mark.usefixtures(
+        "_bnf_releases",
+        "_get_bnf_release_excl_last_concept",
+        "_get_bnf_version_with_search",
     )
+    def test_save_codelist_draft_updates_compatibility_multiple_releases(self):
+        # In this test, we have a draft created with release `bnf_test_20200101`
+        # The `bnf_releases` fixture gives us 3 other releases, which are duplicates
+        # of the data in `bnf_test_20200101`, so would all be compatible
+        # These have dates 20190901, 20221001, 20221201
+        # bnf_release_excl_last_concept is not compatible, and has date 20221101
+
+        # When the draft version is saved for review, releases with more recent valid_from
+        # dates are checked for compatibility in order from oldest to newest. If a release
+        # is found to be incompatible, no later releases are checked.
+        #
+        # i.e. for this draft, releases are checked in this order:
+        # (bnf_import-data_20190901 is skipped because it's earlier than the draft's cs release)
+        # 1) bnf_import-data_20220901: compatible
+        # 2) bnf_import-data_20221101: incompatible
+        # 3) bnf_import-data_20221201: compatible (but later than an incompatible release, so not checked)
+
+        assert self.bnf_version_with_search.status == Status.DRAFT
+        assert not self.bnf_version_with_search.compatible_releases.exists()
+        save_draft_for_review(draft=self.bnf_version_with_search)
+
+        assert self.bnf_version_with_search.compatible_releases.count() == 1
+        assert (
+            self.bnf_version_with_search.compatible_releases.first().database_alias
+            == "bnf_import-data_20220901"
+        )

--- a/coding_systems/ctv3/tests/test_import_data.py
+++ b/coding_systems/ctv3/tests/test_import_data.py
@@ -32,7 +32,7 @@ def mock_migrate():
 
 class TestImportData(DynamicDatabaseTestCase):
     db_alias = "ctv3_v1_20221001"
-    import_data_path = str(MOCK_CTV3_IMPORT_DATA_PATH)
+    import_data_path = MOCK_CTV3_IMPORT_DATA_PATH
 
     def test_import_data(self):
         cs_release_count = CodingSystemRelease.objects.count()
@@ -85,7 +85,7 @@ class TestImportData(DynamicDatabaseTestCase):
 
 class TestImportErrorExistingRelease(DynamicDatabaseTestCaseWithTmpPath):
     db_alias = "ctv3_v_error_20221001"
-    import_data_path = str(MOCK_CTV3_IMPORT_DATA_PATH)
+    import_data_path = MOCK_CTV3_IMPORT_DATA_PATH
     coding_system_subpath_name = "ctv3"
 
     def test_import_error_existing_release(self):

--- a/coding_systems/ctv3/tests/test_import_data.py
+++ b/coding_systems/ctv3/tests/test_import_data.py
@@ -3,9 +3,14 @@ from pathlib import Path
 from unittest.mock import patch
 
 import pytest
+from django.conf import settings
 
 from codelists.coding_systems import CODING_SYSTEMS
 from codelists.hierarchy import Hierarchy
+from coding_systems.base.tests.dynamic_db_classes import (
+    DynamicDatabaseTestCase,
+    DynamicDatabaseTestCaseWithTmpPath,
+)
 from coding_systems.conftest import mock_migrate_coding_system
 from coding_systems.ctv3.import_data import import_data
 from coding_systems.ctv3.models import RawConcept, TPPConcept
@@ -25,92 +30,101 @@ def mock_migrate():
         yield
 
 
-def test_import_data(coding_systems_tmp_path, settings):
-    cs_release_count = CodingSystemRelease.objects.count()
+class TestImportData(DynamicDatabaseTestCase):
+    db_alias = "ctv3_v1_20221001"
+    import_data_path = str(MOCK_CTV3_IMPORT_DATA_PATH)
 
-    # import mock CTV3 data
-    # This consists of a very small subset of the hierarchy for Extrinsic asthma - atopy (& pollen)(XE0ZP)
-    # Plus codes for types and root concept
+    def test_import_data(self):
+        cs_release_count = CodingSystemRelease.objects.count()
 
-    # ...../Xa001/Xa003 Root Concept/Type
-    # Xa00B Clinical findings type
-    # XaBVJ Clinical findings
-    # X0003  └ Disorders
-    # H....     └ Respiratory disorder
-    # H33..        └ Asthma
-    # X101x           └ Allergic asthma
-    # XE0YQ               └ Allergic atopic asthma
-    # XE0ZP                   └ Extrinsic asthma - atopy (& pollen)
+        # import mock CTV3 data
+        # This consists of a very small subset of the hierarchy for Extrinsic asthma - atopy (& pollen)(XE0ZP)
+        # Plus codes for types and root concept
 
-    # And mock TPP data
-    # Consists of the same codes and their hierarchy
+        # ...../Xa001/Xa003 Root Concept/Type
+        # Xa00B Clinical findings type
+        # XaBVJ Clinical findings
+        # X0003  └ Disorders
+        # H....     └ Respiratory disorder
+        # H33..        └ Asthma
+        # X101x           └ Allergic asthma
+        # XE0YQ               └ Allergic atopic asthma
+        # XE0ZP                   └ Extrinsic asthma - atopy (& pollen)
 
-    import_data(
-        str(MOCK_CTV3_IMPORT_DATA_PATH),
-        release_name="v1",
-        valid_from=date(2022, 10, 1),
-        import_ref="Ref",
-    )
-    # A new CodingSystemRelease has been created
-    assert CodingSystemRelease.objects.count() == cs_release_count + 1
-    cs_release = CodingSystemRelease.objects.latest("id")
-    assert cs_release.coding_system == "ctv3"
-    assert cs_release.release_name == "v1"
-    assert cs_release.valid_from == date(2022, 10, 1)
-    assert cs_release.import_ref == "Ref"
-    assert cs_release.database_alias in settings.DATABASES
+        # And mock TPP data
+        # Consists of the same codes and their hierarchy
 
-    assert RawConcept.objects.using("ctv3_v1_20221001").count() == 11
-    assert TPPConcept.objects.using("ctv3_v1_20221001").count() == 11
+        import_data(
+            self.import_data_path,
+            release_name="v1",
+            valid_from=date(2022, 10, 1),
+            import_ref="Ref",
+        )
+        # A new CodingSystemRelease has been created
+        assert CodingSystemRelease.objects.count() == cs_release_count + 1
+        cs_release = CodingSystemRelease.objects.latest("id")
+        assert cs_release.coding_system == "ctv3"
+        assert cs_release.release_name == "v1"
+        assert cs_release.valid_from == date(2022, 10, 1)
+        assert cs_release.import_ref == "Ref"
+        assert cs_release.database_alias in settings.DATABASES
 
-    # The coding system can correctly identify codes_by_type from the imported data
-    latest_coding_system = CODING_SYSTEMS["ctv3"].get_by_release_or_most_recent()
-    hierarchy = Hierarchy.from_codes(latest_coding_system, ["XE0ZP", "Xa00B"])
-    # no codes returns empty dict
-    assert latest_coding_system.codes_by_type([], hierarchy) == {}
-    # codes returned by type
-    assert latest_coding_system.codes_by_type(["XE0ZP", "X101x"], hierarchy) == {
-        "Clinical findings": ["XE0ZP", "X101x"]
-    }
+        assert RawConcept.objects.using("ctv3_v1_20221001").count() == 11
+        assert TPPConcept.objects.using("ctv3_v1_20221001").count() == 11
+
+        # The coding system can correctly identify codes_by_type from the imported data
+        latest_coding_system = CODING_SYSTEMS["ctv3"].get_by_release_or_most_recent()
+        hierarchy = Hierarchy.from_codes(latest_coding_system, ["XE0ZP", "Xa00B"])
+        # no codes returns empty dict
+        assert latest_coding_system.codes_by_type([], hierarchy) == {}
+        # codes returned by type
+        assert latest_coding_system.codes_by_type(["XE0ZP", "X101x"], hierarchy) == {
+            "Clinical findings": ["XE0ZP", "X101x"]
+        }
 
 
-def test_import_error_existing_release(coding_systems_tmp_path):
-    # set up an existing CodingSystemRelease and db file
-    cs_release = CodingSystemRelease.objects.create(
-        coding_system="ctv3",
-        release_name="v_error",
-        valid_from=date(2022, 10, 1),
-        import_ref="A first ref",
-        state=ReleaseState.READY,
-    )
-    cs_release_count = CodingSystemRelease.objects.count()
-    initial_timestamp = cs_release.import_timestamp
-    db_dir = coding_systems_tmp_path / "ctv3"
-    db_dir.mkdir(parents=True, exist_ok=True)
-    db_file = db_dir / "ctv3_v_error_20221001.sqlite3"
-    db_file.touch()
-    assert db_file.exists()
-    # raise an exception after the migrate command
-    with patch(
-        "coding_systems.ctv3.import_data.import_raw_ctv3",
-        side_effect=Exception("expected exception"),
-    ):
-        with pytest.raises(Exception, match="expected exception"):
-            import_data(
-                str(MOCK_CTV3_IMPORT_DATA_PATH),
-                release_name="v_error",
-                valid_from=date(2022, 10, 1),
-                import_ref="Ref",
-            )
+class TestImportErrorExistingRelease(DynamicDatabaseTestCaseWithTmpPath):
+    db_alias = "ctv3_v_error_20221001"
+    import_data_path = str(MOCK_CTV3_IMPORT_DATA_PATH)
+    coding_system_subpath_name = "ctv3"
 
-    # CodingSystemRelease still exists
-    assert CodingSystemRelease.objects.count() == cs_release_count
-    cs_release.refresh_from_db()
-    # import timestamp and ref remains the same as before the errored import
-    assert cs_release.import_timestamp == initial_timestamp
-    assert cs_release.import_ref == "A first ref"
+    def test_import_error_existing_release(self):
+        # set up an existing CodingSystemRelease and db file
+        cs_release = CodingSystemRelease.objects.create(
+            coding_system="ctv3",
+            release_name="v_error",
+            valid_from=date(2022, 10, 1),
+            import_ref="A first ref",
+            state=ReleaseState.READY,
+        )
+        cs_release_count = CodingSystemRelease.objects.count()
+        initial_timestamp = cs_release.import_timestamp
+        db_dir = self.coding_systems_tmp_path / "ctv3"
+        db_dir.mkdir(parents=True, exist_ok=True)
+        db_file = db_dir / "ctv3_v_error_20221001.sqlite3"
+        db_file.touch()
+        assert db_file.exists()
+        # raise an exception after the migrate command
+        with patch(
+            "coding_systems.ctv3.import_data.import_raw_ctv3",
+            side_effect=Exception("expected exception"),
+        ):
+            with pytest.raises(Exception, match="expected exception"):
+                import_data(
+                    self.import_data_path,
+                    release_name="v_error",
+                    valid_from=date(2022, 10, 1),
+                    import_ref="Ref",
+                )
 
-    # new db path still exists
-    assert db_file.exists()
-    # backup path does not exist
-    assert not (db_dir / "ctv3_v_error_20221001.sqlite3.bu").exists()
+        # CodingSystemRelease still exists
+        assert CodingSystemRelease.objects.count() == cs_release_count
+        cs_release.refresh_from_db()
+        # import timestamp and ref remains the same as before the errored import
+        assert cs_release.import_timestamp == initial_timestamp
+        assert cs_release.import_ref == "A first ref"
+
+        # new db path still exists
+        assert db_file.exists()
+        # backup path does not exist
+        assert not (db_dir / "ctv3_v_error_20221001.sqlite3.bu").exists()

--- a/coding_systems/dmd/tests/test_import_data.py
+++ b/coding_systems/dmd/tests/test_import_data.py
@@ -20,7 +20,7 @@ from .conftest import MOCK_DMD_IMPORT_DATA_PATH
 
 class TestImportData(DynamicDatabaseTestCase):
     db_alias = "dmd_2022-100_20221001"
-    import_data_path = str(MOCK_DMD_IMPORT_DATA_PATH)
+    import_data_path = MOCK_DMD_IMPORT_DATA_PATH
 
     @pytest.fixture
     def _get_dmd_version_asthma_medication(self, dmd_version_asthma_medication):
@@ -96,7 +96,7 @@ class TestImportData(DynamicDatabaseTestCase):
 
 class TestImportDataUnexpectedFile(DynamicDatabaseTestCase):
     db_alias = "dmd_2022-110_20221001"
-    import_data_path = str(MOCK_DMD_IMPORT_DATA_PATH)
+    import_data_path = MOCK_DMD_IMPORT_DATA_PATH
 
     @pytest.mark.usefixtures("mock_data_download_bad_zip")
     def test_import_data_unexpected_file(self):
@@ -117,7 +117,7 @@ class TestImportDataUnexpectedFile(DynamicDatabaseTestCase):
 
 class TestImportError(DynamicDatabaseTestCaseWithTmpPath):
     db_alias = "dmd_2022-101_20220901"
-    import_data_path = str(MOCK_DMD_IMPORT_DATA_PATH)
+    import_data_path = MOCK_DMD_IMPORT_DATA_PATH
     coding_system_subpath_name = "dmd"
 
     @pytest.mark.usefixtures("mock_data_download_error")
@@ -147,7 +147,7 @@ class TestImportError(DynamicDatabaseTestCaseWithTmpPath):
 
 class TestImportDataNoVMPPreviousMapping(DynamicDatabaseTestCase):
     db_alias = "dmd_2022-120_20221001"
-    import_data_path = str(MOCK_DMD_IMPORT_DATA_PATH)
+    import_data_path = MOCK_DMD_IMPORT_DATA_PATH
 
     @pytest.mark.usefixtures("dmd_data", "mock_data_download_no_prev_vmp")
     def test_import_data_no_vmp_previous_mapping(self):
@@ -171,7 +171,7 @@ def test_import_no_matching_release(mock_data_download):
         match="No matching release found for release unknown-release, valid from 2022-10-01",
     ):
         import_data(
-            str(MOCK_DMD_IMPORT_DATA_PATH),
+            MOCK_DMD_IMPORT_DATA_PATH,
             release_name="unknown-release",
             valid_from=date(2022, 10, 1),
         )

--- a/coding_systems/dmd/tests/test_import_data.py
+++ b/coding_systems/dmd/tests/test_import_data.py
@@ -3,7 +3,12 @@ from datetime import date
 from unittest.mock import patch
 
 import pytest
+from django.conf import settings
 
+from coding_systems.base.tests.dynamic_db_classes import (
+    DynamicDatabaseTestCase,
+    DynamicDatabaseTestCaseWithTmpPath,
+)
 from coding_systems.dmd.data_downloader import Downloader
 from coding_systems.dmd.import_data import import_data
 from coding_systems.dmd.models import AMP, AMPP, VMP, VMPP, VPI
@@ -13,129 +18,151 @@ from mappings.dmdvmpprevmap.models import Mapping as VmpPrevMapping
 from .conftest import MOCK_DMD_IMPORT_DATA_PATH
 
 
-@pytest.fixture(autouse=True)
-def coding_systems_database_tmp_dir(coding_systems_tmp_path):
-    yield coding_systems_tmp_path
+class TestImportData(DynamicDatabaseTestCase):
+    db_alias = "dmd_2022-100_20221001"
+    import_data_path = str(MOCK_DMD_IMPORT_DATA_PATH)
 
+    @pytest.fixture
+    def _get_dmd_version_asthma_medication(self, dmd_version_asthma_medication):
+        self.dmd_version_asthma_medication = dmd_version_asthma_medication
 
-def test_import_data(
-    settings, dmd_data, dmd_version_asthma_medication, mock_data_download
-):
-    cs_release_count = CodingSystemRelease.objects.count()
-    assert dmd_version_asthma_medication.cached_csv_data == {}
-
-    # import mock XML data
-    # This consists of the AMP 222311000001102 (Ventolin 100micrograms/dose Evohaler)
-    # and its related objects, including:
-    # VMP 39113611000001102 (Salbutamol 100micrograms/dose inhaler CFC free)
-    #  - this VMP has a VMPPREV id 320139002
-    # VPI (with FK to VMP)
-    # AMPP 1479411000001101
-    # VMPP 1056811000001104
-    expected_ids = {
-        AMP: "222311000001102",
-        VMP: "39113611000001102",
-        AMPP: "1479411000001101",
-        VMPP: "1056811000001104",
-    }
-
-    assert not VmpPrevMapping.objects.exists()
-
-    import_data(
-        str(MOCK_DMD_IMPORT_DATA_PATH),
-        release_name="2022 1.0.0",
-        valid_from=date(2022, 10, 1),
+    @pytest.mark.usefixtures(
+        "mock_data_download", "dmd_data", "_get_dmd_version_asthma_medication"
     )
+    def test_import_data(self):
+        cs_release_count = CodingSystemRelease.objects.count()
+        assert self.dmd_version_asthma_medication.cached_csv_data == {}
 
-    # A new CodingSystemRelease has been created
-    assert CodingSystemRelease.objects.count() == cs_release_count + 1
-    cs_release = CodingSystemRelease.objects.latest("id")
-    assert cs_release.coding_system == "dmd"
-    assert cs_release.release_name == "2022 1.0.0"
-    assert cs_release.valid_from == date(2022, 10, 1)
-    # no import ref, defaults to zipfile name
-    assert cs_release.import_ref == "nhsbsa_dmd_1.0.0_20221001000001.zip"
+        # import mock XML data
+        # This consists of the AMP 222311000001102 (Ventolin 100micrograms/dose Evohaler)
+        # and its related objects, including:
+        # VMP 39113611000001102 (Salbutamol 100micrograms/dose inhaler CFC free)
+        #  - this VMP has a VMPPREV id 320139002
+        # VPI (with FK to VMP)
+        # AMPP 1479411000001101
+        # VMPP 1056811000001104
+        expected_ids = {
+            AMP: "222311000001102",
+            VMP: "39113611000001102",
+            AMPP: "1479411000001101",
+            VMPP: "1056811000001104",
+        }
 
-    assert cs_release.database_alias in settings.DATABASES
+        assert not VmpPrevMapping.objects.exists()
 
-    for model, expected_id in expected_ids.items():
-        assert model.objects.using("dmd_2022-100_20221001").count() == 1
-        assert model.objects.using("dmd_2022-100_20221001").first().pk == expected_id
-    # VPI has been imported with a FK to the VMP
-    assert VPI.objects.using("dmd_2022-100_20221001").count() == 1
-    assert (
-        VPI.objects.using("dmd_2022-100_20221001").first().vmp
-        == VMP.objects.using("dmd_2022-100_20221001").first()
-    )
-
-    # One new Mapping obj has been created, to record the previous ID for VMP
-    # 39113611000001102
-    assert VmpPrevMapping.objects.count() == 1
-    mapping = VmpPrevMapping.objects.first()
-    assert mapping.id == "39113611000001102"
-    assert mapping.vpidprev == "320139002"
-
-    # download data on existing CodelistVersions has been cached
-    dmd_version_asthma_medication.refresh_from_db()
-    assert (
-        dmd_version_asthma_medication.cached_csv_data["release"]
-        == "dmd_2022-100_20221001"
-    )
-
-
-def test_import_data_unexpected_file(mock_data_download_bad_zip):
-    cs_release_count = CodingSystemRelease.objects.count()
-    # import from a zip file that contains duplicate matches:
-    # f_lookup2_test.xml and f_lookup2_test1.xml
-    with pytest.raises(
-        AssertionError,
-        match=re.escape("Expected 1 path for f_lookup2_*.xml, found 2"),
-    ):
         import_data(
-            str(MOCK_DMD_IMPORT_DATA_PATH),
-            release_name="2022 1.1.0",
+            self.import_data_path,
+            release_name="2022 1.0.0",
             valid_from=date(2022, 10, 1),
         )
-    assert CodingSystemRelease.objects.count() == cs_release_count
 
+        # A new CodingSystemRelease has been created
+        assert CodingSystemRelease.objects.count() == cs_release_count + 1
+        cs_release = CodingSystemRelease.objects.latest("id")
+        assert cs_release.coding_system == "dmd"
+        assert cs_release.release_name == "2022 1.0.0"
+        assert cs_release.valid_from == date(2022, 10, 1)
+        # no import ref, defaults to zipfile name
+        assert cs_release.import_ref == "nhsbsa_dmd_1.0.0_20221001000001.zip"
 
-def test_import_error(coding_systems_database_tmp_dir, mock_data_download_error):
-    cs_release_count = CodingSystemRelease.objects.count()
-    # raise an exception after the migrate command; i.e after the setup that
-    # creates the CodingSystemRelease and the new db file
-    cs_release_count = CodingSystemRelease.objects.count()
-    with patch(
-        "coding_systems.dmd.import_data.import_model",
-        side_effect=Exception("expected exception"),
-    ):
-        with pytest.raises(Exception, match="expected exception"):
-            import_data(
-                str(MOCK_DMD_IMPORT_DATA_PATH),
-                release_name="2022 1.0.1",
-                valid_from=date(2022, 9, 1),
+        assert cs_release.database_alias in settings.DATABASES
+
+        for model, expected_id in expected_ids.items():
+            assert model.objects.using("dmd_2022-100_20221001").count() == 1
+            assert (
+                model.objects.using("dmd_2022-100_20221001").first().pk == expected_id
             )
+        # VPI has been imported with a FK to the VMP
+        assert VPI.objects.using("dmd_2022-100_20221001").count() == 1
+        assert (
+            VPI.objects.using("dmd_2022-100_20221001").first().vmp
+            == VMP.objects.using("dmd_2022-100_20221001").first()
+        )
 
-    # new CodingSystemRelease has been removed
-    assert CodingSystemRelease.objects.count() == cs_release_count
-    # new db path has been removed
-    assert not (
-        coding_systems_database_tmp_dir / "dmd" / "dmd_2022-100_20220901.sqlite3"
-    ).exists()
+        # One new Mapping obj has been created, to record the previous ID for VMP
+        # 39113611000001102
+        assert VmpPrevMapping.objects.count() == 1
+        mapping = VmpPrevMapping.objects.first()
+        assert mapping.id == "39113611000001102"
+        assert mapping.vpidprev == "320139002"
+
+        # download data on existing CodelistVersions has been cached
+        self.dmd_version_asthma_medication.refresh_from_db()
+        assert (
+            self.dmd_version_asthma_medication.cached_csv_data["release"]
+            == "dmd_2022-100_20221001"
+        )
 
 
-def test_import_data_no_vmp_previous_mapping(dmd_data, mock_data_download_no_prev_vmp):
-    # import mock XML data
-    # This is the same data as dmd_data.zip (see `test_import_data` above), except that
-    # VMP 39113611000001102 has no VMPPREV id
-    assert not VmpPrevMapping.objects.exists()
-    import_data(
-        str(MOCK_DMD_IMPORT_DATA_PATH),
-        release_name="2022 1.2.0",
-        valid_from=date(2022, 10, 1),
-    )
-    vmp = VMP.objects.using("dmd_2022-120_20221001").get(id="39113611000001102")
-    assert vmp.vpidprev is None
-    assert not VmpPrevMapping.objects.exists()
+class TestImportDataUnexpectedFile(DynamicDatabaseTestCase):
+    db_alias = "dmd_2022-110_20221001"
+    import_data_path = str(MOCK_DMD_IMPORT_DATA_PATH)
+
+    @pytest.mark.usefixtures("mock_data_download_bad_zip")
+    def test_import_data_unexpected_file(self):
+        cs_release_count = CodingSystemRelease.objects.count()
+        # import from a zip file that contains duplicate matches:
+        # f_lookup2_test.xml and f_lookup2_test1.xml
+        with pytest.raises(
+            AssertionError,
+            match=re.escape("Expected 1 path for f_lookup2_*.xml, found 2"),
+        ):
+            import_data(
+                self.import_data_path,
+                release_name="2022 1.1.0",
+                valid_from=date(2022, 10, 1),
+            )
+        assert CodingSystemRelease.objects.count() == cs_release_count
+
+
+class TestImportError(DynamicDatabaseTestCaseWithTmpPath):
+    db_alias = "dmd_2022-101_20220901"
+    import_data_path = str(MOCK_DMD_IMPORT_DATA_PATH)
+    coding_system_subpath_name = "dmd"
+
+    @pytest.mark.usefixtures("mock_data_download_error")
+    def test_import_error(self):
+        cs_release_count = CodingSystemRelease.objects.count()
+        # raise an exception after the migrate command; i.e after the setup that
+        # creates the CodingSystemRelease and the new db file
+        cs_release_count = CodingSystemRelease.objects.count()
+        with patch(
+            "coding_systems.dmd.import_data.import_model",
+            side_effect=Exception("expected exception"),
+        ):
+            with pytest.raises(Exception, match="expected exception"):
+                import_data(
+                    self.import_data_path,
+                    release_name="2022 1.0.1",
+                    valid_from=date(2022, 9, 1),
+                )
+
+        # new CodingSystemRelease has been removed
+        assert CodingSystemRelease.objects.count() == cs_release_count
+        # new db path has been removed
+        assert not (
+            self.coding_systems_tmp_path / "dmd" / "dmd_2022-100_20220901.sqlite3"
+        ).exists()
+
+
+class TestImportDataNoVMPPreviousMapping(DynamicDatabaseTestCase):
+    db_alias = "dmd_2022-120_20221001"
+    import_data_path = str(MOCK_DMD_IMPORT_DATA_PATH)
+
+    @pytest.mark.usefixtures("dmd_data", "mock_data_download_no_prev_vmp")
+    def test_import_data_no_vmp_previous_mapping(self):
+        # import mock XML data
+        # This is the same data as dmd_data.zip (see `test_import_data` above), except that
+        # VMP 39113611000001102 has no VMPPREV id
+        assert not VmpPrevMapping.objects.exists()
+        import_data(
+            self.import_data_path,
+            release_name="2022 1.2.0",
+            valid_from=date(2022, 10, 1),
+        )
+        vmp = VMP.objects.using("dmd_2022-120_20221001").get(id="39113611000001102")
+        assert vmp.vpidprev is None
+        assert not VmpPrevMapping.objects.exists()
 
 
 def test_import_no_matching_release(mock_data_download):

--- a/coding_systems/icd10/tests/test_import_data.py
+++ b/coding_systems/icd10/tests/test_import_data.py
@@ -2,6 +2,9 @@ from datetime import date
 from pathlib import Path
 from unittest.mock import patch
 
+from django.conf import settings
+
+from coding_systems.base.tests.dynamic_db_classes import DynamicDatabaseTestCase
 from coding_systems.conftest import mock_migrate_coding_system
 from coding_systems.icd10.import_data import import_data
 from coding_systems.icd10.models import Concept
@@ -16,57 +19,64 @@ MOCK_ICD10_IMPORT_DATA_PATH = (
 )
 
 
-def test_import_data(coding_systems_tmp_path, settings):
-    cs_release_count = CodingSystemRelease.objects.count()
+class TestImportData(DynamicDatabaseTestCase):
+    db_alias = "icd10_release-icd_20221001"
+    import_data_path = str(MOCK_ICD10_IMPORT_DATA_PATH)
 
-    # import mock XML data
-    # This consists of the just the concepts related to "Gastric ulcer", K25
-    # Chapter - XI
-    # Block - K20-31
-    # Category - K25
-    # 9 Modifiers - K25.0 - k25.9 (excl K25.8)
-    with patch(
-        "coding_systems.base.import_data_utils.call_command", mock_migrate_coding_system
-    ):
-        import_data(
-            str(MOCK_ICD10_IMPORT_DATA_PATH),
-            release_name="release ICD",
-            valid_from=date(2022, 10, 1),
-            import_ref="Ref",
+    def test_import_data(self):
+        cs_release_count = CodingSystemRelease.objects.count()
+
+        # import mock XML data
+        # This consists of the just the concepts related to "Gastric ulcer", K25
+        # Chapter - XI
+        # Block - K20-31
+        # Category - K25
+        # 9 Modifiers - K25.0 - k25.9 (excl K25.8)
+        with patch(
+            "coding_systems.base.import_data_utils.call_command",
+            mock_migrate_coding_system,
+        ):
+            import_data(
+                self.import_data_path,
+                release_name="release ICD",
+                valid_from=date(2022, 10, 1),
+                import_ref="Ref",
+            )
+
+        # A new CodingSystemRelease has been created
+        assert CodingSystemRelease.objects.count() == cs_release_count + 1
+        cs_release = CodingSystemRelease.objects.latest("id")
+        assert cs_release.coding_system == "icd10"
+        assert cs_release.release_name == "release ICD"
+        assert cs_release.valid_from == date(2022, 10, 1)
+        assert cs_release.import_ref == "Ref"
+
+        assert cs_release.database_alias in settings.DATABASES
+        concepts = Concept.objects.using(cs_release.database_alias).all()
+        assert concepts.count() == 12
+        assert set(concepts.values_list("code", flat=True)) == {
+            "XI",
+            "K20-K31",
+            "K25",
+            "K250",
+            "K251",
+            "K252",
+            "K253",
+            "K254",
+            "K255",
+            "K256",
+            "K257",
+            "K259",
+        }
+        chapter = concepts.get(code="XI")
+        block = concepts.get(code="K20-K31")
+        category = concepts.get(code="K25")
+        subcategories = concepts.exclude(
+            code__in={chapter.code, block.code, category.code}
         )
 
-    # A new CodingSystemRelease has been created
-    assert CodingSystemRelease.objects.count() == cs_release_count + 1
-    cs_release = CodingSystemRelease.objects.latest("id")
-    assert cs_release.coding_system == "icd10"
-    assert cs_release.release_name == "release ICD"
-    assert cs_release.valid_from == date(2022, 10, 1)
-    assert cs_release.import_ref == "Ref"
-
-    assert cs_release.database_alias in settings.DATABASES
-    concepts = Concept.objects.using(cs_release.database_alias).all()
-    assert concepts.count() == 12
-    assert set(concepts.values_list("code", flat=True)) == {
-        "XI",
-        "K20-K31",
-        "K25",
-        "K250",
-        "K251",
-        "K252",
-        "K253",
-        "K254",
-        "K255",
-        "K256",
-        "K257",
-        "K259",
-    }
-    chapter = concepts.get(code="XI")
-    block = concepts.get(code="K20-K31")
-    category = concepts.get(code="K25")
-    subcategories = concepts.exclude(code__in={chapter.code, block.code, category.code})
-
-    assert chapter.parent is None
-    assert block.parent == chapter
-    assert category.parent == block
-    for subcategory in subcategories:
-        assert subcategory.parent == category
+        assert chapter.parent is None
+        assert block.parent == chapter
+        assert category.parent == block
+        for subcategory in subcategories:
+            assert subcategory.parent == category

--- a/coding_systems/icd10/tests/test_import_data.py
+++ b/coding_systems/icd10/tests/test_import_data.py
@@ -21,7 +21,7 @@ MOCK_ICD10_IMPORT_DATA_PATH = (
 
 class TestImportData(DynamicDatabaseTestCase):
     db_alias = "icd10_release-icd_20221001"
-    import_data_path = str(MOCK_ICD10_IMPORT_DATA_PATH)
+    import_data_path = MOCK_ICD10_IMPORT_DATA_PATH
 
     def test_import_data(self):
         cs_release_count = CodingSystemRelease.objects.count()

--- a/coding_systems/snomedct/tests/test_import_data.py
+++ b/coding_systems/snomedct/tests/test_import_data.py
@@ -15,7 +15,7 @@ from .conftest import MOCK_SNOMEDCT_IMPORT_DATA_PATH
 
 class TestImportData(DynamicDatabaseTestCase):
     db_alias = "snomedct_200_20230101"
-    import_data_path = str(MOCK_SNOMEDCT_IMPORT_DATA_PATH)
+    import_data_path = MOCK_SNOMEDCT_IMPORT_DATA_PATH
 
     @pytest.mark.usefixtures("mock_data_download")
     def test_import_data(self):

--- a/coding_systems/snomedct/tests/test_import_data.py
+++ b/coding_systems/snomedct/tests/test_import_data.py
@@ -1,6 +1,10 @@
 from datetime import date
 from unittest.mock import patch
 
+import pytest
+from django.conf import settings
+
+from coding_systems.base.tests.dynamic_db_classes import DynamicDatabaseTestCase
 from coding_systems.conftest import mock_migrate_coding_system
 from coding_systems.snomedct.import_data import import_data
 from coding_systems.snomedct.models import Concept
@@ -9,45 +13,51 @@ from coding_systems.versioning.models import CodingSystemRelease
 from .conftest import MOCK_SNOMEDCT_IMPORT_DATA_PATH
 
 
-def test_import_data(coding_systems_tmp_path, mock_data_download, settings):
-    cs_release_count = CodingSystemRelease.objects.count()
+class TestImportData(DynamicDatabaseTestCase):
+    db_alias = "snomedct_200_20230101"
+    import_data_path = str(MOCK_SNOMEDCT_IMPORT_DATA_PATH)
 
-    # import mock data
-    # This consists of a very small subset of 6 Snomed concepts
-    #
-    # 3723001        Arthritis
-    # 439656005        └ Arthritis of elbow
-    # 202855006           └ Lateral epicondylitis
-    # 312411000119100        ├ Lateral epicondylitis of left humerus
-    # 15636001000119108      |  └ Lateral epicondylitis of bilateral humerus
-    # 312421000119107        └ Lateral epicondylitis of left humerus
-    # 15636001000119108         └ Lateral epicondylitis of bilateral humerus
+    @pytest.mark.usefixtures("mock_data_download")
+    def test_import_data(self):
+        cs_release_count = CodingSystemRelease.objects.count()
 
-    with patch(
-        "coding_systems.base.import_data_utils.call_command", mock_migrate_coding_system
-    ):
-        import_data(
-            str(MOCK_SNOMEDCT_IMPORT_DATA_PATH),
-            release_name="2.0.0",
-            valid_from=date(2023, 1, 1),
-        )
+        # import mock data
+        # This consists of a very small subset of 6 Snomed concepts
+        #
+        # 3723001        Arthritis
+        # 439656005        └ Arthritis of elbow
+        # 202855006           └ Lateral epicondylitis
+        # 312411000119100        ├ Lateral epicondylitis of left humerus
+        # 15636001000119108      |  └ Lateral epicondylitis of bilateral humerus
+        # 312421000119107        └ Lateral epicondylitis of left humerus
+        # 15636001000119108         └ Lateral epicondylitis of bilateral humerus
 
-    # A new CodingSystemRelease has been created
-    assert CodingSystemRelease.objects.count() == cs_release_count + 1
-    cs_release = CodingSystemRelease.objects.latest("id")
-    assert cs_release.coding_system == "snomedct"
-    assert cs_release.release_name == "2.0.0"
-    assert cs_release.valid_from == date(2023, 1, 1)
-    assert cs_release.import_ref == "uk_sct2cl_2.0.0_20230101000001Z.zip"
+        with patch(
+            "coding_systems.base.import_data_utils.call_command",
+            mock_migrate_coding_system,
+        ):
+            import_data(
+                self.import_data_path,
+                release_name="2.0.0",
+                valid_from=date(2023, 1, 1),
+            )
 
-    assert cs_release.database_alias in settings.DATABASES
-    concepts = Concept.objects.using(cs_release.database_alias).all()
-    assert concepts.count() == 6
-    assert set(concepts.values_list("id", flat=True)) == {
-        "3723001",
-        "439656005",
-        "202855006",
-        "312411000119100",
-        "312421000119107",
-        "15636001000119108",
-    }
+        # A new CodingSystemRelease has been created
+        assert CodingSystemRelease.objects.count() == cs_release_count + 1
+        cs_release = CodingSystemRelease.objects.latest("id")
+        assert cs_release.coding_system == "snomedct"
+        assert cs_release.release_name == "2.0.0"
+        assert cs_release.valid_from == date(2023, 1, 1)
+        assert cs_release.import_ref == "uk_sct2cl_2.0.0_20230101000001Z.zip"
+
+        assert cs_release.database_alias in settings.DATABASES
+        concepts = Concept.objects.using(cs_release.database_alias).all()
+        assert concepts.count() == 6
+        assert set(concepts.values_list("id", flat=True)) == {
+            "3723001",
+            "439656005",
+            "202855006",
+            "312411000119100",
+            "312421000119107",
+            "15636001000119108",
+        }

--- a/opencodelists/settings.py
+++ b/opencodelists/settings.py
@@ -360,3 +360,7 @@ SERVER_EMAIL = "tech@opensafely.org"
 
 # API key for dm+d imports
 TRUD_API_KEY = get_env_var("TRUD_API_KEY")
+
+# This setting will become the default in Django 6
+# and can be removed when Opencodelists is upgraded to Django 6.
+FORMS_URLFIELD_ASSUME_HTTPS = True

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,10 +20,6 @@ skip_covered = true
 DJANGO_SETTINGS_MODULE = "opencodelists.settings"
 addopts = "--tb=native --ignore=node_modules --no-migrations"
 
-filterwarnings = [
-    "ignore::django.utils.deprecation.RemovedInDjango50Warning:rest_framework"
-]
-
 [tool.ruff]
 line-length = 88
 exclude = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,9 @@ skip_covered = true
 [tool.pytest.ini_options]
 DJANGO_SETTINGS_MODULE = "opencodelists.settings"
 addopts = "--tb=native --ignore=node_modules --no-migrations"
+filterwarnings = [
+  "ignore:The FORMS_URLFIELD_ASSUME_HTTPS transitional setting is deprecated.",
+]
 
 [tool.ruff]
 line-length = 88

--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -336,9 +336,9 @@ distlib==0.3.9 \
     --hash=sha256:47f8c22fd27c27e25a65601af709b38e4f0a45ea4fc2e710f65755fa8caaaf87 \
     --hash=sha256:a60f20dea646b8a33f3e7772f74dc0b2d0772d2837ee1342a00645c81edf9403
     # via virtualenv
-django==4.2.18 \
-    --hash=sha256:52ae8eacf635617c0f13b44f749e5ea13dc34262819b2cc8c8636abb08d82c4b \
-    --hash=sha256:ba52eff7e228f1c775d5b0db2ba53d8c49d2f8bfe6ca0234df6b7dd12fb25b19
+django==5.1.6 \
+    --hash=sha256:1e39eafdd1b185e761d9fab7a9f0b9fa00af1b37b25ad980a8aa0dac13535690 \
+    --hash=sha256:8d203400bc2952fbfb287c2bbda630297d654920c72a73cc82a9ad7926feaad5
     # via
     #   -c /home/runner/work/opencodelists/opencodelists/requirements.prod.txt
     #   django-debug-toolbar

--- a/requirements.prod.in
+++ b/requirements.prod.in
@@ -8,7 +8,7 @@ beautifulsoup4
 bleach
 crispy-bootstrap4
 dj-database-url
-django~=4.2
+django
 djangorestframework
 django-anymail[mailgun]
 django-crispy-forms

--- a/requirements.prod.txt
+++ b/requirements.prod.txt
@@ -266,9 +266,9 @@ dj-database-url==2.3.0 \
     --hash=sha256:ae52e8e634186b57e5a45e445da5dc407a819c2ceed8a53d1fac004cc5288787 \
     --hash=sha256:bb0d414ba0ac5cd62773ec7f86f8cc378a9dbb00a80884c2fc08cc570452521e
     # via -r requirements.prod.in
-django==4.2.18 \
-    --hash=sha256:52ae8eacf635617c0f13b44f749e5ea13dc34262819b2cc8c8636abb08d82c4b \
-    --hash=sha256:ba52eff7e228f1c775d5b0db2ba53d8c49d2f8bfe6ca0234df6b7dd12fb25b19
+django==5.1.6 \
+    --hash=sha256:1e39eafdd1b185e761d9fab7a9f0b9fa00af1b37b25ad980a8aa0dac13535690 \
+    --hash=sha256:8d203400bc2952fbfb287c2bbda630297d654920c72a73cc82a9ad7926feaad5
     # via
     #   -r requirements.prod.in
     #   crispy-bootstrap4

--- a/templates/base.html
+++ b/templates/base.html
@@ -77,7 +77,10 @@
                   <span class="dropdown-item text-secondary">Signed in as {{ request.user.username }}</span>
                   <div class="dropdown-divider"></div>
                   <a class="dropdown-item" href="{% url 'password_change' %}">Change password</a>
-                  <a class="dropdown-item" href="{% url 'logout' %}">Sign Out</a>
+                  <form action="{% url 'logout' %}" method="POST">
+                    {% csrf_token %}
+                    <button class="dropdown-item" href="{% url 'logout' %}">Sign Out</button>
+                  </form>
                 </div>
               </li>
             {% else %}


### PR DESCRIPTION
Fixes #2115.

This requires a workaround of the coding systems tests that use databases dynamically, due to changes in Django 5.1. We agreed in #2115 that working around the new restrictions was the best thing to do, to allow the upgrade without delay. In future, we may have to revisit this code and associated tests, either for future Django changes or to make maintenance and improvements easier. 

TODO:

- [x] [local testing of the site](https://github.com/opensafely-core/opencodelists/pull/2130#issuecomment-2476300602)
- [x] ~repin Django to 5.1.x~ *not doing this*
- [x] upgrade this branch to Django 5.1.6
- [x] recheck with `django-upgrade` before merge (maybe there are newer migrations?)
- [ ] open an issue to consider refactoring the BNF tests that use a pytest fixture instead of data stored as a file