### PR TITLE
Add manage and migrations convenience justfile recipies

### DIFF
--- a/justfile
+++ b/justfile
@@ -164,6 +164,14 @@ dev-setup: devenv assets
 run: devenv
     $BIN/python manage.py runserver localhost:7000
 
+# Run a Django management command
+manage command *args: devenv
+    $BIN/python manage.py {{command}} {{args}}
+
+# Generate migrations and apply unapplied ones
+migrations: devenv
+    just manage makemigrations
+    just manage migrate
 
 # Remove built assets and collected static files
 assets-clean:


### PR DESCRIPTION
I regularly find myself wanting to run a Django management command with the devenv's environment with something like .venv/bin/python3.12 manage.py command. Let's add a recipe to make that slightly easier.

`migrations` command provides one command to update the DB after models changes.