### PR TITLE
Create a default issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/default.md
+++ b/.github/ISSUE_TEMPLATE/default.md
@@ -1,0 +1,23 @@
+---
+name: Default issue
+about: Create a standard delivery task
+title: ""
+labels: ""
+assignees: ""
+---
+
+# Why are we doing this?
+
+...
+
+# How will we know when it's done?
+
+...
+
+# What are we doing?
+
+...
+
+---
+
+[Defining delivery tasks guidance](https://bennett.wiki/tech-group/delivery-process/task-definition/)


### PR DESCRIPTION
This is intended to make it easier for us to create issues that are inline with the delivery tasks guidance and to help ensure we have the information we need when picking up the issue.