### PR TITLE
Adds a search box toggle - search by term OR seach by code

### DIFF
--- a/assets/src/scripts/components/CodelistBuilder.tsx
+++ b/assets/src/scripts/components/CodelistBuilder.tsx
@@ -173,7 +173,6 @@ export default class CodelistBuilder extends React.Component<
 
             {isEditable && (
               <>
-                <h3 className="h6">New search</h3>
                 <SearchForm
                   codingSystemName={metadata.coding_system_name}
                   searchURL={searchURL}

--- a/assets/src/scripts/components/SearchForm.tsx
+++ b/assets/src/scripts/components/SearchForm.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from "react";
-import { Button, Form } from "react-bootstrap";
+import { Button, Card, Form, InputGroup } from "react-bootstrap";
 import { getCookie } from "../_utils";
 import { PageData } from "../types";
 
@@ -12,77 +12,121 @@ export default function SearchForm({
   codingSystemName,
   searchURL,
 }: SearchFormProps) {
-  const [searchTerm, setSearchTerm] = useState("");
-
   // NB, if you change the max search length, remember to change it on
   // the server side as well (codelists/models.py - Search - term)
   const MAX_SEARCH_LENGTH = 255;
+  const MAX_CODE_LENGTH = 18;
+
+  type SearchOptionKeys = "term" | "code";
+  const SEARCH_OPTIONS: {
+    [K in SearchOptionKeys]: {
+      label: string;
+      value: K;
+      placeholder: string;
+      maxLength: number;
+      validationMsg: string;
+    };
+  } = {
+    term: {
+      label: "Term",
+      value: "term",
+      placeholder: "Enter a search term...",
+      maxLength: MAX_SEARCH_LENGTH,
+      validationMsg: `Your search term has reached the maximum length of ${MAX_SEARCH_LENGTH} characters`,
+    },
+    code: {
+      label: "Code",
+      value: "code",
+      placeholder: "Enter a clinical code...",
+      maxLength: MAX_CODE_LENGTH,
+      validationMsg: `Your clinical code has reached the maximum length of ${MAX_CODE_LENGTH} characters`,
+    },
+  };
+  const [searchTerm, setSearchTerm] = useState("");
+  const [searchType, setSearchType] = useState<SearchOptionKeys>(
+    SEARCH_OPTIONS.term.value,
+  );
 
   const handleSearchChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const value = e.target.value;
-    if (value.length <= MAX_SEARCH_LENGTH) {
+    if (value.length <= SEARCH_OPTIONS[searchType].maxLength) {
       setSearchTerm(value);
     }
   };
 
+  const handleSearchTypeChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setSearchType(e.target.value as SearchOptionKeys);
+  };
+
   return (
-    <Form action={encodeURI(searchURL)} method="post">
-      <Form.Group>
+    <Card>
+      <Card.Header as="h6" className="p-2">
+        Search the {codingSystemName} dictionary
+      </Card.Header>
+      <Form action={encodeURI(searchURL)} method="post" className="p-2">
         <Form.Control
           name="csrfmiddlewaretoken"
           type="hidden"
           value={getCookie("csrftoken")}
         />
-        <Form.Control
-          name="search"
-          placeholder="Term or code"
-          type="search"
-          value={searchTerm}
-          onInput={handleSearchChange}
-          maxLength={MAX_SEARCH_LENGTH}
-          isInvalid={searchTerm.length >= MAX_SEARCH_LENGTH}
-        />
-        {searchTerm.length >= MAX_SEARCH_LENGTH && (
-          <Form.Control.Feedback type="invalid">
-            Your search term has reached the maximum length of{" "}
-            {MAX_SEARCH_LENGTH} characters
-          </Form.Control.Feedback>
-        )}
-      </Form.Group>
-      <Form.Group>
-        <Button
-          className="mr-1"
-          name="field"
-          size="sm"
-          type="submit"
-          variant="primary"
-        >
-          Search
-        </Button>
-      </Form.Group>
-      <Form.Group>
-        <Form.Text className="text-muted">
-          {codingSystemName === "ICD-10" ? (
-            <p>
-              To search by code, prefix your search with <code>code:</code>. For
-              instance, use <code>code:xyz</code> to find the concept with code{" "}
-              <code>xyz</code>, or <code>code:xyz*</code> to find all concepts
-              with codes beginning <code>xyz</code>. (Wildcard search only
-              available for ICD-10.)
-            </p>
-          ) : (
-            <p>
-              To search by code, prefix your search with <code>code:</code>. For
-              instance, use <code>code:xyz</code> to find the concept with code{" "}
-              <code>xyz</code>.
-            </p>
-          )}
-          <p>
-            Otherwise, searching will return all concepts with a description
-            containing the search term.
-          </p>
-        </Form.Text>
-      </Form.Group>
-    </Form>
+        <Form.Group>
+          <Form.Label>Search by:</Form.Label>
+          <div>
+            {Object.values(SEARCH_OPTIONS).map((option) => (
+              <Form.Check
+                key={option.value}
+                inline
+                label={option.label}
+                name="search-type"
+                type="radio"
+                id={`search-type-${option.value}`}
+                value={option.value}
+                checked={searchType === option.value}
+                onChange={handleSearchTypeChange}
+              />
+            ))}
+          </div>
+        </Form.Group>
+        <Form.Group>
+          <InputGroup className="mb-3">
+            <Form.Control
+              name="search"
+              placeholder={SEARCH_OPTIONS[searchType].placeholder}
+              type="search"
+              value={searchTerm}
+              onInput={handleSearchChange}
+              maxLength={SEARCH_OPTIONS[searchType].maxLength}
+              isInvalid={
+                searchTerm.length >= SEARCH_OPTIONS[searchType].maxLength
+              }
+            />
+            <InputGroup.Append>
+              <Button name="field" type="submit" variant="primary">
+                Search
+              </Button>
+            </InputGroup.Append>
+            {searchTerm.length >= SEARCH_OPTIONS[searchType].maxLength && (
+              <Form.Control.Feedback type="invalid">
+                {SEARCH_OPTIONS[searchType].validationMsg}
+              </Form.Control.Feedback>
+            )}
+          </InputGroup>
+        </Form.Group>
+
+        <Form.Group>
+          <Form.Text className="text-muted">
+            {codingSystemName === "ICD-10" &&
+            searchType === SEARCH_OPTIONS.code.value ? (
+              <p>
+                You can use a wildcard search to find all ICD-10 codes starting
+                with a certain string. E.g. use <code>xyz*</code> to find all
+                codes starting with <code>xyz</code>. (Wildcard search only
+                available for ICD-10.)
+              </p>
+            ) : null}
+          </Form.Text>
+        </Form.Group>
+      </Form>
+    </Card>
   );
 }

--- a/assets/src/scripts/components/SearchForm.tsx
+++ b/assets/src/scripts/components/SearchForm.tsx
@@ -13,9 +13,9 @@ export default function SearchForm({
   searchURL,
 }: SearchFormProps) {
   // NB, if you change the max search length, remember to change it on
-  // the server side as well (codelists/models.py - Search - term)
-  const MAX_SEARCH_LENGTH = 255;
-  const MAX_CODE_LENGTH = 18;
+  // the server side as well in the models.py file
+  const MAX_SEARCH_LENGTH = 255; // (codelists/models.py - Search - term)
+  const MAX_CODE_LENGTH = 18; // (codelists/models.py - Search - code)
 
   type SearchOptionKeys = "term" | "code";
   const SEARCH_OPTIONS: {

--- a/assets/src/scripts/components/SearchForm.tsx
+++ b/assets/src/scripts/components/SearchForm.tsx
@@ -69,9 +69,11 @@ export default function SearchForm({
           type="hidden"
           value={getCookie("csrftoken")}
         />
-        <Form.Group>
-          <Form.Label>Search by:</Form.Label>
-          <div>
+        <fieldset>
+          <Form.Group>
+            <Form.Label className="h6 mt-1" as="legend">
+              Search by:
+            </Form.Label>
             {Object.values(SEARCH_OPTIONS).map((option) => (
               <Form.Check
                 key={option.value}
@@ -85,11 +87,15 @@ export default function SearchForm({
                 onChange={handleSearchTypeChange}
               />
             ))}
-          </div>
-        </Form.Group>
+          </Form.Group>
+        </fieldset>
         <Form.Group>
           <InputGroup className="mb-3">
+            <Form.Label srOnly htmlFor="searchInput">
+              {SEARCH_OPTIONS[searchType].placeholder}
+            </Form.Label>
             <Form.Control
+              id="searchInput"
               name="search"
               placeholder={SEARCH_OPTIONS[searchType].placeholder}
               type="search"

--- a/assets/src/scripts/components/SearchForm.tsx
+++ b/assets/src/scripts/components/SearchForm.tsx
@@ -30,14 +30,14 @@ export default function SearchForm({
     term: {
       label: "Term",
       value: "term",
-      placeholder: "Enter a search term...",
+      placeholder: "Enter a search term…",
       maxLength: MAX_SEARCH_LENGTH,
       validationMsg: `Your search term has reached the maximum length of ${MAX_SEARCH_LENGTH} characters`,
     },
     code: {
       label: "Code",
       value: "code",
-      placeholder: "Enter a clinical code...",
+      placeholder: "Enter a clinical code…",
       maxLength: MAX_CODE_LENGTH,
       validationMsg: `Your clinical code has reached the maximum length of ${MAX_CODE_LENGTH} characters`,
     },

--- a/builder/views.py
+++ b/builder/views.py
@@ -124,8 +124,10 @@ def _draft(request, draft, search_id):
 
     if search_id == NO_SEARCH_TERM:
         results_heading = "Showing concepts with no matching search term"
+    elif search_id is not None and search.term:
+        results_heading = f'Showing concepts matching "{search.term}"'
     elif search_id is not None:
-        results_heading = f'Showing concepts matching "{search.term_or_code}"'
+        results_heading = f"Showing concepts matching the code: {search.code}"
     elif codeset.all_codes():
         results_heading = "Showing all matching concepts"
     else:

--- a/builder/views.py
+++ b/builder/views.py
@@ -217,13 +217,14 @@ def update(request, draft):
 @require_permission
 def new_search(request, draft):
     term = request.POST["search"].strip()
+    search_type = request.POST["search-type"]
     # Ensure that the term is not an empty string after slugifying
     # (e.g. if the user entered "*" as a search term)
     if not slugify(term):
         messages.info(request, f'"{term}" is not a valid search term')
         return redirect(draft.get_builder_draft_url())
-    if term.startswith("code:"):
-        code = term[5:].strip()
+    if search_type == "code":
+        code = term
         term = None
     else:
         code = None

--- a/codelists/models.py
+++ b/codelists/models.py
@@ -956,8 +956,9 @@ class Search(models.Model):
     version = models.ForeignKey(
         "CodelistVersion", related_name="searches", on_delete=models.CASCADE
     )
-    # NB, the "term" max_length is enforced client-side as well, so if you change
-    # the max search length here, remember to change it on the client side as well:
+    # NB, the "term" max_length and the "code" max_length are enforced client-side
+    # as well, so if you change the max search length here, remember to change it
+    # on the client side as well:
     # assets/src/scripts/components/SearchForm.tsx
     term = models.CharField(max_length=255, null=True, blank=True)
     code = models.CharField(max_length=18, null=True, blank=True)


### PR DESCRIPTION
Fixes #2451

New search box now looks like:

![image](https://github.com/user-attachments/assets/67c40f91-43d2-450f-b0d5-344c4559f401)

All help text (about searching with `code:` prefixes is now gone), except for the bit that tells you that you can do wildcard searching for ICD-10 codes:

![image](https://github.com/user-attachments/assets/817010cb-fa69-4ca9-b921-b753f60e558d)
