### PR TITLE
Reintroduce sentry monitoring of backups

### DIFF
--- a/deploy/bin/backup.sh
+++ b/deploy/bin/backup.sh
@@ -2,36 +2,61 @@
 
 set -euxo pipefail
 
+# import sentry functions (must be in same dir as this script)
+SCRIPT_DIR=$(dirname "$0")
+source "$SCRIPT_DIR/sentry_cron_functions.sh"
+
+# set up sentry monitoring
+SENTRY_MONITOR_NAME=$(basename "$0")
+CRONTAB=$(extract_crontab "$SENTRY_MONITOR_NAME" "/app/app.json")
+SENTRY_CRON_URL=$(sentry_cron_url "$SENTRY_DSN" "$SENTRY_MONITOR_NAME")
+
 # DATABASE_DIR is configured via dokku (see DEPLOY.md)
 BACKUP_DIR="$DATABASE_DIR/backup/db"
-
-# Make the backup dir if it doesn't exist.
-mkdir "$BACKUP_DIR" -p
-
-# Take a datestamped backup.
 BACKUP_FILENAME="$(date +%F)-db.sqlite3"
 BACKUP_FILEPATH="$BACKUP_DIR/$BACKUP_FILENAME"
-sqlite3 "$DATABASE_DIR/db.sqlite3" ".backup $BACKUP_FILEPATH"
 
-# Compress the latest backup.
-# Zstandard is a fast, modern, lossless data compression algorithm.  It gives
-# marginally better compression ratios than gzip on the backup and much faster
-# compression and particularly decompression.  We want the backup process to be
-# quick as it's a CPU-intensive activity that could affect site performance.
-# --rm flag removes the source file after compression.
-zstd "$BACKUP_FILEPATH" --rm
+function run_backup() {
+    # Make the backup dir if it doesn't exist.
+    mkdir "$BACKUP_DIR" -p
 
-# Symlink to the new latest backup to make it easy to discover.
-# Make the target a relative path -- an absolute one won't mean the same thing
-# in the host file system if executed inside a container as we expect.
-ln -sf "$BACKUP_FILENAME.zst" "$BACKUP_DIR/latest-db.sqlite3.zst"
+    # Take a datestamped backup.
+    sqlite3 "$DATABASE_DIR/db.sqlite3" ".backup $BACKUP_FILEPATH"
 
-# Keep only the last 30 days of backups.
-# For now, apply this to both the original backup dir with backups based on the
-# Django dumpdata management command and the new dir with backups based on
-# sqlite .backup. Once there are none of the former remaining, the first line can be
-# removed, along with most of this comment.
-find "$DATABASE_DIR" -name "core-data-*.json.gz" -type f -mtime +30 -exec rm {} \;
-# We initially compressed with gzip, this can be removed when none left.
-find "$BACKUP_DIR" -name "*-db.sqlite3.gz" -type f -mtime +30 -exec rm {} \;
-find "$BACKUP_DIR" -name "*-db.sqlite3.zst" -type f -mtime +30 -exec rm {} \;
+    # Compress the latest backup.
+    # Zstandard is a fast, modern, lossless data compression algorithm.  It gives
+    # marginally better compression ratios than gzip on the backup and much faster
+    # compression and particularly decompression.  We want the backup process to be
+    # quick as it's a CPU-intensive activity that could affect site performance.
+    # --rm flag removes the source file after compression.
+    zstd "$BACKUP_FILEPATH" --rm
+
+    # Symlink to the new latest backup to make it easy to discover.
+    # Make the target a relative path -- an absolute one won't mean the same thing
+    # in the host file system if executed inside a container as we expect.
+    ln -sf "$BACKUP_FILENAME.zst" "$BACKUP_DIR/latest-db.sqlite3.zst"
+
+    # Keep only the last 30 days of backups.
+    # For now, apply this to both the original backup dir with backups based on the
+    # Django dumpdata management command and the new dir with backups based on
+    # sqlite .backup. Once there are none of the former remaining, the first line can be
+    # removed, along with most of this comment.
+    find "$DATABASE_DIR" -name "core-data-*.json.gz" -type f -mtime +30 -exec rm {} \;
+
+    # We initially compressed with gzip, this can be removed when none left.
+    find "$BACKUP_DIR" -name "*-db.sqlite3.gz" -type f -mtime +30 -exec rm {} \;
+    find "$BACKUP_DIR" -name "*-db.sqlite3.zst" -type f -mtime +30 -exec rm {} \;
+}
+
+# log start of backup in a way that won't fail the whole script if sentry down
+sentry_cron_start "$SENTRY_CRON_URL" "$CRONTAB" || RESULT=$?
+
+# run the backup
+RESULT=0
+run_backup || RESULT=$?
+
+if [ $RESULT == 0 ] ; then
+    sentry_cron_ok "$SENTRY_CRON_URL"
+else
+    sentry_cron_error "$SENTRY_CRON_URL"
+fi

--- a/deploy/bin/sentry_cron_functions.sh
+++ b/deploy/bin/sentry_cron_functions.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-CRONTAB_PATTERN="([\*\d]+ )+"
+CRONTAB_PATTERN="([\*\d+] ?)+"
 
 function extract_crontab() {
     JOB_IDENTIFIER="$1"
@@ -15,7 +15,7 @@ function extract_crontab() {
         # ensure we only match the terminal argument
         JOB_IDENTIFIER=" $JOB_IDENTIFIER\$"
     fi
-    CRONTAB=$(grep -A "$LINES_AFTER_MATCH" "$JOB_IDENTIFIER" "$CRONTAB_SOURCE" | grep -oP "$CRONTAB_PATTERN")
+    CRONTAB=$(grep -A "$LINES_AFTER_MATCH" "$JOB_IDENTIFIER" "$CRONTAB_SOURCE" | grep -oP "$CRONTAB_PATTERN" | sed -e "s/ $//")
     echo "$CRONTAB"
 }
 

--- a/docker/dependencies.txt
+++ b/docker/dependencies.txt
@@ -6,3 +6,5 @@ sqlite3
 tzdata
 # Fast, modern compression utility. Compress backups. Search 'zstd' to find uses.
 zstd
+# Needed to make HTTP calls to the Sentry API
+curl

--- a/opencodelists/tests/test_sentry_cron_functions.py
+++ b/opencodelists/tests/test_sentry_cron_functions.py
@@ -5,7 +5,7 @@ import subprocess
 # Dummy organisation and project identifiers in URL
 SENTRY_DSN = "https://ecae920f60aa7a6a3e16d50d121ce4f2@o123456.ingest.sentry.io/7891023"
 SENTRY_CRON_URL = "https://ecae920f60aa7a6a3e16d50d121ce4f2@o123456.ingest.sentry.io/api/7891023/cron/test_monitor"
-CRONTAB = "5 23 * * 1 "
+CRONTAB = "5 23 * * 1"
 
 
 def test_extract_crontab_json(tmp_path):


### PR DESCRIPTION
Brings back functionality reverted in https://github.com/opensafely-core/opencodelists/commit/555bc71debb0bd40944811f82d0569886d7e5027 but with three crucial bugfixes:
* correct derivation of script name for sentry
  monitor name
* missing dependency for `curl`
* Fix trailing spaces in cron parsing

Whilst allowing backup script to continue if sentry logging fails for some reason