### PR TITLE
Fix sanitised backup symlink

### DIFF
--- a/deploy/bin/backup.sh
+++ b/deploy/bin/backup.sh
@@ -15,7 +15,8 @@ SENTRY_CRON_URL=$(sentry_cron_url "$SENTRY_DSN" "$SENTRY_MONITOR_NAME")
 BACKUP_DIR="$DATABASE_DIR/backup/db"
 BACKUP_FILENAME="$(date +%F)-db.sqlite3"
 BACKUP_FILEPATH="$BACKUP_DIR/$BACKUP_FILENAME"
-SANITISED_BACKUP_FILEPATH="$BACKUP_DIR/sanitised-$BACKUP_FILENAME"
+SANITISED_BACKUP_FILENAME="sanitised-$BACKUP_FILENAME"
+SANITISED_BACKUP_FILEPATH="$BACKUP_DIR/$SANITISED_BACKUP_FILENAME"
 
 function run_backup() {
     # Make the backup dir if it doesn't exist.
@@ -41,7 +42,7 @@ function run_backup() {
     # Make the target a relative path -- an absolute one won't mean the same thing
     # in the host file system if executed inside a container as we expect.
     ln -sf "$BACKUP_FILENAME.zst" "$BACKUP_DIR/latest-db.sqlite3.zst"
-    ln -sf "$SANITISED_BACKUP_FILEPATH.zst" "$BACKUP_DIR/sanitised-latest-db.sqlite3.zst"
+    ln -sf "$SANITISED_BACKUP_FILENAME.zst" "$BACKUP_DIR/sanitised-latest-db.sqlite3.zst"
 
     # Keep only the last 30 days of raw backups.
     find "$BACKUP_DIR" -name "*-db.sqlite3.zst" -type f -mtime +30 -exec rm {} \;


### PR DESCRIPTION
Use relative path for target as per regular backup symlink


testing:


```sh
I have no name!@0cf1ecf54587:/app$ cd deploy/bin/
I have no name!@0cf1ecf54587:/app/deploy/bin$ BACKUP_DIR="$DATABASE_DIR/backup/db"
BACKUP_FILENAME="$(date +%F)-db.sqlite3"
BACKUP_FILEPATH="$BACKUP_DIR/$BACKUP_FILENAME"
SANITISED_BACKUP_FILENAME="sanitised-$BACKUP_FILENAME"
SANITISED_BACKUP_FILEPATH="$BACKUP_DIR/$SANITISED_BACKUP_FILENAME"
I have no name!@0cf1ecf54587:/app/deploy/bin$ echo "$SANITISED_BACKUP_FILENAME"
sanitised-2025-03-25-db.sqlite3
I have no name!@0cf1ecf54587:/app/deploy/bin$ echo "$SANITISED_BACKUP_FILEPATH"
/storage/backup/db/sanitised-2025-03-25-db.sqlite3
I have no name!@0cf1ecf54587:/app/deploy/bin$ ln -sf "$SANITISED_BACKUP_FILENAME.zst" "$BACKUP_DIR/sanitised-latest-db.sqlite3.zst"
I have no name!@0cf1ecf54587:/app/deploy/bin$ cd /storage/backup/db/
I have no name!@0cf1ecf54587:/storage/backup/db$ readlink -f sanitised-latest-db.sqlite3.zst
/storage/backup/db/sanitised-2025-03-25-db.sqlite3.zst
I have no name!@0cf1ecf54587:/storage/backup/db$ stat /storage/backup/db/sanitised-2025-03-25-db.sqlite3.zst
  File: /storage/backup/db/sanitised-2025-03-25-db.sqlite3.zst
  Size: 1214746091      Blocks: 2372560    IO Block: 4096   regular file
Device: fc01h/64513d    Inode: 775251      Links: 1
Access: (0644/-rw-r--r--)  Uid: (10003/ UNKNOWN)   Gid: (10003/ UNKNOWN)
Access: 2025-03-25 05:02:45.111062294 +0000
Modify: 2025-03-25 05:01:17.106673066 +0000
Change: 2025-03-25 05:02:45.111062294 +0000
 Birth: 2025-03-25 05:01:59.826862730 +0000

```