### PR TITLE
Move migrations to Procfile

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,2 @@
+web: /opt/venv/bin/gunicorn --config /app/deploy/gunicorn/conf.py opencodelists.wsgi
+release: /app/deploy/prod.sh

--- a/Procfile
+++ b/Procfile
@@ -1,2 +1,2 @@
 web: /opt/venv/bin/gunicorn --config /app/deploy/gunicorn/conf.py opencodelists.wsgi
-release: /app/deploy/prod.sh
+release: /usr/bin/env bash /app/deploy/prod.sh

--- a/deploy/prod.sh
+++ b/deploy/prod.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -euo pipefail
 

--- a/deploy/prod.sh
+++ b/deploy/prod.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+set -euo pipefail
+
+./manage.py check --deploy
+./manage.py migrate

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -171,8 +171,6 @@ COPY . /app
 RUN TRUD_API_KEY=dummy-key SECRET_KEY=dummy-key \
     python /app/manage.py collectstatic --no-input
 
-ENTRYPOINT ["/app/docker/entrypoints/prod.sh"]
-
 # We set command rather than entrypoint, to make it easier to run different
 # things from the cli
 CMD ["gunicorn", "--config", "/app/deploy/gunicorn/conf.py", "opencodelists.wsgi"]

--- a/docker/entrypoints/prod.sh
+++ b/docker/entrypoints/prod.sh
@@ -1,5 +1,0 @@
-#!/bin/bash
-
-set -euo pipefail
-
-exec "$@"

--- a/docker/entrypoints/prod.sh
+++ b/docker/entrypoints/prod.sh
@@ -2,7 +2,4 @@
 
 set -euo pipefail
 
-./manage.py check --deploy
-./manage.py migrate
-
 exec "$@"

--- a/docker/justfile
+++ b/docker/justfile
@@ -89,4 +89,5 @@ exec env="dev" *args="bash":
 smoke-test host="http://localhost:7000":
     #!/bin/bash
     set -eu
+    docker compose exec prod bash /app/deploy/prod.sh
     curl -I {{ host }} -s --compressed --fail --retry 20 --retry-delay 1 --retry-all-errors


### PR DESCRIPTION
[Dokku recommends](https://dokku.com/docs/advanced-usage/deployment-tasks/) that database migrations are not done _during_ deployment, but _before_ an app is deployed. They recommend that the migrations are applied during the "release" phase. This should stop deployments failing due to health checks timing out during a long running migration.

Refs: #2393

TODO:
- [ ] test change works with dokku
- [x] figure out how to test migrations in CI (EDIT: this is now being done during unit testing of the dev image and during the smoke test of the prod image)
- [x] ensure migrations are still run in local dev (EDIT: this change only affects the prod image, the dev image is unchanged)