### PR TITLE
Move Plausible JS to HTML head element

### DIFF
--- a/assets/src/scripts/base.js
+++ b/assets/src/scripts/base.js
@@ -21,41 +21,6 @@ import "lite-youtube-embed/src/lite-yt-embed.css";
 // Styles
 import "../styles/base.css";
 
-if (document.location.hostname === "www.opencodelists.org") {
-  /**
-   * <script
-   *   defer
-   *   data-domain="opencodelists.org"
-   *   src="https://plausible.io/js/script.pageview-props.tagged-events.js"
-   *   event-is_admin="false"
-   *   event-is_logged_in="false"
-   * ></script>
-   */
-  const script = document.createElement("script");
-  script.defer = true;
-  script.setAttribute("data-domain", "opencodelists.org");
-  script.src = "https://plausible.io/js/script.pageview-props.tagged-events.js";
-  document.head.appendChild(script);
-
-  const isLoggedIn = document.head.querySelector(`meta[name="is_logged_in"]`);
-  const isAdmin = document.head.querySelector(`meta[name="is_admin"]`);
-
-  if (isLoggedIn) {
-    script.setAttribute("event-is_logged_in", isLoggedIn.content);
-  }
-
-  if (isAdmin) {
-    script.setAttribute("event-is_admin", isAdmin.content);
-  }
-
-  window.plausible =
-    window.plausible ||
-    function () {
-      // biome-ignore lint/suspicious/noAssignInExpressions: Plausible Analytics provided script
-      (window.plausible.q = window.plausible.q || []).push(arguments);
-    };
-}
-
 /**
  * Enable tooltips everywhere
  * https://getbootstrap.com/docs/4.6/components/tooltips/#example-enable-tooltips-everywhere

--- a/templates/base.html
+++ b/templates/base.html
@@ -10,10 +10,19 @@
     {% vite_hmr_client %}
     {% vite_asset "assets/src/scripts/base.js" %}
 
-    {# The following <meta> tags are for Plausible stats collection. #}
-    <meta name="is_logged_in" content="{% if user.is_authenticated %}true{% else %}false{% endif %}">
-    <meta name="is_admin" content="{% if user.is_admin %}true{% else %}false{% endif %}">
-    {# End of stats-collecting <meta> tags. #}
+    {# The following is for Plausible stats collection. #}
+    <script
+      defer
+      data-domain="opencodelists.org"
+      event-is_logged_in="{% if user.is_authenticated %}true{% else %}false{% endif %}"
+      event-is_admin="{% if user.is_admin %}true{% else %}false{% endif %}"
+      src="https://plausible.io/js/script.pageview-props.tagged-events.js"
+    ></script>
+    <script nonce="{{ request.csp_nonce }}">
+      window.plausible = window.plausible || function() { (window.plausible.q = window.plausible.q || []).push(arguments) }
+    </script>
+
+    {# End of stats-collecting. #}
 
     {% block extra_styles %}{% endblock %}
 


### PR DESCRIPTION
Linked to opensafely-core/sysadmin#175

Hostname controls can be performed in the Plausible dashboard, and the events can be directly added to the script tag.