### PR TITLE
Remove old backup format cleanup actions

### DIFF
--- a/deploy/bin/backup.sh
+++ b/deploy/bin/backup.sh
@@ -37,14 +37,6 @@ function run_backup() {
     ln -sf "$BACKUP_FILENAME.zst" "$BACKUP_DIR/latest-db.sqlite3.zst"
 
     # Keep only the last 30 days of backups.
-    # For now, apply this to both the original backup dir with backups based on the
-    # Django dumpdata management command and the new dir with backups based on
-    # sqlite .backup. Once there are none of the former remaining, the first line can be
-    # removed, along with most of this comment.
-    find "$DATABASE_DIR" -name "core-data-*.json.gz" -type f -mtime +30 -exec rm {} \;
-
-    # We initially compressed with gzip, this can be removed when none left.
-    find "$BACKUP_DIR" -name "*-db.sqlite3.gz" -type f -mtime +30 -exec rm {} \;
     find "$BACKUP_DIR" -name "*-db.sqlite3.zst" -type f -mtime +30 -exec rm {} \;
 }
 


### PR DESCRIPTION
These lines were gradually removing old-format backups as they aged out past 30 days. Now there are none left, they do no useful work and are no longer required.

We changed the format of backups from `.json` to `.sqlite3` in #2214 (cdbacb67c62fe6501c6c5164eda62937c71373a1)  on Dec 9, 2024.

We changed the compression format from `gzip` to `Zstandard` in #2248 (79841764b49733510c191bbb2aea3bf5860550a5) on Dec 16, 2024.