### PR TITLE
Correct datatypes for sentry monitor config

### DIFF
--- a/deploy/bin/sentry_cron_functions.sh
+++ b/deploy/bin/sentry_cron_functions.sh
@@ -44,8 +44,8 @@ function sentry_cron_start() {
                 "type":"crontab",
                 "value": "%s"
                 },
-            "checkin_margin":"5",
-            "max_runtime":"300"
+            "checkin_margin":5,
+            "max_runtime":300
             },
         "status":"in_progress"
         }' "$CRONTAB")


### PR DESCRIPTION
These values need to be ints