### PR TITLE
Fix emails in sanitise_backup.py

### DIFF
--- a/deploy/bin/sanitise_backup.py
+++ b/deploy/bin/sanitise_backup.py
@@ -72,7 +72,7 @@ def main(backup_file):
                 fake_usernames.append(fake_username)
                 break;
         fake_name = fake.name()
-        fake_email = f"{username}@example.com"
+        fake_email = f"{fake_username}@example.com"
         fake_password = hash_password(fake.password())
 
         # Update FK fields (must be done first)


### PR DESCRIPTION
use `fake_username` rather than `username` for the local email part of the sanitised email