### PR TITLE
Added debug config for vscode

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,31 @@
+{
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "Debug: Launch opencodelists",
+      "type": "debugpy",
+      "request": "launch",
+      "args": ["runserver", "localhost:7000"],
+      "django": true,
+      "autoStartBrowser": true,
+      "program": "${workspaceFolder}/manage.py",
+      "justMyCode": true
+    },
+    {
+      "name": "Debug: Current test file",
+      "type": "debugpy",
+      "request": "launch",
+      "args": ["${file}"],
+      "module": "pytest",
+      "console": "integratedTerminal"
+    },
+    {
+      "name": "Debug: Playwright test file",
+      "type": "debugpy",
+      "request": "launch",
+      "args": ["${file}", "--headed"],
+      "module": "pytest",
+      "console": "integratedTerminal"
+    }
+  ]
+}


### PR DESCRIPTION
Added some debugging shortcuts for vscode users. One click setup for:
1. Launching opencodelists in debug mode
2. Debugging the current test file
3. Debugging the current PlayWright test file (in anticipation of PlayWright tests)