### PR TITLE
Populate development dbs with test fixture data

### DIFF
--- a/coding_systems/versioning/models.py
+++ b/coding_systems/versioning/models.py
@@ -76,13 +76,19 @@ def update_coding_system_database_connections():
         for coding_system_release in CodingSystemRelease.objects.all():
             if not CODING_SYSTEMS[coding_system_release.coding_system].has_database:
                 continue
-            db_path = (
-                settings.CODING_SYSTEMS_DATABASE_DIR
-                / coding_system_release.coding_system
-                / f"{coding_system_release.database_alias}.sqlite3"
-            )
+            db_path = build_db_path(coding_system_release)
             database_dict = {
                 **connections.databases[DEFAULT_DB_ALIAS],
                 **dj_database_url.parse(f"sqlite:///{db_path}"),
             }
             connections.databases[coding_system_release.database_alias] = database_dict
+
+
+def build_db_path(coding_system_release):
+    db_path = (
+        settings.CODING_SYSTEMS_DATABASE_DIR
+        / coding_system_release.coding_system
+        / f"{coding_system_release.database_alias}.sqlite3"
+    )
+
+    return db_path

--- a/opencodelists/management/commands/setup_local_dev_databases.py
+++ b/opencodelists/management/commands/setup_local_dev_databases.py
@@ -1,0 +1,120 @@
+import sys
+
+from django.core.management import BaseCommand, call_command
+
+from coding_systems.versioning.models import (
+    CodingSystemRelease,
+    build_db_path,
+    update_coding_system_database_connections,
+)
+from opencodelists import settings
+from opencodelists.tests.fixtures import build_fixtures
+
+
+class Command(BaseCommand):
+    help = """Populates local opencodelists dbs with test fixture data:
+           Loads the CodingSystemReleases needed for the snomed and dmd
+           fixtures into the Core db (you will be prompted for consent
+           to do this), deletes existing test coding system release dbs,
+           creates new coding system release dbs, populates these with
+           test fixture data, instantiates a universe of fixture
+           objects, and creates a superuser. Running this command
+           directly is not recommended, instead use `just
+           build-dbs-for-local-development`"""
+
+    def handle(self, *args, **options):
+        if not settings.DEBUG:
+            self.stderr.write(
+                "This management command will not run in a production environment."
+            )
+            sys.exit(1)
+
+        load_versioning_fixture_answer = input(
+            "Running this command will load the CodingSystemReleases needed for the snomed and dmd test fixtures, into the Core db. Any local test coding system release dbs will then be deleted and recreated. Do you want to proceed? (Y/n)"
+        )
+
+        if load_versioning_fixture_answer == "n":
+            return
+
+        call_command(
+            "loaddata",
+            "coding_systems/versioning/fixtures/coding_system_releases.json",
+        )
+
+        self.stdout.write("Deleting local coding system release dbs...")
+        for coding_system_release in CodingSystemRelease.objects.all():
+            db_path = build_db_path(coding_system_release)
+            if db_path.exists():
+                db_path.unlink()
+                self.stdout.write(f"{str(db_path)} has been deleted")
+
+        self.stdout.write(
+            "Migrating coding system release dbs and populating them with test fixture data"
+        )
+
+        update_coding_system_database_connections()
+
+        # migrate snomedct test db and load test fixtures
+        call_command("migrate", "snomedct", database="snomedct_test_20200101")
+
+        call_command(
+            "loaddata",
+            "coding_systems/snomedct/fixtures/core-model-components.snomedct_test_20200101.json",
+            database="snomedct_test_20200101",
+        )
+
+        call_command(
+            "loaddata",
+            "coding_systems/snomedct/fixtures/tennis-elbow.snomedct_test_20200101.json",
+            database="snomedct_test_20200101",
+        )
+
+        call_command(
+            "loaddata",
+            "coding_systems/snomedct/fixtures/tennis-toe.snomedct_test_20200101.json",
+            database="snomedct_test_20200101",
+        )
+
+        # migrate dmd test db and load test fixture
+        call_command("migrate", "dmd", database="dmd_test_20200101")
+
+        call_command(
+            "loaddata",
+            "coding_systems/dmd/fixtures/asthma-medication.dmd_test_20200101.json",
+            database="dmd_test_20200101",
+        )
+
+        # migrate bnf test db and load test fixture
+        call_command("migrate", "bnf", database="bnf_test_20200101")
+
+        call_command(
+            "loaddata",
+            "coding_systems/bnf/fixtures/asthma.bnf_test_20200101.json",
+            database="bnf_test_20200101",
+        )
+
+        # migrate icd10 test db and load test fixture
+        call_command("migrate", "icd10", database="icd10_test_20200101")
+        call_command(
+            "loaddata",
+            "coding_systems/icd10/fixtures/icd10.icd10_test_20200101.json",
+            database="icd10_test_20200101",
+        )
+
+        # instantiate the test data universe
+        build_fixtures()
+
+        call_command(
+            "createsuperuser",
+            no_input=True,
+            username="localdev",
+            email="localdev@example.com",
+        )
+
+        self.stdout.write(
+            "Local setup complete! You can now:\n"
+            " - Log in as `localdev`\n"
+            " - Search for 'arthritis', 'tennis', and 'elbow'\n"
+            " - Build codelists with the concepts returned from these searches (see /opencodelists/opencodelists/tests/fixtures.py for more info)\n"
+            " - View a BNF codelist, a minimal codelist, and a new-style SNOMED CT codelist"
+        )

--- a/opencodelists/tests/management/commands/test_setup_local_dev_databases.py
+++ b/opencodelists/tests/management/commands/test_setup_local_dev_databases.py
@@ -1,0 +1,14 @@
+import pytest
+from django.core.management import call_command
+
+# from opencodelists.management.commands import setup_local_dev_databases
+from opencodelists import settings
+
+
+def test_setup_local_dev_databases_exits_early_when_in_prod_environment(monkeypatch):
+    monkeypatch.setattr(settings, "DEBUG", False)
+
+    with pytest.raises(SystemExit) as error:
+        call_command("setup_local_dev_databases")
+
+    assert error.value.code == 1


### PR DESCRIPTION
Closes #2313.

### What has been done?
A `setup_local_dev_databases` management command deletes, rebuilds and populates databases (dbs). This is called from a `just` recipe which deletes and rebuilds the core db. Both are safe by default. The result is a lightweight local development setup that uses our test data. 

You can use the `just` recipe in **safe-mode**: `just build-dbs-for-local-development`
To actually **delete local dbs** if you have them, pass the `nuclear` argument: `just build-dbs-for-local-development nuclear`

#### A note on design choices
Originally, deletion of the core db occurred inside the management command. However, this led to unexpected behaviour. When a Django management command is invoked, it triggers `django.setup()` and the [app initialization process](https://docs.djangoproject.com/en/5.1/ref/applications/#initialization-process). During initialization, Django loads `settings.py`and expects the core database to exist at the path in `DATABASES`. If it's missing, SQLite creates a `db.sqlite3` file automatically. If the file is deleted after initialization, when migrations are run later in the same process, they don’t trigger a reinitialization of the app and re-check for the presence of the database file, so a new core db isn't recreated. 

Addressing this would require reinitializing the Django app from within the command — a potentially complex rabbit hole. Instead, the deletion step was moved out of the management command and into the `just` recipe.