### PR TITLE
Replace updated_at date with created_at date in CodelistVersion view

### DIFF
--- a/assets/src/styles/base.css
+++ b/assets/src/styles/base.css
@@ -68,7 +68,7 @@ a:focus {
   font-size: 1.1rem;
 }
 
-.sidebar-versions .updated {
+.sidebar-versions .created {
   border-top: 1px dotted #ddd;
   font-size: 0.9rem;
 }

--- a/templates/codelists/version.html
+++ b/templates/codelists/version.html
@@ -230,12 +230,12 @@
                 </code>
               </span>
 
-              <span class="updated d-block pt-1">
+              <span class="created d-block pt-1">
                 <span>
-                  Updated:
+                  Created:
                 </span>
                 <span class="d-block">
-                  {{ version.updated_at | date:'Y-m-d H:i:s' }}
+                  {{ version.created_at | date:'Y-m-d H:i:s' }}
                 </span>
               </span>
             </li>

--- a/templates/codelists/version.html
+++ b/templates/codelists/version.html
@@ -232,7 +232,7 @@
 
               <span class="created d-block pt-1">
                 <span>
-                  Created:
+                  <a href="#" data-toggle="tooltip" data-placement="right" title="When this codelist version was added to OpenCodelists">Created:</a>
                 </span>
                 <span class="d-block">
                   {{ version.created_at | date:'Y-m-d H:i:s' }}


### PR DESCRIPTION
For certain types of codelist (dm+d, SNOMED CT etc)
every time the coding system is updated the
versions of every codelist using this system
get updated and thus the updated_at field
is not very useful to understand the timeline
of codelist versions.

Therefore, switch to created_at which is
hopefully less confusing.

Part fix for #2285 