### PR TITLE
Use the current year in copyright notice

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -152,7 +152,7 @@
 
           <div class="row">
             <div class="col-12 offset-md-1 col-md-10 offset-lg-2 col-lg-8 text-center mt-3 mb-0 small">
-              <p>© University of Oxford for the Bennett Institute for Applied Data Science 2022. This work may be copied freely for non-commercial research and study. If you wish to do any of the other acts restricted by the copyright you should apply in writing to <a href="mailto:team@opensafely.org">team@opensafely.org</a>.</p>
+              <p>© University of Oxford for the Bennett Institute for Applied Data Science {% now "Y" %}. This work may be copied freely for non-commercial research and study. If you wish to do any of the other acts restricted by the copyright you should apply in writing to <a href="mailto:team@opensafely.org">team@opensafely.org</a>.</p>
               <p>SNOMED Clinical Terms® content © International Health Terminology Standards Development Organisation.</p>
               <p>ICD-10 codes, terms and text © World Health Organization, Third Edition. 2007.</p>
             </div>


### PR DESCRIPTION
The "2022" potentially makes the site look unmaintained, which isn't the case.