### PR TITLE
Fix for missing templates in Docker npm build

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -45,9 +45,10 @@ RUN --mount=type=cache,target=/usr/src/app/.npm \
     npm set cache /usr/src/app/.npm && \
     npm ci
 
-# copy just what npm build needs
+# just copy in the files `npm run build` needs
 COPY vite.config.mjs ./
-COPY assets ./assets
+COPY assets/src ./assets/src
+COPY templates ./templates
 RUN --mount=type=cache,target=./npm npm run build
 
 ##################################################


### PR DESCRIPTION
Tailwind requires the templates to be able to build the stylesheet.

[Prior art from Job Server](https://github.com/opensafely-core/job-server/blob/741168fa369be20c5d3b1615710c3c1d5804a027/docker/Dockerfile#L46-L49).