### PR TITLE
Remove `DATABASE_DUMP_DIR` setting

### DIFF
--- a/opencodelists/settings.py
+++ b/opencodelists/settings.py
@@ -213,7 +213,6 @@ DATABASES = {
 
 DATABASE_DIR = Path(os.environ.get("DATABASE_DIR", default=BASE_DIR))
 # location of sqlite files e.g. /storage/
-DATABASE_DUMP_DIR = DATABASE_DIR / "sql_dump"
 CODING_SYSTEMS_DATABASE_DIR = DATABASE_DIR / "coding_systems"
 DATABASE_ROUTERS = ["opencodelists.db_utils.CodingSystemReleaseRouter"]
 


### PR DESCRIPTION
This is no longer needed. It was added in
https://github.com/opensafely-core/opencodelists/pull/1397 for management command `coding_systems/versioning/management/commands/migrate_coding_system.py` which no longer exists. There are no references to the setting in the repo.