### PR TITLE
Ignore local dev artifacts in Docker image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -15,3 +15,7 @@ node_modules/
 staticfiles/
 # dockerfile image build its own dir
 assets/dist/
+# local dev artifacts
+**/*.sqlite3
+**/*.zip
+**/*.zst


### PR DESCRIPTION
This ignores artifacts that are likely to be in a development environment. This shouldn't be an issue for production images, because they're built in a clean CI environment, however it can cause issues with large docker images when building locally.