### PR TITLE
Enhance otel spans with an identifier for logged in users

### DIFF
--- a/DEPLOY.md
+++ b/DEPLOY.md
@@ -34,6 +34,10 @@ dokku$ dokku config:set opencodelists DATABASE_URL='sqlite:////storage/db.sqlite
 dokku$ dokku config:set opencodelists DATABASE_DIR='/storage'
 dokku$ dokku config:set opencodelists SECRET_KEY='xxx'
 dokku$ dokku config:set opencodelists SENTRY_DSN='https://xxx@xxx.ingest.sentry.io/xxx'
+dokku$ dokku config:set opencodelists OTEL_EXPORTER_OLTP_ENDPOINT='https://api.honeycomb.io'
+dokku$ dokku config:set opencodelists OTEL_EXPORTER_OTLP_HEADERS='x-honeycomb-team=VALIDKEY1234,x-honeycomb-dataset=opencodelists'
+dokku$ dokku config:set opencodelists OTEL_SERVICE_NAME='opencodelists'
+dokku$ dokku config:set opencodelists DJANGO_SETTINGS_MODULE="opencodelists.settings"
 dokku$ dokku config:set opencodelists EMAIL_BACKEND='anymail.backends.mailgun.EmailBackend'
 dokku$ dokku config:set opencodelists MAILGUN_API_KEY='xxx'
 ```

--- a/conftest.py
+++ b/conftest.py
@@ -1,6 +1,14 @@
 import pytest
 from django.db import connections
 from django.test import TestCase
+from opentelemetry import trace
+from opentelemetry.instrumentation.django import DjangoInstrumentor
+from opentelemetry.sdk.resources import Resource
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
+
+from services.tracing import response_hook
 
 
 # TestCase.databases sets the databases that tests have access to; this allows all tests
@@ -71,3 +79,57 @@ def reset_connections():
     databases_added_during_tests = set(connections.databases.keys()) - initial_databases
     for db in databases_added_during_tests:
         del connections.databases[db]
+
+
+################################################################################################################
+# Setup global tracing infrastructure for testing purposes.
+
+# The test setup is designed to be as close to the prod environment as possible,
+# with only necessary modifications specific to testing.
+
+# Create a resource for testing purposes with a unique 'service.name' value to
+# minimise risk of mixing test and prod telemetry data.
+# https://opentelemetry-python.readthedocs.io/en/latest/sdk/resources.html
+resource = Resource.create(attributes={"service.name": "opencodelists-test"})
+
+# Configure a global default OTel TracerProvider for our tests:
+# The TracerProvider enables access to Tracers, Tracers create Spans.
+# TracerProvider configuration is done once, globally because the OTel Tracing API
+# should be used to configure and set/register a global default TracerProvider once,
+# at the start of a process (in this case, the pytest session; in prod, a gunicorn
+# worker process)). This means that during the pytest test session any test
+# that uses Django's test client will generate telemetry data (spans)
+# that we can assert against.
+# https://opentelemetry.io/docs/specs/otel/trace/api/#tracerprovider
+provider = TracerProvider(resource=resource)
+trace.set_tracer_provider(provider)
+
+# In prod, we use the OTLPSpanExporter which exports our telemetry data to Honeycomb.
+# In testing, we use InMemorySpanExporter() to collect spans locally, and assert
+# against them during tests.
+testing_span_exporter = InMemorySpanExporter()
+
+# In prod, we use the BatchSpanProcessor as this is asynchronous, and queues
+# and retries sending telemetry. In testing, we use SimpleSpanProcessor, which is
+# synchronous and easy to inspect the output of within a test.
+provider.add_span_processor(SimpleSpanProcessor(testing_span_exporter))
+
+# Mirror production instrumentation:
+# Use DjangoInstumentor() to instrument OpenCodelists test data, with prod response_hook().
+DjangoInstrumentor().instrument(response_hook=response_hook)
+################################################################################################################
+
+
+@pytest.fixture(autouse=True)
+def clear_testing_span_exporter():
+    """Clear OTel spans from the test exporter after each test"""
+    yield
+    testing_span_exporter.clear()
+
+
+@pytest.fixture()
+def span_exporter():
+    """Provide an empty test exporter to export OTel spans for each test.
+    Interrogate it with, for example get_finished_spans()."""
+    assert not testing_span_exporter.get_finished_spans()
+    yield testing_span_exporter

--- a/conftest.py
+++ b/conftest.py
@@ -94,7 +94,7 @@ resource = Resource.create(attributes={"service.name": "opencodelists-test"})
 
 # Configure a global default OTel TracerProvider for our tests:
 # The TracerProvider enables access to Tracers, Tracers create Spans.
-# TracerProvider configuration is done once, globally because the OTel Tracing API
+# TracerProvider configuration is done once, globally, because the OTel Tracing API
 # should be used to configure and set/register a global default TracerProvider once,
 # at the start of a process (in this case, the pytest session; in prod, a gunicorn
 # worker process)). This means that during the pytest test session any test
@@ -106,7 +106,7 @@ trace.set_tracer_provider(provider)
 
 # In prod, we use the OTLPSpanExporter which exports our telemetry data to Honeycomb.
 # In testing, we use InMemorySpanExporter() to collect spans locally, and assert
-# against them during tests.
+# against them during tests using the span_exporter fixture.
 testing_span_exporter = InMemorySpanExporter()
 
 # In prod, we use the BatchSpanProcessor as this is asynchronous, and queues
@@ -129,7 +129,7 @@ def clear_testing_span_exporter():
 
 @pytest.fixture()
 def span_exporter():
-    """Provide an empty test exporter to export OTel spans for each test.
-    Interrogate it with, for example get_finished_spans()."""
+    """Provide access to the global span exporter for interrogation.
+    Interrogate it with, for example, get_finished_spans()."""
     assert not testing_span_exporter.get_finished_spans()
     yield testing_span_exporter

--- a/deploy/gunicorn/conf.py
+++ b/deploy/gunicorn/conf.py
@@ -1,8 +1,5 @@
-from opentelemetry import trace
-from opentelemetry.exporter.otlp.proto.grpc.trace_exporter import OTLPSpanExporter
-from opentelemetry.sdk.resources import Resource
-from opentelemetry.sdk.trace import TracerProvider
-from opentelemetry.sdk.trace.export import BatchSpanProcessor
+from opentelemetry.instrumentation.django import DjangoInstrumentor
+from services.tracing import set_up_tracing, response_hook
 
 from services.logging import logging_config_dict
 
@@ -20,22 +17,15 @@ errorlog = "-"
 logconfig_dict = logging_config_dict
 
 
-# Because of Gunicorn's pre-fork web server model, we need to initialise opentelemetry
-# in gunicorn's post_fork method in order to instrument our application process, see:
+# Because of Gunicorn's pre-fork web server model,
+# we need to initialise opentelemetry in gunicorn's post_fork method
+# in order to instrument our application process, see:
 # https://opentelemetry-python.readthedocs.io/en/latest/examples/fork-process-model/README.html
 def post_fork(server, worker):
     server.log.info("Worker spawned (pid: %s)", worker.pid)
 
-    resource = Resource.create(attributes={"service.name": "opencodelists"})
+    set_up_tracing()
 
-    trace.set_tracer_provider(TracerProvider(resource=resource))
-    span_processor = BatchSpanProcessor(
-        OTLPSpanExporter(endpoint="https://api.honeycomb.io")
-    )
-    trace.get_tracer_provider().add_span_processor(span_processor)
-
-    # initialise the automatic Django instrumentation
-    # https://opentelemetry-python-contrib.readthedocs.io/en/latest/instrumentation/django/django.html#module-opentelemetry.instrumentation.django
-    from opentelemetry.instrumentation.auto_instrumentation import (  # noqa: F401
-        sitecustomize,
-    )
+    # Initialise the automatic Django instrumentation
+    # https://opentelemetry-python-contrib.readthedocs.io/en/latest/instrumentation/django/django.html#id1
+    DjangoInstrumentor().instrument(response_hook=response_hook)

--- a/opencodelists/tests/test_tracing.py
+++ b/opencodelists/tests/test_tracing.py
@@ -1,0 +1,18 @@
+def test_user_span_attribute_added_for_logged_in_user(
+    client, user_without_organisation, span_exporter
+):
+    client.login(username="dave", password="test")
+
+    client.get("/")
+    spans = span_exporter.get_finished_spans()
+
+    assert spans[0].attributes.get("user") == "dave"
+
+
+def test_user_span_attribute_added_for_non_logged_in_user(
+    client, user_without_organisation, span_exporter
+):
+    client.get("/")
+    spans = span_exporter.get_finished_spans()
+
+    assert spans[0].attributes.get("user") == ""

--- a/services/tracing.py
+++ b/services/tracing.py
@@ -1,0 +1,49 @@
+"""Functions to configure OTel tracing and instrumentation
+We use OpenTelemetry (OTel) to instrument the app and capture telemetry
+data about requests in traces and spans emitted by our code. We send
+this data to Honeycomb to view and interrogate it, helping us to
+understand the internal state of our system and assist our users.
+
+In production, the functions below are invoked in
+deploy/gunicorn/conf.py. OTel requires environment variables to be set;
+these are described in dotenv-sample and DEPLOY.md."""
+
+from opentelemetry import trace
+from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
+from opentelemetry.sdk.resources import Resource
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import BatchSpanProcessor
+
+
+def set_up_tracing():
+    """Setup tracing infrastructure for production.
+    The resource represents the entity producing telemetry data.
+    We configure a global default OTel TracerProvider, because the OTel
+    Tracing API should be used to configure and set a TracerProvider
+    once, at the start of a process (in prod, this is a gunicorn worker
+    process)). TracerProvider provides Tracers and Tracers create Spans.
+    https://opentelemetry.io/docs/specs/otel/trace/api/#tracerprovider.
+    OTLPSpanExporter sends our telemetry data to Honeycomb. No endpoint
+    argument is passed to the exporter, so it uses the value stored
+    in OTEL_EXPORTER_OLTP_ENDPOINT environment variable.
+    https://opentelemetry.exporter.otlp.proto.http.trace_exporter.OTLPSpanExporter.
+    We use a BatchSpanProcessor as this is asynchronous, and queues and
+    retries sending telemetry data."""
+
+    resource = Resource.create(attributes={"service.name": "opencodelists"})
+
+    trace.set_tracer_provider(TracerProvider(resource=resource))
+    span_processor = BatchSpanProcessor(OTLPSpanExporter())
+    trace.get_tracer_provider().add_span_processor(span_processor)
+
+
+def response_hook(span, request, response):
+    """Add user data to spans so that we can query this in Honeycomb.
+    OTel's request_hook and response_hook run at span creation for a request
+    and just before span completion for the response. As request_hook
+    runs before authentication middleware has added a 'user' attribute
+    to a request, we use a response_hook to access the request after the
+    middleware has run so we can include user data in the spans.
+    https://opentelemetry-python-contrib.readthedocs.io/en/latest/instrumentation/django/django.html#request-and-response-hooks"""
+    if hasattr(request, "user"):
+        span.set_attribute("user", request.user.username)

--- a/services/tracing.py
+++ b/services/tracing.py
@@ -1,4 +1,5 @@
-"""Functions to configure OTel tracing and instrumentation
+"""Functions to configure OTel tracing and instrumentation.
+
 We use OpenTelemetry (OTel) to instrument the app and capture telemetry
 data about requests in traces and spans emitted by our code. We send
 this data to Honeycomb to view and interrogate it, helping us to
@@ -17,6 +18,7 @@ from opentelemetry.sdk.trace.export import BatchSpanProcessor
 
 def set_up_tracing():
     """Setup tracing infrastructure for production.
+
     The resource represents the entity producing telemetry data.
     We configure a global default OTel TracerProvider, because the OTel
     Tracing API should be used to configure and set a TracerProvider
@@ -39,6 +41,7 @@ def set_up_tracing():
 
 def response_hook(span, request, response):
     """Add user data to spans so that we can query this in Honeycomb.
+
     OTel's request_hook and response_hook run at span creation for a request
     and just before span completion for the response. As request_hook
     runs before authentication middleware has added a 'user' attribute


### PR DESCRIPTION
Fixes #2255 

Add username of opencodelist users to OTel spans.

**Why was this work done?**
We use [OpenTelemetry](https://opentelemetry.io/docs/what-is-opentelemetry/) to instrument opencodelists such that when users make requests, we can capture data about these requests in [traces and spans](https://opentelemetry.io/docs/concepts/signals/traces/#spans) emitted by our code. We send this data to [Honeycomb](https://docs.honeycomb.io/get-started/start-building/application/traces/) in order to view and interrogate it, helping us to understand the internal state of our system. Previously, the traces and spans emitted from opencodelists did not include information to identify, or query by, logged-in users. Adding the username of opencodelist users as a span attribute allows us to do this, and potentially help users facing particular issues.

**What has been done?**
Initially, attempts were made to use an [environment variable](https://opentelemetry-python-contrib.readthedocs.io/en/latest/instrumentation/django/django.html#request-attributes) provided by OTel which extracts attributes from Django’s request object and adds them as span attributes. However, this did not work: spans created when a request is made do not yet have access to the ‘user’ attribute on Django’s request object, as Django’s [authentication middleware](https://docs.djangoproject.com/en/5.1/topics/auth/default/#authentication-in-web-requests) (which adds the user attribute to the request object) hasn’t yet run. Thus a different approach was required. 

OTel provides [request and response hooks](https://opentelemetry-python-contrib.readthedocs.io/en/latest/instrumentation/django/django.html#request-and-response-hooks), used with [Django instrumentation](https://opentelemetry-python-contrib.readthedocs.io/en/latest/instrumentation/django/django.html#id1) to instrument the app. Request and response hooks enable access to the Django request object immediately after span creation and right before a span finishes, respectively. The current approach uses a response_hook() to ensure the authentication middleware has added the 'user' attribute to the Django request object, before attempting to add this to a span. To facilitate testing of the response_hook, and to more closely mirror how tracing is set up in other OpenSafely applications e.g. airlock, this functionality was moved to services/tracing.py. 

Additionally, OTel instrumentation requires specific environment variables to be set, so dotenv-sample and DEPLOY.md have been updated to reflect this. 

**Has this been tested?**
Yes:
1. Pytest fixtures set up a global tracing infrastructure and instrumentation for the purposes of testing, and two ‘end-to-end’ tests then exercise the prod response_hook() functionality.
2. Honeycomb has a development environment; local dev OTel data was sent to this environment by generating an API key in the Honeycomb dev env (note: only Team Organisers have this authority), adding 'user' as a tracing field on the dataset definition, updating the OTEL_EXPORTER_OTLP_HEADERS env var with the API key, spinning up a gunicorn server locally and making requests in local opencodelists (see Honeycomb dashboard images below). NOTE: adding 'user' as a tracing field on the dataset definition will need to be done in the Honeycomb production environment once the changes in this PR are deployed.

Logged in user (see bottom right of image for ‘user’ field):
![Screenshot from 2025-01-23 15-25-20](https://github.com/user-attachments/assets/4177c338-6284-48c5-a019-d1f4f7a48a69)

Non-logged in user:
![Screenshot from 2025-01-23 15-18-31](https://github.com/user-attachments/assets/45b1a461-fa04-4e17-8ab4-e32c829411d4)

Query by logged in user:
![Screenshot from 2025-01-23 16-46-20](https://github.com/user-attachments/assets/aeeb4ddd-5e81-42cd-abb5-f0df2be100b9)
