### PR TITLE
Make remaining coding systems tests independent

### DIFF
--- a/coding_systems/base/tests/dynamic_db_classes.py
+++ b/coding_systems/base/tests/dynamic_db_classes.py
@@ -27,15 +27,13 @@ class DynamicDatabaseTestCase(TestCase):
     """
 
     @property
-    def db_alias(self):
-        """The database alias that needs to be accessed in this test class, str."""
-        raise NotImplementedError(
-            "This test class requires a database alias to be set."
-        )
+    def db_aliases(self):
+        """The database aliases that need to be accessed in this test class, list[str]."""
+        raise NotImplementedError("This test class requires db_aliases to be set.")
 
     import_data_path = None
 
-    def add_to_testcase_allowed_db_aliases(self, *db_aliases):
+    def add_to_testcase_allowed_db_aliases(self, db_aliases):
         """Add database names to the test instance's allowed database aliases.
 
         This mutates the *class* state by changing the `databases` attribute.
@@ -61,7 +59,7 @@ class DynamicDatabaseTestCase(TestCase):
             # Record the original state, so we can later restore it.
             self.original_databases = type(self).databases
 
-        type(self).databases |= frozenset({*db_aliases})
+        type(self).databases |= frozenset(db_aliases)
 
     def restore_original_testcase_db_aliases(self):
         """Restore the original `databases` attribute on the test case.
@@ -79,7 +77,7 @@ class DynamicDatabaseTestCase(TestCase):
     def setUp(self):
         super().setUp()
 
-        self.add_to_testcase_allowed_db_aliases(self, self.db_alias)
+        self.add_to_testcase_allowed_db_aliases(self.db_aliases)
 
     def tearDown(self):
         self.restore_original_testcase_db_aliases()
@@ -119,8 +117,11 @@ class DynamicDatabaseTestCaseWithTmpPath(DynamicDatabaseTestCase):
             )
 
         self.coding_systems_tmp_path = coding_systems_tmp_path
+        # These tests currently only use one database alias.
+        assert len(self.db_aliases) == 1
+
         self.expected_db_path = (
             self.coding_systems_tmp_path
             / f"{self.coding_system_subpath_name}"
-            / f"{self.db_alias}.sqlite3"
+            / f"{self.db_aliases[0]}.sqlite3"
         )

--- a/coding_systems/base/tests/test_import_data_utils.py
+++ b/coding_systems/base/tests/test_import_data_utils.py
@@ -46,7 +46,7 @@ class BaseCodingSystemDynamicDatabaseTestCase(DynamicDatabaseTestCase):
         # *before* the class's setUp() runs.
         # This fixture is run before setUp() and
         # other fixtures required by this fixture access the database.
-        self.add_to_testcase_allowed_db_aliases(self.db_alias)
+        self.add_to_testcase_allowed_db_aliases(self.db_aliases)
 
         # setup the database as a duplicate of the fixture one
         csr = _bnf_csr()
@@ -64,7 +64,7 @@ class BaseCodingSystemDynamicDatabaseTestCase(DynamicDatabaseTestCase):
         # *before* the class's setUp() runs.
         # This fixture is run before setUp() and
         # other fixtures required by this fixture access the database.
-        self.add_to_testcase_allowed_db_aliases(self.db_alias)
+        self.add_to_testcase_allowed_db_aliases(self.db_aliases)
 
         # setup the database as a duplicate of the fixture one, omitting the last concept
         csr = _bnf_csr(datetime(2022, 10, 1))
@@ -74,7 +74,7 @@ class BaseCodingSystemDynamicDatabaseTestCase(DynamicDatabaseTestCase):
 
     @pytest.fixture
     def _bnf_releases(self, _bnf_csr):
-        db_alias_additions = [
+        db_aliases_additions = [
             "bnf_import-data_20190101",
             "bnf_import-data_20220901",
             "bnf_import-data_20221201",
@@ -83,7 +83,7 @@ class BaseCodingSystemDynamicDatabaseTestCase(DynamicDatabaseTestCase):
         # *before* the class's setUp() runs.
         # This fixture is run before setUp() and
         # other fixtures required by this fixture access the database.
-        self.add_to_testcase_allowed_db_aliases(*db_alias_additions)
+        self.add_to_testcase_allowed_db_aliases(db_aliases_additions)
 
         # setup multiple databases as duplicates of the fixture one, with different dates
 
@@ -150,7 +150,9 @@ def _cleanup_db(csr):
 class TestUpdateCodelistVersionCompatibilityNoSearches(
     BaseCodingSystemDynamicDatabaseTestCase
 ):
-    db_alias = "bnf_import-data_20221101"
+    db_aliases = [
+        "bnf_import-data_20221101",
+    ]
 
     @pytest.mark.usefixtures("_get_bnf_release", "_get_bnf_version_asthma")
     def test_update_codelist_version_compatibility_no_searches(self):
@@ -164,7 +166,9 @@ class TestUpdateCodelistVersionCompatibilityNoSearches(
 class TestUpdateCodelistVersionDraftVersionExcluded(
     BaseCodingSystemDynamicDatabaseTestCase
 ):
-    db_alias = "bnf_import-data_20221101"
+    db_aliases = [
+        "bnf_import-data_20221101",
+    ]
 
     @pytest.mark.usefixtures("_get_bnf_release", "_get_bnf_version_with_search")
     def test_update_codelist_draft_version_excluded(self):
@@ -176,7 +180,9 @@ class TestUpdateCodelistVersionDraftVersionExcluded(
 
 
 class TestUpdateCodelistVersionWithSearch(BaseCodingSystemDynamicDatabaseTestCase):
-    db_alias = "bnf_import-data_20221101"
+    db_aliases = [
+        "bnf_import-data_20221101",
+    ]
 
     @pytest.mark.usefixtures("_get_bnf_release", "_get_bnf_review_version_with_search")
     def test_update_codelist_version_with_search(self):
@@ -193,7 +199,9 @@ class TestUpdateCodelistVersionWithSearch(BaseCodingSystemDynamicDatabaseTestCas
 class TestUpdateCodelistVersionCompatibilityWithMismatchedSearch(
     BaseCodingSystemDynamicDatabaseTestCase
 ):
-    db_alias = "bnf_import-data_20221001"
+    db_aliases = [
+        "bnf_import-data_20221001",
+    ]
 
     @pytest.mark.usefixtures(
         "_get_bnf_release_excl_last_concept", "_get_bnf_review_version_with_search"
@@ -210,7 +218,9 @@ class TestUpdateCodelistVersionCompatibilityWithMismatchedSearch(
 class TestUpdateCodelistVersionCompatibilityWithSearchButMismatchedHierarchy(
     BaseCodingSystemDynamicDatabaseTestCase
 ):
-    db_alias = "bnf_import-data_20221001"
+    db_aliases = [
+        "bnf_import-data_20221001",
+    ]
 
     @pytest.mark.usefixtures(
         "_get_bnf_release_excl_last_concept", "_get_bnf_review_version_with_search"
@@ -246,7 +256,9 @@ class TestUpdateCodelistVersionCompatibilityWithSearchButMismatchedHierarchy(
 class TestSaveCodelistDraftUpdatesCompatibility(
     BaseCodingSystemDynamicDatabaseTestCase
 ):
-    db_alias = "bnf_import-data_20221001"
+    db_aliases = [
+        "bnf_import-data_20221001",
+    ]
 
     @pytest.mark.usefixtures("_get_bnf_release", "_get_bnf_version_with_search")
     def test_save_codelist_draft_updates_compatibility(self):
@@ -262,7 +274,9 @@ class TestSaveCodelistDraftUpdatesCompatibility(
 class TestSaveCodelistDraftUpdatesCompatibilityMultipleReleases(
     BaseCodingSystemDynamicDatabaseTestCase
 ):
-    db_alias = "bnf_import-data_20190101"
+    db_aliases = [
+        "bnf_import-data_20190101",
+    ]
 
     @pytest.mark.usefixtures(
         "_bnf_releases",

--- a/coding_systems/base/tests/test_import_data_utils.py
+++ b/coding_systems/base/tests/test_import_data_utils.py
@@ -256,11 +256,12 @@ class TestUpdateCodelistVersionCompatibilityWithSearchButMismatchedHierarchy(
 class TestSaveCodelistDraftUpdatesCompatibility(
     BaseCodingSystemDynamicDatabaseTestCase
 ):
-    db_aliases = [
-        "bnf_import-data_20221001",
-    ]
+    db_aliases = []
 
-    @pytest.mark.usefixtures("_get_bnf_release", "_get_bnf_version_with_search")
+    @pytest.mark.usefixtures(
+        "_bnf_releases",
+        "_get_bnf_version_with_search",
+    )
     def test_save_codelist_draft_updates_compatibility(self):
         assert self.bnf_version_with_search.status == Status.DRAFT
         assert not self.bnf_version_with_search.compatible_releases.exists()
@@ -275,12 +276,12 @@ class TestSaveCodelistDraftUpdatesCompatibilityMultipleReleases(
     BaseCodingSystemDynamicDatabaseTestCase
 ):
     db_aliases = [
-        "bnf_import-data_20190101",
+        "bnf_import-data_20221001",
     ]
 
     @pytest.mark.usefixtures(
         "_bnf_releases",
-        "_get_bnf_release_excl_last_concept",
+        "_bnf_release_excl_last_concept",
         "_get_bnf_version_with_search",
     )
     def test_save_codelist_draft_updates_compatibility_multiple_releases(self):

--- a/coding_systems/base/tests/test_import_data_utils.py
+++ b/coding_systems/base/tests/test_import_data_utils.py
@@ -37,16 +37,6 @@ def _bnf_review_version_with_search(bnf_version_with_search):
 
 class BaseCodingSystemDynamicDatabaseTestCase(DynamicDatabaseTestCase):
     @pytest.fixture
-    def _get_bnf_release(self, _bnf_release):
-        # This attribute is necessary for tests that need to access
-        # the underlying CodingSystemRelease.
-        # Currently, all tests only use one CodingSystemRelease.
-        # It might be necessary to refactor how this attribute works
-        # (maybe as a dictionary or similar) if any future tests require
-        # accessing multiple CodingSystemReleases
-        self.bnf_release = _bnf_release
-
-    @pytest.fixture
     def _bnf_release(self, _bnf_csr):
         # This addition of a allowed database alias needs to be done
         # *before* the class's setUp() runs.
@@ -61,8 +51,14 @@ class BaseCodingSystemDynamicDatabaseTestCase(DynamicDatabaseTestCase):
         _cleanup_db(csr)
 
     @pytest.fixture
-    def _get_bnf_release_excl_last_concept(self, _bnf_release_excl_last_concept):
-        self.bnf_release = _bnf_release_excl_last_concept
+    def _get_bnf_release(self, _bnf_release):
+        # This attribute is necessary for tests that need to access
+        # the underlying CodingSystemRelease.
+        # Currently, all tests only use one CodingSystemRelease.
+        # It might be necessary to refactor how this attribute works
+        # (maybe as a dictionary or similar) if any future tests require
+        # accessing multiple CodingSystemReleases
+        self.bnf_release = _bnf_release
 
     @pytest.fixture
     def _bnf_release_excl_last_concept(self, _bnf_csr):
@@ -77,6 +73,10 @@ class BaseCodingSystemDynamicDatabaseTestCase(DynamicDatabaseTestCase):
         _setup_db(csr, exclude_last_concept=True)
         yield csr
         _cleanup_db(csr)
+
+    @pytest.fixture
+    def _get_bnf_release_excl_last_concept(self, _bnf_release_excl_last_concept):
+        self.bnf_release = _bnf_release_excl_last_concept
 
     @pytest.fixture
     def _bnf_releases(self, _bnf_csr):

--- a/coding_systems/base/tests/test_import_data_utils.py
+++ b/coding_systems/base/tests/test_import_data_utils.py
@@ -74,16 +74,11 @@ class BaseCodingSystemDynamicDatabaseTestCase(DynamicDatabaseTestCase):
 
     @pytest.fixture
     def _bnf_releases(self, _bnf_csr):
-        db_aliases_additions = [
-            "bnf_import-data_20190101",
-            "bnf_import-data_20220901",
-            "bnf_import-data_20221201",
-        ]
         # This addition of a allowed database alias needs to be done
         # *before* the class's setUp() runs.
         # This fixture is run before setUp() and
         # other fixtures required by this fixture access the database.
-        self.add_to_testcase_allowed_db_aliases(db_aliases_additions)
+        self.add_to_testcase_allowed_db_aliases(self.db_aliases)
 
         # setup multiple databases as duplicates of the fixture one, with different dates
 
@@ -167,6 +162,7 @@ class TestUpdateCodelistVersionDraftVersionExcluded(
     BaseCodingSystemDynamicDatabaseTestCase
 ):
     db_aliases = [
+        # _bnf_release
         "bnf_import-data_20221101",
     ]
 
@@ -181,6 +177,7 @@ class TestUpdateCodelistVersionDraftVersionExcluded(
 
 class TestUpdateCodelistVersionWithSearch(BaseCodingSystemDynamicDatabaseTestCase):
     db_aliases = [
+        # _bnf_release
         "bnf_import-data_20221101",
     ]
 
@@ -200,6 +197,7 @@ class TestUpdateCodelistVersionCompatibilityWithMismatchedSearch(
     BaseCodingSystemDynamicDatabaseTestCase
 ):
     db_aliases = [
+        # _bnf_release_excl_last_concept
         "bnf_import-data_20221001",
     ]
 
@@ -219,6 +217,7 @@ class TestUpdateCodelistVersionCompatibilityWithSearchButMismatchedHierarchy(
     BaseCodingSystemDynamicDatabaseTestCase
 ):
     db_aliases = [
+        # _bnf_release_excl_last_concept
         "bnf_import-data_20221001",
     ]
 
@@ -256,7 +255,12 @@ class TestUpdateCodelistVersionCompatibilityWithSearchButMismatchedHierarchy(
 class TestSaveCodelistDraftUpdatesCompatibility(
     BaseCodingSystemDynamicDatabaseTestCase
 ):
-    db_aliases = []
+    db_aliases = [
+        # _bnf_releases
+        "bnf_import-data_20190101",
+        "bnf_import-data_20220901",
+        "bnf_import-data_20221201",
+    ]
 
     @pytest.mark.usefixtures(
         "_bnf_releases",
@@ -276,6 +280,11 @@ class TestSaveCodelistDraftUpdatesCompatibilityMultipleReleases(
     BaseCodingSystemDynamicDatabaseTestCase
 ):
     db_aliases = [
+        # _bnf_releases
+        "bnf_import-data_20190101",
+        "bnf_import-data_20220901",
+        "bnf_import-data_20221201",
+        # _bnf_release_excl_last_concept
         "bnf_import-data_20221001",
     ]
 

--- a/coding_systems/base/tests/test_import_data_utils.py
+++ b/coding_systems/base/tests/test_import_data_utils.py
@@ -38,6 +38,12 @@ def _bnf_review_version_with_search(bnf_version_with_search):
 class BaseCodingSystemDynamicDatabaseTestCase(DynamicDatabaseTestCase):
     @pytest.fixture
     def _get_bnf_release(self, _bnf_release):
+        # This attribute is necessary for tests that need to access
+        # the underlying CodingSystemRelease.
+        # Currently, all tests only use one CodingSystemRelease.
+        # It might be necessary to refactor how this attribute works
+        # (maybe as a dictionary or similar) if any future tests require
+        # accessing multiple CodingSystemReleases
         self.bnf_release = _bnf_release
 
     @pytest.fixture
@@ -274,8 +280,6 @@ class TestSaveCodelistDraftUpdatesCompatibility(
         assert self.bnf_version_with_search.compatible_releases.exists()
 
 
-# This test is particularly unusual compared with the other coding systems
-# tests that use dynamic databases, in that multiple databases are used.
 class TestSaveCodelistDraftUpdatesCompatibilityMultipleReleases(
     BaseCodingSystemDynamicDatabaseTestCase
 ):

--- a/coding_systems/bnf/tests/test_import_data.py
+++ b/coding_systems/bnf/tests/test_import_data.py
@@ -177,7 +177,9 @@ class BNFDynamicDatabaseTestCaseWithTmpPath(DynamicDatabaseTestCaseWithTmpPath):
 
 
 class TestImportData(BNFDynamicDatabaseTestCaseWithTmpPath):
-    db_alias = "bnf_release-1-a_20221001"
+    db_aliases = [
+        "bnf_release-1-a_20221001",
+    ]
     coding_system_subpath_name = "bnf"
 
     @pytest.mark.usefixtures("setup_coding_systems")
@@ -212,7 +214,9 @@ class TestImportData(BNFDynamicDatabaseTestCaseWithTmpPath):
 
 
 class TestImportDataExisting(BNFDynamicDatabaseTestCaseWithTmpPath):
-    db_alias = "bnf_v1-1_20221001"
+    db_aliases = [
+        "bnf_v1-1_20221001",
+    ]
     coding_system_subpath_name = "bnf"
 
     @pytest.mark.usefixtures("setup_coding_systems")
@@ -346,7 +350,9 @@ def test_import_setup_error_existing_release(
 
 
 class TestImportMigrationError(BNFDynamicDatabaseTestCaseWithTmpPath):
-    db_alias = "bnf_migrate-error_20221001"
+    db_aliases = [
+        "bnf_migrate-error_20221001",
+    ]
     coding_system_subpath_name = "bnf"
 
     def test_import_error_during_migration(self):

--- a/coding_systems/ctv3/tests/test_import_data.py
+++ b/coding_systems/ctv3/tests/test_import_data.py
@@ -31,7 +31,9 @@ def mock_migrate():
 
 
 class TestImportData(DynamicDatabaseTestCase):
-    db_alias = "ctv3_v1_20221001"
+    db_aliases = [
+        "ctv3_v1_20221001",
+    ]
     import_data_path = MOCK_CTV3_IMPORT_DATA_PATH
 
     @pytest.mark.usefixtures("setup_coding_systems")
@@ -85,7 +87,9 @@ class TestImportData(DynamicDatabaseTestCase):
 
 
 class TestImportErrorExistingRelease(DynamicDatabaseTestCaseWithTmpPath):
-    db_alias = "ctv3_v_error_20221001"
+    db_aliases = [
+        "ctv3_v_error_20221001",
+    ]
     import_data_path = MOCK_CTV3_IMPORT_DATA_PATH
     coding_system_subpath_name = "ctv3"
 

--- a/coding_systems/dmd/tests/test_import_data.py
+++ b/coding_systems/dmd/tests/test_import_data.py
@@ -19,7 +19,9 @@ from .conftest import MOCK_DMD_IMPORT_DATA_PATH
 
 
 class TestImportData(DynamicDatabaseTestCase):
-    db_alias = "dmd_2022-100_20221001"
+    db_aliases = [
+        "dmd_2022-100_20221001",
+    ]
     import_data_path = MOCK_DMD_IMPORT_DATA_PATH
 
     @pytest.fixture
@@ -95,7 +97,9 @@ class TestImportData(DynamicDatabaseTestCase):
 
 
 class TestImportDataUnexpectedFile(DynamicDatabaseTestCase):
-    db_alias = "dmd_2022-110_20221001"
+    db_aliases = [
+        "dmd_2022-110_20221001",
+    ]
     import_data_path = MOCK_DMD_IMPORT_DATA_PATH
 
     @pytest.mark.usefixtures("mock_data_download_bad_zip")
@@ -116,7 +120,9 @@ class TestImportDataUnexpectedFile(DynamicDatabaseTestCase):
 
 
 class TestImportError(DynamicDatabaseTestCaseWithTmpPath):
-    db_alias = "dmd_2022-101_20220901"
+    db_aliases = [
+        "dmd_2022-101_20220901",
+    ]
     import_data_path = MOCK_DMD_IMPORT_DATA_PATH
     coding_system_subpath_name = "dmd"
 
@@ -146,7 +152,9 @@ class TestImportError(DynamicDatabaseTestCaseWithTmpPath):
 
 
 class TestImportDataNoVMPPreviousMapping(DynamicDatabaseTestCase):
-    db_alias = "dmd_2022-120_20221001"
+    db_aliases = [
+        "dmd_2022-120_20221001",
+    ]
     import_data_path = MOCK_DMD_IMPORT_DATA_PATH
 
     @pytest.mark.usefixtures("dmd_data", "mock_data_download_no_prev_vmp")

--- a/coding_systems/icd10/tests/test_import_data.py
+++ b/coding_systems/icd10/tests/test_import_data.py
@@ -21,7 +21,9 @@ MOCK_ICD10_IMPORT_DATA_PATH = (
 
 
 class TestImportData(DynamicDatabaseTestCase):
-    db_alias = "icd10_release-icd_20221001"
+    db_aliases = [
+        "icd10_release-icd_20221001",
+    ]
     import_data_path = MOCK_ICD10_IMPORT_DATA_PATH
 
     @pytest.mark.usefixtures("setup_coding_systems")

--- a/coding_systems/snomedct/tests/test_import_data.py
+++ b/coding_systems/snomedct/tests/test_import_data.py
@@ -14,7 +14,9 @@ from .conftest import MOCK_SNOMEDCT_IMPORT_DATA_PATH
 
 
 class TestImportData(DynamicDatabaseTestCase):
-    db_alias = "snomedct_200_20230101"
+    db_aliases = [
+        "snomedct_200_20230101",
+    ]
     import_data_path = MOCK_SNOMEDCT_IMPORT_DATA_PATH
 
     @pytest.mark.usefixtures("mock_data_download", "setup_coding_systems")

--- a/coding_systems/versioning/tests/test_database_routing.py
+++ b/coding_systems/versioning/tests/test_database_routing.py
@@ -30,7 +30,9 @@ def test_coding_system_routing_errors_if_no_using_db_specified(coding_system):
 
 
 class TestMismatchedCodingSystemDatabaseRelations(DynamicDatabaseTestCaseWithTmpPath):
-    db_alias = "ctv3_testv2_20221101"
+    db_aliases = [
+        "ctv3_testv2_20221101",
+    ]
     coding_system_subpath_name = "ctv3"
 
     def test_mismatched_coding_system_database_relations(self):

--- a/coding_systems/versioning/tests/test_models.py
+++ b/coding_systems/versioning/tests/test_models.py
@@ -44,7 +44,9 @@ def test_coding_system_release_most_recent(coding_system_release):
 
 
 class TestUpdateCodingSystemDatabaseConnections(DynamicDatabaseTestCaseWithTmpPath):
-    db_alias = "snomedct_v1_20221001"
+    db_aliases = [
+        "snomedct_v1_20221001",
+    ]
     coding_system_subpath_name = "snomedct"
 
     @pytest.fixture


### PR DESCRIPTION
Fixes #2493 and fixes #2301. See #2403.

This facilitates running two tests that were not made independently-runnable in #2492.

A slightly earlier version of this PR was tested with all tests running independently, except for the database timeout which was changed in case there were issues with it. (Which was mentioned in the comments for the helper script to run the tests independently.)

The changes made since then are essentially comment/commit message changes and rebasing.