### PR TITLE
Fix removal of old sanitised backups

### DIFF
--- a/deploy/bin/backup.sh
+++ b/deploy/bin/backup.sh
@@ -47,7 +47,7 @@ function run_backup() {
     find "$BACKUP_DIR" -name "*-db.sqlite3.zst" -type f -mtime +30 -exec rm {} \;
 
     # Keep only the most recent sanitised backup.
-    find "$BACKUP_DIR" -name "*sanitised*-db.sqlite3.zst" ! -name "$SANITISED_BACKUP_FILEPATH.zst" -type f -exec rm {} \;
+    find "$BACKUP_DIR" -name "*sanitised*-db.sqlite3.zst" ! -wholename "$SANITISED_BACKUP_FILEPATH.zst" -type f -exec rm {} \;
 }
 
 # log start of backup in a way that won't fail the whole script if sentry down


### PR DESCRIPTION
using -name to exclude files from `find` when the pattern contains directory separators (which in the case of $BACKUP_FILEPATH it does) gives the following error:

"find: warning: ‘-name’ matches against basenames only, but the given pattern contains a directory separator (‘/’), thus the expression will evaluate to false all the time. Did you mean ‘-wholename’?"

and fails to exclude the most recent backup file as desired.

Using -wholename as suggested fixes this.