### PR TITLE
Improve sqlite configuration options

### DIFF
--- a/opencodelists/settings.py
+++ b/opencodelists/settings.py
@@ -174,10 +174,17 @@ WSGI_APPLICATION = "opencodelists.wsgi.application"
 # see coding_systems.versioning.models.update_coding_system_database_connections (called
 # from coding_systems.versioning.apps)
 DATABASES = {
-    "default": dj_database_url.parse(
-        os.environ.get("DATABASE_URL", default="sqlite:///db.sqlite3")
-    ),
-    "OPTIONS": {"timeout": 90},
+    "default": {
+        **dj_database_url.parse(
+            os.environ.get("DATABASE_URL", default="sqlite:///db.sqlite3")
+        ),
+        "OPTIONS": {
+            # Transaction timeout in seconds. 5 is the default applied by the
+            # django backend; uncomment and edit the following line to change
+            # it.
+            # "timeout": 5,
+        },
+    }
 }
 
 DATABASE_DIR = Path(os.environ.get("DATABASE_DIR", default=BASE_DIR))

--- a/opencodelists/tests/integration/test_db_settings.py
+++ b/opencodelists/tests/integration/test_db_settings.py
@@ -1,12 +1,19 @@
 import pytest
-from django.db.utils import ConnectionHandler
+from django.db import ConnectionHandler, connection, transaction
+from django.db.backends.utils import CursorWrapper
+from django.test.utils import CaptureQueriesContext
 
 
-@pytest.mark.django_db
+def _assert_pragma(cursor: CursorWrapper, name: str, value: str | int):
+    assert cursor.execute(f"PRAGMA {name}").fetchone()[0] == value
+
+
+@pytest.mark.django_db()
 class TestDatabaseSettings:
     """Tests that our intended core DB settings will be correctly applied.
 
-    I say 'will be' because tests can't actually access the prod core DB."""
+    I say 'will be' because tests can't actually access the prod core DB. So
+    the tests that rely on the database state can't test that directly."""
 
     @pytest.fixture()
     def fresh_db_cursor(self, settings, tmp_path):
@@ -26,13 +33,54 @@ class TestDatabaseSettings:
                 },
             }
         )
-        cursor = connections["default"].cursor()
+        self.connection = connections["default"]
+        cursor = self.connection.cursor()
         yield cursor
         cursor.close()
-        connections["default"].close()
+        self.connection.close()
 
     def test_database_pragma_busy_timeout(self, fresh_db_cursor):
         """Test that the `busy_timeout` parameter is set as we expect.
 
-        We don't set this explicitly in settings, but Django defaults it to 5s."""
-        assert fresh_db_cursor.execute("PRAGMA busy_timeout").fetchone()[0] == 5000
+        We don't set this explicitly in settings, but Django defaults it to 5s. Let's check."""
+        # https://www.sqlite.org/pragma.html#pragma_busy_timeout
+        # 5 seconds in milliseconds == 5000.
+        _assert_pragma(fresh_db_cursor, "busy_timeout", 5000)
+
+    def test_database_pragma_journal_mode(self, fresh_db_cursor):
+        """Test that the `journal_mode` parameter is set as we expect."""
+        # https://www.sqlite.org/pragma.html#pragma_journal_mode
+        # 'wal' = write-ahead logging mode
+        _assert_pragma(fresh_db_cursor, "journal_mode", "wal")
+
+    def test_database_pragma_synchronous(self, fresh_db_cursor):
+        """Test that the `synchronous` parameter is set as we expect."""
+        # https://www.sqlite.org/pragma.html#pragma_synchronous
+        # 2 == NORMAL
+        _assert_pragma(fresh_db_cursor, "synchronous", 2)
+
+    def test_database_pragma_cache_size(self, fresh_db_cursor):
+        """Test that the `cache_size` parameter is set as we expect."""
+        # https://www.sqlite.org/pragma.html#pragma_cache_size
+        # -256000 = 200 * 1024Kb = 250MB. Negative indicates KB measurement.
+        _assert_pragma(fresh_db_cursor, "cache_size", -256000)
+
+    def test_database_pragma_foreign_keys(self, fresh_db_cursor):
+        """Test that the `foreign_keys` parameter is set as we expect.
+
+        We don't explicitly set this, Django does. Let's check."""
+        # https://www.sqlite.org/pragma.html#pragma_foreign_keys
+        # C boolean, 1 = True
+        _assert_pragma(fresh_db_cursor, "foreign_keys", 1)
+
+    @pytest.mark.django_db(transaction=True)
+    def test_transaction_mode_immediate(self):
+        """Test that Django opens connections in IMMEDIATE mode."""
+        # Note that this test doesn't care about any property of the database
+        # other than that it's a sqlite3 database, so there's no need to use
+        # the fresh_db_cursor fixture, the normal in-memory test database works
+        # fine.
+        with CaptureQueriesContext(connection) as ctx:
+            with transaction.atomic():
+                pass
+        assert ctx.captured_queries[0]["sql"] == "BEGIN IMMEDIATE"

--- a/opencodelists/tests/integration/test_db_settings.py
+++ b/opencodelists/tests/integration/test_db_settings.py
@@ -1,0 +1,38 @@
+import pytest
+from django.db.utils import ConnectionHandler
+
+
+@pytest.mark.django_db
+class TestDatabaseSettings:
+    """Tests that our intended core DB settings will be correctly applied.
+
+    I say 'will be' because tests can't actually access the prod core DB."""
+
+    @pytest.fixture()
+    def fresh_db_cursor(self, settings, tmp_path):
+        """Provide a cursor for a connection to a freshly-created
+        filesystem-based database based on the core default configuration.
+
+        The standard test database is memory-based, and may be configured
+        differently, so we don't just check against that. Scope is
+        test-function to avoid any interaction between tests.
+        """
+        tmp_db_path = tmp_path / "test.db"
+        connections = ConnectionHandler(
+            {
+                "default": {
+                    **settings.DATABASES["default"],
+                    "NAME": tmp_db_path,
+                },
+            }
+        )
+        cursor = connections["default"].cursor()
+        yield cursor
+        cursor.close()
+        connections["default"].close()
+
+    def test_database_pragma_busy_timeout(self, fresh_db_cursor):
+        """Test that the `busy_timeout` parameter is set as we expect.
+
+        We don't set this explicitly in settings, but Django defaults it to 5s."""
+        assert fresh_db_cursor.execute("PRAGMA busy_timeout").fetchone()[0] == 5000


### PR DESCRIPTION
Fixes #2268.

We think immediate mode in particular might help resolve 'database is locked' errors.

Options used here are largely following suggestions from the article https://kerkour.com/sqlite-for-servers as referenced in #2268/#2251, some of which I found Django applies by default. See commit messages for more discussion. In particular, I think we should not be using an excessively large timeout as this can cause users to wait a long time if there was a problem with the site. Let's try 5 seconds and see if the other settings changes resolve the issue, then gradually increase the value if there are still many errors.

I discovered that unfortunately we have been configuring the timeout settings for the default database incorrectly, so #1143, #1811, #2276 increasing it from5 ro 30, 60, and most recently 90 seconds had no effect. This might explain why the "database is locked" errors that they sought to remedy never improved.

```python
DATABASES = {
    "default": dj_database_url.parse(
        os.environ.get("DATABASE_URL", default="sqlite:///db.sqlite3")
    ),
    "OPTIONS": {"timeout": 90},
}
```

The `OPTIONS` parameter is a key of `DATABASES`, not `DATABASES["default"]`. Therefore it doesn't apply to any database and does not take effect. This can be verified by checking `PRAGMA busy_timeout`, for example in a management command ([show_db_timeout.txt](https://github.com/user-attachments/files/18774679/show_db_timeout.txt)). By default it's 5 seconds. Correct the structure of `DATABASES` and the changed setting is respected.

Added tests of the settings. I wondered if this is just testing `django`, but we've seen a minor error in configuring `DATABASES` can lead to unintended results, so let's test. Also to demonstrate that defaults do indeed take effect, and that the options work are applied to the DB / transactions as we expect.

I've attached two more throwaway management commands. One (
[upgraded_transaction_fail.txt](https://github.com/user-attachments/files/18774677/upgraded_transaction_fail.txt)) I used to satisfy myself that changing to immediate mode fixes the "database is locked" issue when a transaction start as a read and upgrades to a write while another holds the lock. And another ([profile_db.txt](https://github.com/user-attachments/files/18774678/profile_db.txt)) to try bulk writes (I think this can be used to demonstrate that transactions that start by writing are affected by the DB lock regardless of transaction mode setting). I don't think the reviewer need to look at these, it's in case they're useful for debugging etc. in future. All designed to work with `class TestTable(models.Model): value = models.CharField(max_length=255)` in opencodelists/models.py

Approach to testing inspired by https://github.com/opensafely-core/airlock/issues/248. I noticed some of the settings they apply there from the article don't need to be set explicitly in Django as it applies them automatically. But maybe they're setting them for future-proofing or to be explicit? I might mention that to team RAP.