### PR TITLE
Remove outdated 'We plan to support ...' message (closes #2437)

### DIFF
--- a/assets/src/scripts/components/SearchForm.tsx
+++ b/assets/src/scripts/components/SearchForm.tsx
@@ -54,10 +54,6 @@ export default function SearchForm({
             Otherwise, searching will return all concepts with a description
             containing the search term.
           </p>
-          <p>
-            We plan to support boolean search operators (eg{" "}
-            <code>ambulatory AND blood pressure</code>) in future.
-          </p>
         </Form.Text>
       </Form.Group>
     </Form>


### PR DESCRIPTION
Removed outdated message "We plan to support ..." from the UI, as per issue #2437.

Closes #2437
