### PR TITLE
Make tests runnable in isolation

### DIFF
--- a/codelists/tests/test_forms.py
+++ b/codelists/tests/test_forms.py
@@ -102,7 +102,7 @@ def test_codelistform_incorrect_header(bnf_data):
     assert e.value.messages[0] == 'Header 1 ("code ") contains extraneous whitespace'
 
 
-def test_codelistform_no_code_header():
+def test_codelistform_no_code_header(setup_coding_systems):
     form = CSVValidationMixin()
 
     # wrap CSV up in SimpleUploadedFile to mirror how a Django view would
@@ -122,7 +122,7 @@ def test_codelistform_no_code_header():
     )
 
 
-def test_codelistform_ambiguous_code_header():
+def test_codelistform_ambiguous_code_header(setup_coding_systems):
     form = CSVValidationMixin()
 
     # wrap CSV up in SimpleUploadedFile to mirror how a Django view would
@@ -139,7 +139,7 @@ def test_codelistform_ambiguous_code_header():
     assert e.value.messages[0] == "Ambiguous headers: both 'dmd_id' and 'code' found"
 
 
-def test_codelistform_invalid_codes():
+def test_codelistform_invalid_codes(setup_coding_systems):
     form = CSVValidationMixin()
 
     # wrap CSV up in SimpleUploadedFile to mirror how a Django view would

--- a/coding_systems/bnf/tests/test_import_data.py
+++ b/coding_systems/bnf/tests/test_import_data.py
@@ -180,6 +180,7 @@ class TestImportData(BNFDynamicDatabaseTestCaseWithTmpPath):
     db_alias = "bnf_release-1-a_20221001"
     coding_system_subpath_name = "bnf"
 
+    @pytest.mark.usefixtures("setup_coding_systems")
     def test_import_data(self):
         """Test importing BNF coding system data with dynamic database creation."""
         cs_release_count = CodingSystemRelease.objects.count()
@@ -214,6 +215,7 @@ class TestImportDataExisting(BNFDynamicDatabaseTestCaseWithTmpPath):
     db_alias = "bnf_v1-1_20221001"
     coding_system_subpath_name = "bnf"
 
+    @pytest.mark.usefixtures("setup_coding_systems")
     def test_import_data_existing_coding_system_release(self):
         # Set up an existing CodingSystemRelease and DB file.
         cs_release = CodingSystemRelease.objects.create(

--- a/coding_systems/ctv3/tests/test_import_data.py
+++ b/coding_systems/ctv3/tests/test_import_data.py
@@ -34,6 +34,7 @@ class TestImportData(DynamicDatabaseTestCase):
     db_alias = "ctv3_v1_20221001"
     import_data_path = MOCK_CTV3_IMPORT_DATA_PATH
 
+    @pytest.mark.usefixtures("setup_coding_systems")
     def test_import_data(self):
         cs_release_count = CodingSystemRelease.objects.count()
 

--- a/coding_systems/icd10/tests/test_import_data.py
+++ b/coding_systems/icd10/tests/test_import_data.py
@@ -2,6 +2,7 @@ from datetime import date
 from pathlib import Path
 from unittest.mock import patch
 
+import pytest
 from django.conf import settings
 
 from coding_systems.base.tests.dynamic_db_classes import DynamicDatabaseTestCase
@@ -23,6 +24,7 @@ class TestImportData(DynamicDatabaseTestCase):
     db_alias = "icd10_release-icd_20221001"
     import_data_path = MOCK_ICD10_IMPORT_DATA_PATH
 
+    @pytest.mark.usefixtures("setup_coding_systems")
     def test_import_data(self):
         cs_release_count = CodingSystemRelease.objects.count()
 

--- a/coding_systems/snomedct/tests/test_coding_system.py
+++ b/coding_systems/snomedct/tests/test_coding_system.py
@@ -34,7 +34,7 @@ def test_code_to_term(snomedct_data, coding_system):
     }
 
 
-def test_matching_codes(icd10_data, coding_system):
+def test_matching_codes(snomedct_data, coding_system):
     assert coding_system.matching_codes(["705115006", "239964003", "99999"]) == {
         "705115006",
         "239964003",

--- a/coding_systems/snomedct/tests/test_import_data.py
+++ b/coding_systems/snomedct/tests/test_import_data.py
@@ -17,7 +17,7 @@ class TestImportData(DynamicDatabaseTestCase):
     db_alias = "snomedct_200_20230101"
     import_data_path = MOCK_SNOMEDCT_IMPORT_DATA_PATH
 
-    @pytest.mark.usefixtures("mock_data_download")
+    @pytest.mark.usefixtures("mock_data_download", "setup_coding_systems")
     def test_import_data(self):
         cs_release_count = CodingSystemRelease.objects.count()
 

--- a/conftest.py
+++ b/conftest.py
@@ -36,6 +36,21 @@ def enable_db_access_for_all_tests(db):
     pass
 
 
+@pytest.fixture(scope="session", autouse=True)
+def testing_db_setup(django_db_modify_db_settings, django_db_blocker):
+    """
+    Set up the test databases for all configured databases aliases, including
+    schema creation, before any test plan execution.
+
+    For pytest to do this natively, we could alternatively mark up tests/modules with:
+        pytest.mark.django_db(databases=['default', 'snomedct_test_20200101', 'dmd_test_20200101', 'bnf_test_20200101'])
+    """
+    for alias in connections.databases.keys():
+        with django_db_blocker.unblock():
+            # Does nothing if already exists -- as for 'default'.
+            connections[alias].creation.create_test_db(verbosity=0, autoclobber=False)
+
+
 @pytest.fixture(scope="session")
 def django_db_modify_db_settings():
     """


### PR DESCRIPTION
Relates to #2403. Most tests cases in the repo can't be run independently because there are undeclared dependencies between their fixtures, that are only resolved by running groups of tests with mutually-compatible sets of fixtures together. If we make those dependencies explicit, we can run tests in isolation.

Several fixes combined in one PR as tests may be affected by more than one of these issues, preventing them from being run in isolation until all changes are in place. See commit messages for more details. See #2403 for more on the investigation.

The work done by the `testing_db_setup` fixture could also possibly have been applied by overriding [`django_db_setup`](https://pytest-django.readthedocs.io/en/latest/database.html#django-db-setup), or only when individual fixtures need it rather than in a blanket approach, but that seems more complicated for not much benefit. The current approach makes pytest-django tests behave more like Django-style testcases, setting up all the configured test databases no matter what. This doesn't take very long, and almost all test cases need at least one of them.

There are two `coding_systems/base/tests/test_import_data_utils.py` that have a different issue that isn't resolved in this PR and still can't be run in isolation, see https://github.com/opensafely-core/opencodelists/issues/2493:

- `coding_systems/base/tests/test_import_data_utils.py::TestSaveCodelistDraftUpdatesCompatibilityMultipleReleases::test_save_codelist_draft_updates_compatibility_multiple_releases`
- `coding_systems/base/tests/test_import_data_utils.py::TestSaveCodelistDraftUpdatesCompatibility::test_save_codelist_draft_updates_compatibility`