### PR TITLE
Link to playbook for using sanitised prod data for local development

### DIFF
--- a/DEVELOPERS.md
+++ b/DEVELOPERS.md
@@ -131,12 +131,12 @@ This backup is a verbatim copy of the live data,
 and so contains user personal data and API keys.
 
 For development purposes,you should use the sanitised copy at
-`/storage/backup/db/sanitised-latest-db.sqlite3.zst`.
-You can use `scp`, `zstd -d` and
-`sqlite3 ".restore" to bring your local database into the same state as the
-production database. You may also wish to retrieve the coding systems
-databases, otherwise you will not be able to interact with codelists that
-require them.
+`/storage/backup/db/sanitised-latest-db.sqlite3.zst`.  You can use `scp`, `zstd
+-d` and `sqlite3 ".restore" to bring your local database into the same state as
+the production database. Refer to the team manual [OpenCodelists
+playbook](https://bennett.wiki/tech-group/playbooks/opencodelists/) for
+commands.  You may also wish to retrieve the coding systems databases,
+otherwise you will not be able to interact with codelists that require them.
 
 ## Local development
 


### PR DESCRIPTION
Added in https://github.com/ebmdatalab/team-manual/pull/1060, let's add breadcrumbs from DEVELOPERS.md to the playbook.