### PR TITLE
Add instructions to initial codelist builder template

### DIFF
--- a/assets/src/scripts/components/CodelistBuilder.tsx
+++ b/assets/src/scripts/components/CodelistBuilder.tsx
@@ -3,6 +3,7 @@ import { Col, Row } from "react-bootstrap";
 import Hierarchy from "../_hierarchy";
 import { getCookie } from "../_utils";
 import { Code, PageData, Status } from "../types";
+import EmptyState from "./EmptyState";
 import Filter from "./Filter";
 import ManagementForm from "./ManagementForm";
 import Search from "./Search";
@@ -214,21 +215,27 @@ export default class CodelistBuilder extends React.Component<
             </ul>
           </Col>
 
-          <Col md="9" className="overflow-auto">
-            <h3 className="h4">{resultsHeading}</h3>
-            <hr />
-            <TreeTables
-              allCodes={allCodes}
-              codeToStatus={this.state.codeToStatus}
-              codeToTerm={codeToTerm}
-              hierarchy={hierarchy}
-              isEditable={isEditable}
-              toggleVisibility={() => null}
-              treeTables={treeTables}
-              updateStatus={this.updateStatus}
-              visiblePaths={visiblePaths}
-            />
-          </Col>
+          {isEmpty ? (
+            <Col md="9">
+              <EmptyState />
+            </Col>
+          ) : (
+            <Col md="9" className="overflow-auto">
+              <h3 className="h4">{resultsHeading}</h3>
+              <hr />
+              <TreeTables
+                allCodes={allCodes}
+                codeToStatus={this.state.codeToStatus}
+                codeToTerm={codeToTerm}
+                hierarchy={hierarchy}
+                isEditable={isEditable}
+                toggleVisibility={() => null}
+                treeTables={treeTables}
+                updateStatus={this.updateStatus}
+                visiblePaths={visiblePaths}
+              />
+            </Col>
+          )}
         </Row>
       </>
     );

--- a/assets/src/scripts/components/CodelistBuilder.tsx
+++ b/assets/src/scripts/components/CodelistBuilder.tsx
@@ -143,6 +143,12 @@ export default class CodelistBuilder extends React.Component<
       visiblePaths,
     } = this.props;
 
+    const isEmpty =
+      searches.length === 0 &&
+      treeTables.length === 0 &&
+      resultsHeading ===
+        "Start building your codelist by searching for a term or a code";
+
     return (
       <>
         <Row>

--- a/assets/src/scripts/components/CodelistBuilder.tsx
+++ b/assets/src/scripts/components/CodelistBuilder.tsx
@@ -155,10 +155,14 @@ export default class CodelistBuilder extends React.Component<
           <Col md="3">
             {isEditable && <ManagementForm counts={this.counts()} />}
 
-            <h3 className="h6">Summary</h3>
-            <Filter filter={filter} />
-            <Summary counts={this.counts()} />
-            <hr />
+            {!isEmpty ? (
+              <>
+                <Filter filter={filter} />
+                <h3 className="h6">Summary</h3>
+                <Summary counts={this.counts()} />
+                <hr />
+              </>
+            ) : null}
 
             {searches.length > 0 && (
               <Search draftURL={draftURL} searches={searches} />

--- a/assets/src/scripts/components/EmptyState.tsx
+++ b/assets/src/scripts/components/EmptyState.tsx
@@ -1,0 +1,34 @@
+import React from "react";
+
+export default function EmptyState() {
+  return (
+    <section style={{ maxWidth: "80ch" }}>
+      <h2>Create a codelist</h2>
+      <p className="lead">
+        Search for medical terms or codes to find matching concepts. Then select
+        which concepts you want to include in your codelist.
+      </p>
+      <p>To get started with the search form on the left:</p>
+      <ol>
+        <li>
+          Choose whether to search using a medical term (like "asthma") or a
+          specific code
+        </li>
+        <li>
+          Type your search term or code into the search box and click Search
+        </li>
+        <li>
+          The results will show matching concepts organized in a tree structure,
+          including any related sub-concepts
+        </li>
+      </ol>
+      <p>
+        Your search history will appear below the search box. You can click on
+        any previous search to see those results again.
+      </p>
+      <a href="/docs" target="_blank" rel="noopener noreferrer">
+        View the documentation &rarr;
+      </a>
+    </section>
+  );
+}


### PR DESCRIPTION
Part of [Improve instructions to users on initial codelist creation page #2395](https://github.com/opensafely-core/opencodelists/issues/2395).

