### PR TITLE
Spike dmd codelist builder

### DIFF
--- a/codelists/models.py
+++ b/codelists/models.py
@@ -495,7 +495,7 @@ class CodelistVersion(models.Model):
             return self._new_style_codes()
 
     def _old_style_codes(self):
-        if self.coding_system_id in ["bnf", "ctv3", "icd10", "snomedct"]:
+        if self.coding_system_id in ["bnf", "ctv3", "icd10", "snomedct", "dmd"]:
             headers, *rows = self.table
             headers = [header.lower().strip() for header in headers]
             # (non-dmd) old style codelists are now required to contain a column named "code"

--- a/codelists/tests/views/test_version_diff.py
+++ b/codelists/tests/views/test_version_diff.py
@@ -61,12 +61,17 @@ def test_get_dmd_diff_codes_differ(
     assert rsp.context["lhs_only_codes"] == {"10514511000001106"}
     assert rsp.context["rhs_only_codes"] == {"123"}
     assert rsp.context["rhs_only_summary"] == [
-        {"code": "123", "term": "[Unknown] Test refill (VMP)"}
+        {
+            "code": "123",
+            "term": "[Unknown] Test refill (VMP)",
+            "descendants": [],
+        }
     ]
     assert rsp.context["common_summary"] == [
         {
             "code": "10525011000001107",
             "term": "Adrenaline (base) 220micrograms/dose inhaler refill (VMP)",
+            "descendants": [],
         }
     ]
 
@@ -119,12 +124,17 @@ def test_get_dmd_diff_alternative_column_names(
     assert rsp.context["lhs_only_codes"] == {"10514511000001106"}
     assert rsp.context["rhs_only_codes"] == {"123"}
     assert rsp.context["rhs_only_summary"] == [
-        {"code": "123", "term": expected_unknown_term}
+        {
+            "code": "123",
+            "term": expected_unknown_term,
+            "descendants": [],
+        }
     ]
     assert rsp.context["common_summary"] == [
         {
             "code": "10525011000001107",
             "term": "Adrenaline (base) 220micrograms/dose inhaler refill (VMP)",
+            "descendants": [],
         }
     ]
 

--- a/coding_systems/dmd/coding_system.py
+++ b/coding_systems/dmd/coding_system.py
@@ -1,12 +1,10 @@
 from django.db.models import Q
 
-from django.db.models import Q
-
-from ..base.coding_system_base import BaseCodingSystem
+from ..base.coding_system_base import BuilderCompatibleCodingSystem
 from .models import AMP, AMPP, VMP, VMPP, VTM, Ing
 
 
-class CodingSystem(BaseCodingSystem):
+class CodingSystem(BuilderCompatibleCodingSystem):
     id = "dmd"
     name = "Dictionary of Medicines and Devices"
     short_name = "dm+d"

--- a/coding_systems/dmd/coding_system.py
+++ b/coding_systems/dmd/coding_system.py
@@ -1,5 +1,7 @@
 from django.db.models import Q
 
+from django.db.models import Q
+
 from ..base.coding_system_base import BaseCodingSystem
 from .models import AMP, AMPP, VMP, VMPP, VTM, Ing
 
@@ -15,28 +17,104 @@ class CodingSystem(BaseCodingSystem):
 
     def ancestor_relationships(self, codes):
         amps = AMP.objects.using(self.database_alias).filter(id__in=codes)
+        vmps = VMP.objects.using(self.database_alias).filter(
+            id__in=(set(codes) | {amp.vmp_id for amp in amps})
+        )
 
-        # get VMPs that are either in `codes` or are ancestors
-        # of the AMPs in `codes`
-        codes = set(codes) | {amp.vmp_id for amp in amps}
-        vmps = VMP.objects.using(self.database_alias).filter(id__in=codes)
-
-        # exclude null VTM-VMP relationships (i.e. VMPs with no VTM)
         return {(amp.vmp_id, amp.id) for amp in amps} | {
-            (vmp.vtm_id, vmp.id) for vmp in vmps if vmp.vtm_id
+            (vpi.ing_id, vmp.id) for vmp in vmps for vpi in vmp.vpi_set.all()
         }
 
     def descendant_relationships(self, codes):
-        vmps_from_vtms = VMP.objects.using(self.database_alias).filter(vtm__in=codes)
-
-        # get AMPs that have ancestor VMPs that are either in `codes`
-        # or are descendants of VTMs that are in `codes`
-        codes = set(codes) | {vmp.id for vmp in vmps_from_vtms}
+        vmps_from_ings = VMP.objects.using(self.database_alias).filter(
+            vpi__ing_id__in=codes
+        )
+        amps_from_ings = AMP.objects.using(self.database_alias).filter(
+            vmp_id__in=[vmp.id for vmp in vmps_from_ings]
+        )
         amps_from_vmps = AMP.objects.using(self.database_alias).filter(vmp_id__in=codes)
 
-        return {(vmp.vtm_id, vmp.id) for vmp in vmps_from_vtms} | {
-            (amp.vmp_id, amp.id) for amp in amps_from_vmps
+        rv = (
+            {
+                (vpi.ing_id, vmp.id)
+                for vmp in vmps_from_ings
+                for vpi in vmp.vpi_set.all()
+            }
+            | {(amp.vmp_id, amp.id) for amp in amps_from_ings}
+            | {(amp.vmp_id, amp.id) for amp in amps_from_vmps}
+        )
+        return rv
+
+    def search_by_term(self, term):
+        return (
+            set(
+                Ing.objects.using(self.database_alias)
+                .filter(nm__contains=term)
+                .values_list("id", flat=True)
+            )
+            | set(
+                VMP.objects.using(self.database_alias)
+                .filter(nm__contains=term)
+                .values_list("id", flat=True)
+            )
+            | set(
+                AMP.objects.using(self.database_alias)
+                .filter(Q(nm__contains=term) | Q(descr__contains=term))
+                .values_list("id", flat=True)
+            )
+        )
+
+    def search_by_code(self, code):
+        return (
+            set(
+                Ing.objects.using(self.database_alias)
+                .filter(id=code)
+                .values_list("id", flat=True)
+            )
+            | set(
+                VMP.objects.using(self.database_alias)
+                .filter(id=code)
+                .values_list("id", flat=True)
+            )
+            | set(
+                AMP.objects.using(self.database_alias)
+                .filter(id=code)
+                .values_list("id", flat=True)
+            )
+        )
+
+    def codes_by_type(self, codes, hierarchy):
+        d = {
+            "Ingredient": Ing.objects.using(self.database_alias)
+            .filter(id__in=codes)
+            .values_list("id", flat=True),
+            "VMP": VMP.objects.using(self.database_alias)
+            .filter(id__in=codes)
+            .values_list("id", flat=True),
+            "AMP": AMP.objects.using(self.database_alias)
+            .filter(id__in=codes)
+            .values_list("id", flat=True),
         }
+        return {k: v for k, v in d.items() if v}
+
+    def matching_codes(self, codes):
+        return (
+            set(
+                Ing.objects.using(self.database_alias)
+                .filter(id__in=codes)
+                .values_list("id", flat=True)
+            )
+            | set(
+                VMP.objects.using(self.database_alias)
+                .filter(id__in=codes)
+                .values_list("id", flat=True)
+            )
+            | set(
+                AMP.objects.using(self.database_alias)
+                .filter(id__in=codes)
+                .values_list("id", flat=True)
+            )
+        )
 
     def lookup_names(self, codes):
         # A code is a unique identifier in dm+d which corresponds to a SNOMED-CT code
@@ -47,7 +125,7 @@ class CodingSystem(BaseCodingSystem):
         # might contain these
         codes = set(codes)
         lookup = {}
-        for model_cls in [AMP, VMP, AMPP, VMPP, VTM]:
+        for model_cls in [AMP, VMP, AMPP, VMPP, VTM, Ing]:
             matched = dict(
                 model_cls.objects.using(self.database_alias)
                 .filter(id__in=codes)


### PR DESCRIPTION
Demonstration of what a first fix of #2388 could look like.


Currently this shows medicinal products in a hierarchy of VTM->VMP->AMP, but searches across Ingredient, VTM, VMP, AMP (by code and name). The VTM-Ing ingredient relationship is of a many-to-many form such that that neither hierarchy of Ing->VTM->VMP->AMP nor VTM->Ing->VMP->AMP make sense. Additionally, there is no direct link between VTM and Ing, only via VMP and VPI.

For example, VTM 776002003 ("Fluorouracil") is related to VMPs that have a single ingredient of one of two forms of Fluorouracil: 387172005 ("Fluorouracil") or 441807008 ("Fluorouracil sodium"), which implies that the VTM is the "parent" object of these two active forms of this drug.

However, Ing 372687004 ("Amoxicillin") is present in VMPs that belong to multiple VTMs: 774586009 ("Amoxicillin") and 774587000 ("Co-Amoxiclav") which implies that the Ing is a parent of both those VTMs.

_[...and these VTMs also have relationships to VMPs with other amoxicillin salts, both as a single ingredient and in combination with clavulanic acid which further reveals that this is not resolvable to a single hierarchy...]_

Thus, searching on Ing but omitting it from the hierarchy is a reasonable compromise - the downside being that a user trying to make a codelist of a very specific ingredient form rather than the general would have to manually select the codes for inclusion and exclusion. I feel like this is a rarer case than users wanting to differentiate between different therapeutic combinations that may contain a particular ingredient (e.g. only non-potentiated Amoxicillins,  paracetamol in combination with codeine but not codeine-only or paracetamol-only products).


Strength and Route and two concepts that are not included in this spike (raised by @rw251 and @sebbacon  I believe) but are useful classification axes for medication codelist building ("all nasal sprays", "low-dose statins"). We would have to do some analysis to see if these would be able to fit in a simple hierarchy. My instinct tells me Route should be OK - I'm not aware of any products that have multiple routes of administration; but each ingredient in a VMP has its own strength so this may be more complicated. It may be that there aren't many strength options for a VMPs of a particular Route and VTM so the potential amount of user-clicking to achieve their desired inclusions and exclusions mightn't be _too_ bad.