### PR TITLE
Tidy up tests slightly

### DIFF
--- a/codelists/tests/test_db_utils.py
+++ b/codelists/tests/test_db_utils.py
@@ -1,14 +1,11 @@
-from django.test import TestCase
-
 from opencodelists import db_utils
 
 
-class DBUtilsTest(TestCase):
-    def test_query_with_many_params(self):
-        values = list(range(5000))
-        placeholders = ["%s"] * len(values)
-        sql = "SELECT 'found' WHERE %s IN ({})".format(", ".join(placeholders))
-        last_value = values[-1]
-        params = [last_value] + values
-        result = db_utils.query(sql, params)
-        self.assertEqual(result, [("found",)])
+def test_query_with_many_params():
+    values = list(range(5000))
+    placeholders = ["%s"] * len(values)
+    sql = "SELECT 'found' WHERE %s IN ({})".format(", ".join(placeholders))
+    last_value = values[-1]
+    params = [last_value] + values
+    result = db_utils.query(sql, params)
+    assert result == [("found",)]

--- a/coding_systems/bnf/tests/test_import_data.py
+++ b/coding_systems/bnf/tests/test_import_data.py
@@ -171,7 +171,6 @@ class BNFDynamicDatabaseTestCaseWithTmpPath(DynamicDatabaseTestCaseWithTmpPath):
     # Set this fixture as `autouse`:
     # all the tests currently using this class use this import data fixture.
     @pytest.fixture(autouse=True)
-    @pytest.mark.usefixtures("mock_bnf_import_data_path")
     def _set_import_data_from_fixture(self, mock_bnf_import_data_path):
         self.import_data_path = mock_bnf_import_data_path
 

--- a/coding_systems/bnf/tests/test_import_data.py
+++ b/coding_systems/bnf/tests/test_import_data.py
@@ -125,13 +125,14 @@ def mock_bnf_import_data_path(tmp_path):
 
 
 def test_import_data_no_csv_files(tmp_path):
+    other_file = tmp_path / "test.txt"
+    other_file.touch()
+    with ZipFile(tmp_path / "test.zip", "w") as zip_file:
+        zip_file.write(other_file, arcname=other_file.name)
+
     with pytest.raises(
         AssertionError, match=re.escape("Expected 1 and only one .csv file (found 0)")
     ):
-        other_file = tmp_path / "test.txt"
-        other_file.touch()
-        with ZipFile(tmp_path / "test.zip", "w") as zip_file:
-            zip_file.write(other_file, arcname=other_file.name)
         import_data(
             str(tmp_path / "test.zip"), release_name="v1", valid_from=date(2022, 10, 1)
         )

--- a/coding_systems/versioning/tests/test_models.py
+++ b/coding_systems/versioning/tests/test_models.py
@@ -120,11 +120,11 @@ def test_coding_system_invalid_database_alias():
         state=ReleaseState.READY,
     )
     # if any of the component fields are changed, the db alias must be updated too
+    csr.release_name = "Version 2"
+
     with pytest.raises(AssertionError):
-        csr.release_name = "Version 2"
         csr.save()
 
-    csr.release_name = "Version 2"
     csr.database_alias = "null_version-2_20221001"
     csr.save()
 

--- a/conftest.py
+++ b/conftest.py
@@ -142,7 +142,7 @@ def clear_testing_span_exporter():
     testing_span_exporter.clear()
 
 
-@pytest.fixture()
+@pytest.fixture
 def span_exporter():
     """Provide access to the global span exporter for interrogation.
     Interrogate it with, for example, get_finished_spans()."""

--- a/opencodelists/tests/fixtures.py
+++ b/opencodelists/tests/fixtures.py
@@ -161,7 +161,7 @@ def build_fixture(fixture_name):
 
     # This docstring is used in the output of `pytest --fixtures`
     fixture.__doc__ = f"Return {fixture_name} from the universe fixture"
-    return pytest.fixture(scope="function")(fixture)
+    return pytest.fixture()(fixture)
 
 
 @pytest.fixture(scope="session")
@@ -834,7 +834,7 @@ null_codelist = build_fixture("null_codelist")
 
 
 # These extra fixtures make modifications to those built in build_fixtures
-@pytest.fixture(scope="function")
+@pytest.fixture
 def draft_with_no_searches(version_with_no_searches, organisation_user):
     return export_to_builder(
         version=version_with_no_searches,
@@ -843,7 +843,7 @@ def draft_with_no_searches(version_with_no_searches, organisation_user):
     )
 
 
-@pytest.fixture(scope="function")
+@pytest.fixture
 def draft_with_some_searches(version_with_some_searches, organisation_user):
     return export_to_builder(
         version=version_with_some_searches,
@@ -852,7 +852,7 @@ def draft_with_some_searches(version_with_some_searches, organisation_user):
     )
 
 
-@pytest.fixture(scope="function")
+@pytest.fixture
 def draft_with_complete_searches(version_with_complete_searches, organisation_user):
     return export_to_builder(
         version=version_with_complete_searches,
@@ -861,7 +861,7 @@ def draft_with_complete_searches(version_with_complete_searches, organisation_us
     )
 
 
-@pytest.fixture(scope="function")
+@pytest.fixture
 def draft(draft_with_complete_searches):
     return draft_with_complete_searches
 
@@ -870,7 +870,6 @@ def draft(draft_with_complete_searches):
 # each of version_with_no_searches, version_with_some_searches,
 # version_with_complete_searches.
 @pytest.fixture(
-    scope="function",
     params=[
         "version_with_no_searches",
         "version_with_some_searches",
@@ -883,7 +882,6 @@ def new_style_version(universe, request):
 
 
 @pytest.fixture(
-    scope="function",
     params=[
         "version_with_no_searches",
         "version_with_some_searches",

--- a/opencodelists/tests/integration/test_db_settings.py
+++ b/opencodelists/tests/integration/test_db_settings.py
@@ -8,14 +8,14 @@ def _assert_pragma(cursor: CursorWrapper, name: str, value: str | int):
     assert cursor.execute(f"PRAGMA {name}").fetchone()[0] == value
 
 
-@pytest.mark.django_db()
+@pytest.mark.django_db
 class TestDatabaseSettings:
     """Tests that our intended core DB settings will be correctly applied.
 
     I say 'will be' because tests can't actually access the prod core DB. So
     the tests that rely on the database state can't test that directly."""
 
-    @pytest.fixture()
+    @pytest.fixture
     def fresh_db_cursor(self, settings, tmp_path):
         """Provide a cursor for a connection to a freshly-created
         filesystem-based database based on the core default configuration.

--- a/opencodelists/tests/templatetags/test_widget_with_classes_filter.py
+++ b/opencodelists/tests/templatetags/test_widget_with_classes_filter.py
@@ -1,5 +1,4 @@
 from django import forms
-from django.test import SimpleTestCase
 
 from opencodelists.templatetags.widget_with_classes_filter import widget_with_classes
 
@@ -8,13 +7,12 @@ class DummyForm(forms.Form):
     name = forms.CharField()
 
 
-class AddClassFilterTests(SimpleTestCase):
-    def test_widget_with_classes(self):
-        form = DummyForm()
-        field = form["name"]
+def test_widget_with_classes():
+    form = DummyForm()
+    field = form["name"]
 
-        # Apply the template filter
-        rendered_widget = widget_with_classes(field, "custom-class")
+    # Apply the template filter
+    rendered_widget = widget_with_classes(field, "custom-class")
 
-        # Check if the class is added correctly
-        self.assertIn('class=" custom-class"', str(rendered_widget))
+    # Check if the class is added correctly
+    assert 'class=" custom-class"' in str(rendered_widget)


### PR DESCRIPTION
While digging around the tests, there were a few style inconsistencies, and possible simplifications.

These were found using the [flake8-pytest-style rules in Ruff](https://docs.astral.sh/ruff/rules/#flake8-pytest-style-pt). With the relative complexity of tests and fixtures in this codebase, I think there's some benefit in having a more consistent style. 

However, there's still some debate about [which of the flake8-pytest-style rules](https://github.com/astral-sh/ruff/issues/8796) are worthwhile, so if we were to apply this as a setting, we might want to pick and choose certain rules only.