### PR TITLE
Codelist create form: Check for `UnicodeDecodeError`

### DIFF
--- a/opencodelists/forms.py
+++ b/opencodelists/forms.py
@@ -77,13 +77,21 @@ class CodelistCreateForm(forms.Form):
         if not f:
             return
 
+        try:
+            data = f.read().decode("utf-8-sig")
+        except UnicodeDecodeError as exception:
+            raise forms.ValidationError(
+                "File could not be read. Please ensure the file contains CSV "
+                "data (not Excel, for example). It should be a text file encoded "
+                f"in the UTF-8 format. Error details: {exception}."
+            )
+
         # Eventually coding system version may be a selectable field, but for now it
-        # just defaults to using the most recent one
+        # just defaults to using the most recent one.
         coding_system = CODING_SYSTEMS[
             self.cleaned_data["coding_system_id"]
         ].get_by_release_or_most_recent()
 
-        data = f.read().decode("utf-8-sig")
         codes = [row[0] for row in csv.reader(StringIO(data)) if row]
         validate_csv_data_codes(coding_system, codes)
         return codes


### PR DESCRIPTION
Fixes #1474.

Otherwise there can be an unhandled exception and 500 error if trying to upload a file encoded differently, or if an XLSX is accidentally uploaded in place of CSV text.

I considered looking at the file extension to try to provide extra hints but it didn't seem worth the complication, the error message tells them what they need to do clearly enough.

There were no tests of this form specifically so I added a basic valid form test as well as the test of the error case.
[codelists/tests/views/test_codelist_create.py](https://github.com/opensafely-core/opencodelists/blob/main/codelists/tests/views/test_codelist_create.py) has tests of the view as a whole but they seemed to relate to behaviour before or after the form is processed.