### PR TITLE
Finalize Sentry release after deployment completes

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -58,6 +58,17 @@ jobs:
             docker tag $IMAGE_NAME $PUBLIC_IMAGE_NAME:latest
             docker push $PUBLIC_IMAGE_NAME:latest
 
+      - name: Create Sentry release
+        uses: getsentry/action-release@00ed2a6cc2171514e031a0f5b4b3cdc586dc171a  # v3.1.1
+        env:
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_RELEASE_INTEGRATION_TOKEN }}
+          SENTRY_ORG: ebm-datalab
+          SENTRY_PROJECT: opencodelists
+        with:
+          environment: production
+          ignore_empty: true
+          finalize: false
+
       - name: Setup SSH Agent
         run: |
             ssh-agent -a $SSH_AUTH_SOCK > /dev/null
@@ -77,3 +88,4 @@ jobs:
         with:
           environment: production
           ignore_empty: true
+          finalize: true


### PR DESCRIPTION
Fixes #2391.

Mirrors what we did in:

opensafely-core/job-server#5053