### PR TITLE
Increase DB transaction timeout from 5 to 15s.

### DIFF
--- a/opencodelists/settings.py
+++ b/opencodelists/settings.py
@@ -198,10 +198,12 @@ DATABASES = {
                 # would set it by number of database pages.
                 f"PRAGMA cache_size = -{250 * 1024};"
             ),
-            # Transaction timeout in seconds. 5 is the default applied by the
-            # django backend; uncomment and edit the following line to change
-            # it. This affects PRAGMA busy_timeout.
-            # "timeout": 5,
+            # Transaction timeout in seconds. Increased from the default 5s as
+            # it may help with the remaining "Database is locked" errors. See
+            # https://github.com/opensafely-core/opencodelists/issues/2251 for
+            # discussion. This affects PRAGMA busy_timeout. Increasing it
+            # excessively may lead to worse UX for users that time out.
+            "timeout": 15,
             #
             # Switch from SQLite's default DEFERRED transaction mode to IMMEDIATE. This
             # has the effect that write transactions will respect the busy timeout,

--- a/opencodelists/tests/integration/test_db_settings.py
+++ b/opencodelists/tests/integration/test_db_settings.py
@@ -42,10 +42,10 @@ class TestDatabaseSettings:
     def test_database_pragma_busy_timeout(self, fresh_db_cursor):
         """Test that the `busy_timeout` parameter is set as we expect.
 
-        We don't set this explicitly in settings, but Django defaults it to 5s. Let's check."""
+        Django defaults it to 5s but we override in settings. Let's check."""
         # https://www.sqlite.org/pragma.html#pragma_busy_timeout
-        # 5 seconds in milliseconds == 5000.
-        _assert_pragma(fresh_db_cursor, "busy_timeout", 5000)
+        # 15 seconds in milliseconds == 15000.
+        _assert_pragma(fresh_db_cursor, "busy_timeout", 15000)
 
     def test_database_pragma_journal_mode(self, fresh_db_cursor):
         """Test that the `journal_mode` parameter is set as we expect."""


### PR DESCRIPTION
We changed some settings to help reduce the number of "Database is locked" errors, which seems to have helped, but there are still some. Let's try increasing the timeout to 15 seconds from the default 5 in case this helps with some of the remaining cases. See comments in file and https://github.com/opensafely-core/opencodelists/issues/2251 for discussion.

Fixes #2251, potentially.,