### PR TITLE
Replace use of pytest-subtests with `parametrize`

### DIFF
--- a/codelists/tests/test_codeset.py
+++ b/codelists/tests/test_codeset.py
@@ -19,11 +19,11 @@ from .helpers import build_hierarchy, hierarchies
 # g   h   i   j
 
 
-def id_fn(value):
+def _get_description(value):
     return value["description"]
 
 
-@pytest.mark.parametrize("example", examples, ids=id_fn)
+@pytest.mark.parametrize("example", examples, ids=_get_description)
 def test_from_codes(example):
     hierarchy = build_hierarchy()
 
@@ -33,7 +33,7 @@ def test_from_codes(example):
     assert codeset.codes() == example["codes"]
 
 
-@pytest.mark.parametrize("example", examples, ids=id_fn)
+@pytest.mark.parametrize("example", examples, ids=_get_description)
 def test_codes(example):
     hierarchy = build_hierarchy()
 
@@ -47,7 +47,7 @@ def test_codes(example):
     assert codeset.codes() == example["codes"]
 
 
-@pytest.mark.parametrize("example", examples, ids=id_fn)
+@pytest.mark.parametrize("example", examples, ids=_get_description)
 def test_defining_tree(example):
     hierarchy = build_hierarchy()
 
@@ -59,7 +59,7 @@ def test_defining_tree(example):
     assert codeset.defining_tree() == example["tree"]
 
 
-@pytest.mark.parametrize("example", examples, ids=id_fn)
+@pytest.mark.parametrize("example", examples, ids=_get_description)
 def test_walk_defining_tree(example):
     hierarchy = build_hierarchy()
 

--- a/codelists/tests/test_codeset.py
+++ b/codelists/tests/test_codeset.py
@@ -1,3 +1,4 @@
+import pytest
 from hypothesis import given, settings
 from hypothesis import strategies as st
 
@@ -18,56 +19,56 @@ from .helpers import build_hierarchy, hierarchies
 # g   h   i   j
 
 
-def test_from_codes(subtests):
+def id_fn(value):
+    return value["description"]
+
+
+@pytest.mark.parametrize("example", examples, ids=id_fn)
+def test_from_codes(example):
     hierarchy = build_hierarchy()
 
-    for example in examples:
-        with subtests.test(example["description"]):
-            codeset = Codeset.from_codes(example["codes"], hierarchy)
-            assert codeset.codes("+") == example["explicitly_included"]
-            assert codeset.codes("-") == example["explicitly_excluded"]
-            assert codeset.codes() == example["codes"]
+    codeset = Codeset.from_codes(example["codes"], hierarchy)
+    assert codeset.codes("+") == example["explicitly_included"]
+    assert codeset.codes("-") == example["explicitly_excluded"]
+    assert codeset.codes() == example["codes"]
 
 
-def test_codes(subtests):
+@pytest.mark.parametrize("example", examples, ids=id_fn)
+def test_codes(example):
     hierarchy = build_hierarchy()
 
-    for example in examples:
-        with subtests.test(example["description"]):
-            codeset = Codeset.from_definition(
-                example["explicitly_included"],
-                example["explicitly_excluded"],
-                hierarchy,
-            )
-            assert codeset.codes("+") == example["explicitly_included"]
-            assert codeset.codes("-") == example["explicitly_excluded"]
-            assert codeset.codes() == example["codes"]
+    codeset = Codeset.from_definition(
+        example["explicitly_included"],
+        example["explicitly_excluded"],
+        hierarchy,
+    )
+    assert codeset.codes("+") == example["explicitly_included"]
+    assert codeset.codes("-") == example["explicitly_excluded"]
+    assert codeset.codes() == example["codes"]
 
 
-def test_defining_tree(subtests):
+@pytest.mark.parametrize("example", examples, ids=id_fn)
+def test_defining_tree(example):
     hierarchy = build_hierarchy()
 
-    for example in examples:
-        with subtests.test(example["description"]):
-            codeset = Codeset.from_definition(
-                example["explicitly_included"],
-                example["explicitly_excluded"],
-                hierarchy,
-            )
-            assert codeset.defining_tree() == example["tree"]
+    codeset = Codeset.from_definition(
+        example["explicitly_included"],
+        example["explicitly_excluded"],
+        hierarchy,
+    )
+    assert codeset.defining_tree() == example["tree"]
 
 
-def test_walk_defining_tree(subtests):
+@pytest.mark.parametrize("example", examples, ids=id_fn)
+def test_walk_defining_tree(example):
     hierarchy = build_hierarchy()
 
-    for example in examples:
-        with subtests.test(example["description"]):
-            codeset = Codeset.from_definition(
-                example["explicitly_included"],
-                example["explicitly_excluded"],
-                hierarchy,
-            )
-            assert list(codeset.walk_defining_tree(lambda x: x)) == example["tree_rows"]
+    codeset = Codeset.from_definition(
+        example["explicitly_included"],
+        example["explicitly_excluded"],
+        hierarchy,
+    )
+    assert list(codeset.walk_defining_tree(lambda x: x)) == example["tree_rows"]
 
 
 def test_update():

--- a/coding_systems/snomedct/tests/test_ecl_parser.py
+++ b/coding_systems/snomedct/tests/test_ecl_parser.py
@@ -17,12 +17,11 @@ examples = [
 ]
 
 
-def test_handle(subtests):
-    for expr, included, excluded in examples:
-        with subtests.test(expr):
-            handled = handle(expr)
-            assert handled["included"] == included
-            assert handled["excluded"] == excluded
+@pytest.mark.parametrize("expr,included,excluded", examples)
+def test_handle(expr, included, excluded):
+    handled = handle(expr)
+    assert handled["included"] == included
+    assert handled["excluded"] == excluded
 
 
 def test_parse_error_syntax_error():

--- a/requirements.dev.in
+++ b/requirements.dev.in
@@ -10,7 +10,6 @@ django-debug-toolbar
 hypothesis
 pytest-cov
 pytest-django
-pytest-subtests
 responses
 
 # dev

--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -15,7 +15,6 @@ attrs==25.1.0 \
     --hash=sha256:c75a69e28a550a7e93789579c22aa26b0f5b83b75dc4e08fe092980051e1090a
     # via
     #   hypothesis
-    #   pytest-subtests
 bcrypt==4.2.1 \
     --hash=sha256:041fa0155c9004eb98a232d54da05c0b41d4b8e66b6fc3cb71b4b3f6144ba837 \
     --hash=sha256:04e56e3fe8308a88b77e0afd20bec516f74aecf391cdd6e374f15cbed32783d6 \
@@ -543,7 +542,6 @@ pytest==8.3.4 \
     # via
     #   pytest-cov
     #   pytest-django
-    #   pytest-subtests
 pytest-cov==6.0.0 \
     --hash=sha256:eee6f1b9e61008bd34975a4d5bab25801eb31898b032dd55addc93e96fcaaa35 \
     --hash=sha256:fde0b595ca248bb8e2d76f020b465f3b107c9632e6a1d1705f17834c89dcadc0
@@ -551,10 +549,6 @@ pytest-cov==6.0.0 \
 pytest-django==4.9.0 \
     --hash=sha256:1d83692cb39188682dbb419ff0393867e9904094a549a7d38a3154d5731b2b99 \
     --hash=sha256:8bf7bc358c9ae6f6fc51b6cebb190fe20212196e6807121f11bd6a3b03428314
-    # via -r requirements.dev.in
-pytest-subtests==0.14.1 \
-    --hash=sha256:350c00adc36c3aff676a66135c81aed9e2182e15f6c3ec8721366918bbbf7580 \
-    --hash=sha256:e92a780d98b43118c28a16044ad9b841727bd7cb6a417073b38fd2d7ccdf052d
     # via -r requirements.dev.in
 python-dateutil==2.9.0.post0 \
     --hash=sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3 \


### PR DESCRIPTION
Fixes #2206.