### PR TITLE
Fixup #2303

### DIFF
--- a/deploy/bin/cronfile
+++ b/deploy/bin/cronfile
@@ -7,6 +7,6 @@ SHELL=/bin/bash
 SLACK_WEBHOOK_URL=dummy-url
 SLACK_TEAM_WEBHOOK_URL=dummy-url
 
-5 23 * * 1 dokku /var/lib/dokku/data/storage/opencodelists/deploy/bin/run_cron.sh import_latest_release.sh dmd
-5 23 * * 2 dokku /var/lib/dokku/data/storage/opencodelists/deploy/bin/run_cron.sh import_latest_release.sh snomedct
-5 23 * * 3 dokku /var/lib/dokku/data/storage/opencodelists/deploy/bin/run_cron.sh import_latest_release.sh mappings.bnfdmd
+5 23 * * 1 dokku /var/lib/dokku/data/storage/opencodelists/deploy/bin/import_latest_release.sh dmd
+5 23 * * 2 dokku /var/lib/dokku/data/storage/opencodelists/deploy/bin/import_latest_release.sh snomedct
+5 23 * * 3 dokku /var/lib/dokku/data/storage/opencodelists/deploy/bin/import_latest_release.sh mappings.bnfdmd

--- a/deploy/bin/import_latest_release.sh
+++ b/deploy/bin/import_latest_release.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 set -euo pipefail
-source sentry_cron_functions.sh
+
 # NOTE: this script is run by cron (as the dokku user) weekly
 # For dm+d, it is run every Monday night, to coincide with weekly
 # dm+d releases
@@ -23,6 +23,10 @@ source sentry_cron_functions.sh
 # SLACK_WEBHOOK_URL channel (#tech-noise).  Failures are posted to the
 # SLACK_TEAM_WEBHOOK_URL. This should be set to the channel for the team responsible
 # for OpenCodelists.
+
+# import sentry functions (must be in same dir as this script)
+SCRIPT_DIR=$(dirname "$0")
+source "$SCRIPT_DIR/sentry_cron_functions.sh"
 
 CODING_SYSTEM=$1
 

--- a/deploy/bin/sentry_cron_functions.sh
+++ b/deploy/bin/sentry_cron_functions.sh
@@ -24,6 +24,10 @@ function extract_crontab() {
 function sentry_cron_url() {
     SENTRY_DSN="$1"
     JOB_NAME="$2"
+
+    # dots not supported in job names, replace with underscores
+    JOB_NAME="${JOB_NAME//\./_}"
+
     # modify the DSN to point it at the cron API
     SENTRY_CRON_URL=$(sed -E "s/([0-9]+$)/api\/\1/g" <<< "$SENTRY_DSN")
     echo "$SENTRY_CRON_URL/cron/$JOB_NAME"


### PR DESCRIPTION
Reverting and re-applying bits of PRs is _fun_ , I missed an important change in rebasing for #2303 .

I've manually patched the cron file in prod as I was in there doing a manual job run anyway but this brings the codebase in line with it.

Additionally, I've fixed a couple of bugs that didn't show up when running locally:
* the path to the sentry functions script needs to be either absolute or derived from the calling script path, I've chosen the latter.
* "test" is a valid sentry monitor name, "import_data.sh_bnf.dmd" is not on account of the dots.