### PR TITLE
Run OpenCodelists in Dokku in Codespaces

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,6 @@
+{
+    "name": "OpenCodelists",
+    "features": {
+        "ghcr.io/devcontainers/features/docker-in-docker:2": {}
+    }
+}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -2,5 +2,6 @@
     "name": "OpenCodelists",
     "features": {
         "ghcr.io/devcontainers/features/docker-in-docker:2": {}
-    }
+    },
+    "postCreateCommand": "/bin/bash /workspaces/opencodelists/dokku.sh"
 }

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,18 @@
+services:
+  dokku:
+    image: dokku/dokku:0.32.4
+    container_name: dokku
+    network_mode: bridge
+    ports:
+      - "3022:22"
+      - "8080:80"
+      - "8443:443"
+      - "7000:7000"
+    volumes:
+      - "/var/lib/dokku:/mnt/dokku"
+      - "/var/run/docker.sock:/var/run/docker.sock"
+    environment:
+      DOKKU_HOSTNAME: dokku.me
+      DOKKU_HOST_ROOT: /var/lib/dokku/home/dokku
+      DOKKU_LIB_HOST_ROOT: /var/lib/dokku/var/lib/dokku
+    restart: unless-stopped

--- a/dokku.sh
+++ b/dokku.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+set -eu
+
+cd /tmp && wget https://github.com/casey/just/releases/download/1.40.0/just-1.40.0-x86_64-unknown-linux-musl.tar.gz && tar -xzf just-1.40.0-x86_64-unknown-linux-musl.tar.gz && chmod 555 just
+sudo mv /tmp/just /usr/bin/
+
+cd /workspaces/opencodelists
+cp dotenv-sample .env
+touch db.sqlite3 # workaround because build-dbs-for-local-development expects a db.sqlite3
+yes Y | just build-dbs-for-local-development nuclear
+
+docker-compose up -d
+
+docker exec -t dokku sh -c "dokku apps:create opencodelists"
+docker exec -t dokku sh -c 'dokku config:set opencodelists BASE_URLS="http://localhost:7000,http://127.0.0.1:7000" DATABASE_DIR="/storage" DATABASE_URL="sqlite:////storage/db.sqlite3" DJANGO_SETTINGS_MODULE="opencodelists.settings" SECRET_KEY="thisisatestsecretkeyfortestingonly" TRUD_API_KEY="thisisatesttrudkeyfortestingonly"'
+
+sudo mkdir -p /var/lib/dokku/data/storage/opencodelists
+sudo mkdir -p /var/lib/dokku/data/storage/opencodelists/coding_systems/bnf/
+sudo mkdir -p /var/lib/dokku/data/storage/opencodelists/coding_systems/dmd/
+sudo mkdir -p /var/lib/dokku/data/storage/opencodelists/coding_systems/icd10/
+sudo mkdir -p /var/lib/dokku/data/storage/opencodelists/coding_systems/snomedct/
+
+sudo cp db.sqlite3 /var/lib/dokku/data/storage/opencodelists/
+sudo cp coding_systems/bnf/bnf_test_20200101.sqlite3 /var/lib/dokku/data/storage/opencodelists/coding_systems/bnf/
+sudo cp coding_systems/dmd/dmd_test_20200101.sqlite3 /var/lib/dokku/data/storage/opencodelists/coding_systems/dmd/
+sudo cp coding_systems/icd10/icd10_test_20200101.sqlite3 /var/lib/dokku/data/storage/opencodelists/coding_systems/icd10/
+sudo cp coding_systems/snomedct/snomedct_test_20200101.sqlite3 /var/lib/dokku/data/storage/opencodelists/coding_systems/snomedct/
+
+sudo chown -R 10003:10003 /var/lib/dokku/data/storage/opencodelists
+
+cd /workspaces/opencodelists/docker
+just build prod
+
+docker exec -t dokku sh -c "dokku storage:mount opencodelists /var/lib/dokku/data/storage/opencodelists/:/storage"
+docker exec -t dokku sh -c "dokku git:from-image opencodelists opencodelists:latest"


### PR DESCRIPTION
See #2483.

This PR is currently a sketch of adding a configuration for running OpenCodelists in Dokku in a dev container/Codespaces. It is not complete enough to be merged, but functional enough to try out. If it's useful, it may warrant some tidying before merging.

It adds a minimal `devcontainer.json` configuration and a script that:

* installs `just`, necessary to build the test databases and Docker image
* installs Dokku via docker-compose (it was tricky to get Dokku working outside of Docker, in the dev container directly)
* builds the OpenCodelists test data
* copies the OpenCodelists tests data into the right place for Dokku
* configures Dokku to run OpenCodelists
* builds the OpenCodelists production Docker image
* deploys that OpenCodelists image with Dokku

You can see the Django logs by running:

```
docker exec -t dokku sh -c "dokku logs opencodelists --tail"
```