### PR TITLE
Move metadata under title in builder

### DIFF
--- a/assets/src/scripts/__tests__/components/Metadata.spec.tsx
+++ b/assets/src/scripts/__tests__/components/Metadata.spec.tsx
@@ -1,0 +1,96 @@
+import "@testing-library/jest-dom";
+import { render, screen } from "@testing-library/react";
+import React from "react";
+import { expect, it } from "vitest";
+import Metadata from "../../components/Metadata";
+
+const mockData = {
+  coding_system_name: "Test Coding System",
+  coding_system_release: {
+    release_name: "v1.0",
+    valid_from: "2024-01-01",
+  },
+  organisation_name: "Test Organisation",
+  codelist_full_slug: "test/codelist",
+  codelist_name: "Test Codelist",
+  draft: false,
+  hash: "abc123",
+};
+
+it("renders all required metadata fields", () => {
+  render(<Metadata data={mockData} />);
+
+  expect(screen.getByText("Coding system").tagName).toBe("DT");
+  expect(screen.getByText(mockData.coding_system_name).tagName).toBe("DD");
+  expect(
+    screen.getByText(mockData.coding_system_name).previousElementSibling,
+  ).toBe(screen.getByText("Coding system"));
+
+  const codingSystemRelease = `${mockData.coding_system_release.release_name} (${mockData.coding_system_release.valid_from})`;
+  expect(screen.getByText("Coding system release").tagName).toBe("DT");
+  expect(screen.getByText(codingSystemRelease).tagName).toBe("DD");
+  expect(screen.getByText(codingSystemRelease).previousElementSibling).toBe(
+    screen.getByText("Coding system release"),
+  );
+
+  expect(screen.getByText("Organisation").tagName).toBe("DT");
+  expect(screen.getByText(mockData.organisation_name).tagName).toBe("DD");
+  expect(
+    screen.getByText(mockData.organisation_name).previousElementSibling,
+  ).toBe(screen.getByText("Organisation"));
+
+  expect(screen.getByText("Codelist ID").tagName).toBe("DT");
+  expect(screen.getByText(mockData.codelist_full_slug).tagName).toBe("DD");
+  expect(
+    screen.getByText(mockData.codelist_full_slug).previousElementSibling,
+  ).toBe(screen.getByText("Codelist ID"));
+
+  expect(screen.getByText("Version ID").tagName).toBe("DT");
+  expect(screen.getByText(mockData.hash).tagName).toBe("DD");
+  expect(screen.getByText(mockData.hash).previousElementSibling).toBe(
+    screen.getByText("Version ID"),
+  );
+});
+
+it("handles empty organisation name", () => {
+  const dataWithoutOrg = {
+    ...mockData,
+    organisation_name: "",
+  };
+
+  render(<Metadata data={dataWithoutOrg} />);
+
+  // Organisation field should not be present
+  expect(screen.queryByText("Organisation")).not.toBeInTheDocument();
+
+  // Other fields should still be present
+  expect(screen.getByText("Version ID").tagName).toBe("DT");
+  expect(screen.getByText(mockData.hash).tagName).toBe("DD");
+  expect(screen.getByText(mockData.hash).previousElementSibling).toBe(
+    screen.getByText("Version ID"),
+  );
+});
+
+it("handles empty valid_from date in coding system release", () => {
+  const dataWithoutValidFrom = {
+    ...mockData,
+    coding_system_release: {
+      release_name: "v1.0",
+      valid_from: "",
+    },
+  };
+
+  render(<Metadata data={dataWithoutValidFrom} />);
+
+  expect(screen.getByText("Coding system release").tagName).toBe("DT");
+  expect(
+    screen.getByText(mockData.coding_system_release.release_name).tagName,
+  ).toBe("DD");
+  expect(
+    screen.getByText(mockData.coding_system_release.release_name)
+      .previousElementSibling,
+  ).toBe(screen.getByText("Coding system release"));
+  expect(
+    screen.queryByText(mockData.coding_system_release.valid_from),
+  ).not.toBeInTheDocument();
+});

--- a/assets/src/scripts/components/CodelistBuilder.tsx
+++ b/assets/src/scripts/components/CodelistBuilder.tsx
@@ -5,6 +5,7 @@ import { getCookie } from "../_utils";
 import { Code, PageData, Status } from "../types";
 import EmptyState from "./EmptyState";
 import ManagementForm from "./ManagementForm";
+import Metadata from "./Metadata";
 import Search from "./Search";
 import SearchForm from "./SearchForm";
 import Summary from "./Summary";
@@ -152,6 +153,7 @@ export default class CodelistBuilder extends React.Component<
     return (
       <>
         <Title name={metadata.codelist_name} />
+          <Metadata data={metadata} />
         <Row>
           <Col md="3">
             {isEditable && <ManagementForm counts={this.counts()} />}
@@ -176,33 +178,6 @@ export default class CodelistBuilder extends React.Component<
                 <hr />
               </>
             )}
-
-            <dl>
-              <dt>Coding system</dt>
-              <dd>{metadata.coding_system_name}</dd>
-
-              <dt>Coding system release</dt>
-              <dd>
-                {metadata.coding_system_release.release_name}
-                {metadata.coding_system_release.valid_from ? (
-                  <>({metadata.coding_system_release.valid_from})</>
-                ) : null}
-              </dd>
-
-              {metadata.organisation_name ? (
-                <>
-                  <dt>Organisation</dt>
-                  <dd>{metadata.organisation_name}</dd>
-                </>
-              ) : null}
-
-              <dt>Codelist ID</dt>
-              <dd className="text-break">{metadata.codelist_full_slug}</dd>
-
-              <dt>ID</dt>
-              <dd>{metadata.hash}</dd>
-            </dl>
-            <hr />
 
             <h3 className="h6">Versions</h3>
             <ul className="pl-3">

--- a/assets/src/scripts/components/CodelistBuilder.tsx
+++ b/assets/src/scripts/components/CodelistBuilder.tsx
@@ -152,8 +152,10 @@ export default class CodelistBuilder extends React.Component<
 
     return (
       <>
-        <Title name={metadata.codelist_name} />
+        <div className="border-bottom mb-3 pb-3">
+          <Title name={metadata.codelist_name} />
           <Metadata data={metadata} />
+        </div>
         <Row>
           <Col md="3">
             {isEditable && <ManagementForm counts={this.counts()} />}

--- a/assets/src/scripts/components/Metadata.tsx
+++ b/assets/src/scripts/components/Metadata.tsx
@@ -1,0 +1,41 @@
+import React from "react";
+import { ListGroup } from "react-bootstrap";
+import { PageData } from "../types";
+
+export default function Metadata({ data }: { data: PageData["metadata"] }) {
+  return (
+    <ListGroup horizontal className="small">
+      <ListGroup.Item className="py-1 px-2">
+        <dt>Coding system</dt>
+        <dd className="mb-0">{data.coding_system_name}</dd>
+      </ListGroup.Item>
+
+      <ListGroup.Item className="py-1 px-2">
+        <dt>Coding system release</dt>
+        <dd className="mb-0">
+          {data.coding_system_release.release_name}{" "}
+          {data.coding_system_release.valid_from ? (
+            <>({data.coding_system_release.valid_from})</>
+          ) : null}
+        </dd>
+      </ListGroup.Item>
+
+      {data.organisation_name ? (
+        <ListGroup.Item className="py-1 px-2">
+          <dt>Organisation</dt>
+          <dd className="mb-0">{data.organisation_name}</dd>
+        </ListGroup.Item>
+      ) : null}
+
+      <ListGroup.Item className="py-1 px-2">
+        <dt>Codelist ID</dt>
+        <dd className="mb-0">{data.codelist_full_slug}</dd>
+      </ListGroup.Item>
+
+      <ListGroup.Item className="py-1 px-2">
+        <dt>Version ID</dt>
+        <dd className="mb-0">{data.hash}</dd>
+      </ListGroup.Item>
+    </ListGroup>
+  );
+}

--- a/assets/src/scripts/components/Title.tsx
+++ b/assets/src/scripts/components/Title.tsx
@@ -3,13 +3,11 @@ import { Badge } from "react-bootstrap";
 
 export default function Title({ name }: { name: string }) {
   return (
-    <div className="border-bottom mb-3">
-      <h1 className="h3">
-        {name}
-        <Badge className="align-text-bottom ml-1" variant="secondary">
-          Draft
-        </Badge>
-      </h1>
-    </div>
+    <h1 className="h3">
+      {name}
+      <Badge className="align-text-bottom ml-1" variant="secondary">
+        Draft
+      </Badge>
+    </h1>
   );
 }


### PR DESCRIPTION
Closes [#2446](https://github.com/opensafely-core/opencodelists/issues/2446)

Metadata is currently shown in the sidebar, but we are moving to the sidebar being for searching and interacting with the codelist. For this reason, we have moved the metadata under the title.

It also means we can create a `<Metadata />` component, and add tests with 100% coverage for the component.

## Screenshots

### Before

![](https://github.com/user-attachments/assets/eb7b30a6-d510-4706-a2ab-bddd71e427e3)

### After

![](https://github.com/user-attachments/assets/6a39bc63-6ff4-4ea2-83ee-4918f9b87daa)