### PR TITLE
Remove unused test fixtures

### DIFF
--- a/opencodelists/tests/fixtures.py
+++ b/opencodelists/tests/fixtures.py
@@ -267,11 +267,6 @@ def build_fixtures():
         "disorder-of-elbow.csv"
     )
 
-    # disorder_of_elbow_excl_arthritis_csv_data_no_header
-    disorder_of_elbow_excl_arthritis_csv_data_no_header = load_csv_data_no_header(
-        "disorder-of-elbow-excl-arthritis.csv"
-    )
-
     # enthesopathy_of_elbow_region_plus_tennis_toe
     enthesopathy_of_elbow_region_plus_tennis_toe = load_codes_from_csv(
         "enthesopathy-of-elbow-region-plus-tennis-toe.csv"
@@ -791,9 +786,6 @@ disorder_of_elbow_excl_arthritis_csv_data = build_fixture(
 )
 disorder_of_elbow_csv_data_no_header = build_fixture(
     "disorder_of_elbow_csv_data_no_header"
-)
-disorder_of_elbow_excl_arthritis_csv_data_no_header = build_fixture(
-    "disorder_of_elbow_excl_arthritis_csv_data_no_header"
 )
 organisation = build_fixture("organisation")
 another_organisation = build_fixture("another_organisation")

--- a/opencodelists/tests/fixtures.py
+++ b/opencodelists/tests/fixtures.py
@@ -866,15 +866,6 @@ def draft_with_complete_searches(version_with_complete_searches, organisation_us
 
 
 @pytest.fixture(scope="function")
-def draft_from_scratch(version_with_complete_searches, organisation_user):
-    return export_to_builder(
-        version=version_with_complete_searches,
-        author=organisation_user,
-        coding_system_database_alias=most_recent_database_alias("snomedct"),
-    )
-
-
-@pytest.fixture(scope="function")
 def draft(draft_with_complete_searches):
     return draft_with_complete_searches
 


### PR DESCRIPTION
These were found with [`pytest-deadfixtures`](https://github.com/jllorencetti/pytest-deadfixtures) which isn't very actively maintained and had quite a few false positives (mainly around fixtures used via decorators such as `autouse=True` or `usefixtures`).

I also tried [`pytest-unused-fixtures`](https://github.com/mikicz/pytest-unused-fixtures/) though this didn't catch anything.

So it's probably not worth adding these to our tests or CI checks, but it was useful for a one-time run.