### PR TITLE
Update Vite dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,7 @@
         "@vitejs/plugin-react-swc": "^3.7.2",
         "@vitest/coverage-v8": "^3.0.2",
         "jsdom": "^26.0.0",
-        "vite": "^6.0.9",
+        "vite": "^6.0.11",
         "vite-plugin-live-reload": "^3.0.4",
         "vitest": "^3.0.2"
       }
@@ -3671,10 +3671,11 @@
       "peer": true
     },
     "node_modules/vite": {
-      "version": "6.0.9",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-6.0.9.tgz",
-      "integrity": "sha512-MSgUxHcaXLtnBPktkbUSoQUANApKYuxZ6DrbVENlIorbhL2dZydTLaZ01tjUoE3szeFzlFk9ANOKk0xurh4MKA==",
+      "version": "6.0.11",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-6.0.11.tgz",
+      "integrity": "sha512-4VL9mQPKoHy4+FE0NnRE/kbY51TOfaknxAjt3fJbGJxhIpBZiqVzlZDEesWWsuREXHwNdAoOFZ9MkPEVXczHwg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "esbuild": "^0.24.2",
         "postcss": "^8.4.49",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "@vitejs/plugin-react-swc": "^3.7.2",
     "@vitest/coverage-v8": "^3.0.2",
     "jsdom": "^26.0.0",
-    "vite": "^6.0.9",
+    "vite": "^6.0.11",
     "vite-plugin-live-reload": "^3.0.4",
     "vitest": "^3.0.2"
   },


### PR DESCRIPTION
Vite v6.0.9 is causing issues when running as a local dev server for assets, claiming a CORS misconfiguration. Vite v6.0.11 fixes this.