### PR TITLE
Fix slowdown due to modal text recalculation

### DIFF
--- a/assets/src/scripts/components/CodelistBuilder.tsx
+++ b/assets/src/scripts/components/CodelistBuilder.tsx
@@ -24,7 +24,6 @@ export default class CodelistBuilder extends React.Component<
     updating: boolean;
   }
 > {
-  private _isMounted: boolean = false;
   constructor(props: CodelistBuilderProps) {
     super(props);
 
@@ -46,15 +45,6 @@ export default class CodelistBuilder extends React.Component<
     this.setState({
       expandedCompatibleReleases: !this.state.expandedCompatibleReleases,
     });
-  }
-
-  componentDidMount() {
-    // This is required for testing.  See other uses for _isMounted for explanation.
-    this._isMounted = true;
-  }
-
-  componentWillUnmount() {
-    this._isMounted = false;
   }
 
   updateStatus(code: Code, status: Status) {
@@ -98,14 +88,6 @@ export default class CodelistBuilder extends React.Component<
     })
       .then((response) => response.json())
       .then((data) => {
-        if (!this._isMounted) {
-          // In tests the compenent is unmounted, and this may happen before
-          // the promise is resolved.  Calling setState on an unmounted
-          // component is a no-op and may indicate a memory leak, so it triggers
-          // a warning.  Exiting early here prevents that warning.
-          return;
-        }
-
         const lastUpdates = data.updates;
 
         this.setState(

--- a/assets/src/scripts/components/CodelistBuilder.tsx
+++ b/assets/src/scripts/components/CodelistBuilder.tsx
@@ -102,7 +102,11 @@ export default class CodelistBuilder extends React.Component<
   }
 
   counts() {
-    let counts = {
+    // Define the list of valid status values that we want to count
+    const validStatuses = ["?", "!", "+", "(+)", "-", "(-)"];
+
+    // Initialize counts object with 0 for each status and total
+    const counts = {
       "?": 0,
       "!": 0,
       "+": 0,
@@ -111,14 +115,16 @@ export default class CodelistBuilder extends React.Component<
       "(-)": 0,
       total: 0,
     };
-    this.props.allCodes.forEach((code) => {
+
+    // Iterate through all codes and count occurrences of each valid status
+    return this.props.allCodes.reduce((acc, code) => {
       const status = this.state.codeToStatus[code];
-      if (["?", "!", "+", "(+)", "-", "(-)"].includes(status)) {
-        counts[status] += 1;
-        counts["total"] += 1;
+      if (validStatuses.includes(status)) {
+        acc[status]++; // Increment count for this status
+        acc.total++; // Increment total count
       }
-    });
-    return counts;
+      return acc;
+    }, counts);
   }
 
   render() {

--- a/assets/src/scripts/components/MoreInfoModal.tsx
+++ b/assets/src/scripts/components/MoreInfoModal.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
 import { Button, Modal } from "react-bootstrap";
 import Hierarchy from "../_hierarchy";
 import { Code, PageData, Status, Term } from "../types";
@@ -82,15 +82,22 @@ function MoreInfoModal({
   term,
 }: MoreInfoModalProps) {
   const [showMoreInfoModal, setShowMoreInfoModal] = useState(false);
+  const [modalText, setModalText] = useState("");
 
-  const modalText = createModalText({
-    allCodes,
-    code,
-    codeToStatus,
-    codeToTerm,
-    hierarchy,
-    status,
-  });
+  useEffect(() => {
+    if (showMoreInfoModal) {
+      setModalText(
+        createModalText({
+          allCodes,
+          code,
+          codeToStatus,
+          codeToTerm,
+          hierarchy,
+          status,
+        }),
+      );
+    }
+  }, [showMoreInfoModal]);
 
   return (
     <>


### PR DESCRIPTION
When testing the builder as part of unrelated work, I noticed a significant lag between clicking to update the status of a tree item and seeing that change reflected in the UI.

## Issue

The issue was caused by a performance bottleneck: when a status is updated, all hidden modals in the tree rows *below* that item were having their text recalculated. This becomes particularly expensive in large or deeply nested trees.

## Solution

The solution is to defer text calculation until a modal is actually opened. Since this text can be computed just before the modal is added to the DOM, we avoid unnecessary recalculations and improve performance significantly.

## Additional changes

While investigating this issue, I also made two additional improvements:

1. **Removed the `_isMounted` variable** and its related code from `CodelistBuilder`. The issue it was originally introduced to fix is no longer relevant, as confirmed by the current test suite.
2. **Refactored the `counts()` function** to use `Array.reduce()`. `reduce` is designed for transforming a collection into a single accumulated value. Since we're calculating a single counts object from an array of codes, `reduce` is the right thing to use here.