### PR TITLE
Add metadata to the user list of codelists

### DIFF
--- a/opencodelists/tests/views/test_user.py
+++ b/opencodelists/tests/views/test_user.py
@@ -83,12 +83,14 @@ def test_user_codelists(
     save_for_review(draft=codelist.versions.first())
     publish_version(version=codelist.versions.last())
     publish_version(version=organisation_codelist.versions.last())
+    user_codelist_version_id = codelist.latest_published_version().id
+    org_codelist_version_id = organisation_codelist.latest_published_version().id
     response = client.get(user_url)
     for codelist_category in ["under_review", "drafts"]:
         assert not response.context[codelist_category]
-    assert [cl.id for cl in response.context["codelists"]] == [codelist.id]
+    assert [cl.id for cl in response.context["codelists"]] == [user_codelist_version_id]
     assert [cl.id for cl in response.context["authored_for_organisation"]] == [
-        organisation_codelist.id
+        org_codelist_version_id
     ]
 
     # change the owner for the user-owned codelist to an organisation
@@ -107,6 +109,6 @@ def test_user_codelists(
     for codelist_category in ["codelists", "under_review", "drafts"]:
         assert not response.context[codelist_category]
     assert [cl.id for cl in response.context["authored_for_organisation"]] == [
-        organisation_codelist.id,
-        codelist.id,
+        org_codelist_version_id,
+        user_codelist_version_id,
     ]

--- a/opencodelists/views/user.py
+++ b/opencodelists/views/user.py
@@ -19,7 +19,10 @@ def user(request, username):
     )
     ctx = {
         "user": user,
-        "codelists": owned_codelists.order_by("handles__name"),
+        "codelists": [
+            codelist.latest_published_version()
+            for codelist in owned_codelists.order_by("handles__name")
+        ],
         # note that name is a property on a codelist, not an attribute, and it comes from the current handle.
         # If we want to order codelists or versions by codelist name, we actually need to order them by handle name.
         # We can't use a queryset order_by in the following cases (where versions_under_review/drafts are querysets of
@@ -27,9 +30,12 @@ def user(request, username):
         # and this results in duplicates in the returned queryset.
         # See https://code.djangoproject.com/ticket/18165
         # Sort by organisation then name
-        "authored_for_organisation": sorted(
-            authored_for_organisation, key=lambda x: (x.owner.name, x.name)
-        ),
+        "authored_for_organisation": [
+            codelist.latest_published_version()
+            for codelist in sorted(
+                authored_for_organisation, key=lambda x: (x.owner.name, x.name)
+            )
+        ],
         "under_review": sorted(
             user.versions_under_review.select_related("codelist"),
             key=lambda x: x.codelist.name,

--- a/templates/opencodelists/_codelist_links.html
+++ b/templates/opencodelists/_codelist_links.html
@@ -1,0 +1,5 @@
+<ul>
+  {% for version in codelist_versions %}
+  <li><a href="{{ version.get_absolute_url }}">{{ version.codelist.name }} {% if show_ownership %}(owned by {{ version.codelist.owner }}){% endif %}</a></li>
+  {% endfor %}
+</ul>

--- a/templates/opencodelists/_codelist_links.html
+++ b/templates/opencodelists/_codelist_links.html
@@ -1,5 +1,12 @@
 <ul>
   {% for version in codelist_versions %}
-  <li><a href="{{ version.get_absolute_url }}">{{ version.codelist.name }} {% if show_ownership %}(owned by {{ version.codelist.owner }}){% endif %}</a></li>
+  <li>
+    <div class="d-flex align-items-center">
+      <a href="{{ version.get_absolute_url }}">{{ version.codelist.name }} {% if show_ownership %}(owned by {{ version.codelist.owner }}){% endif %}</a>
+      <span class="badge badge-secondary ml-2">{{ version.codelist.coding_system_short_name }}</span>
+      <span class="badge badge-primary ml-1">{{ version.codes | length }} code{% if version.codes|length != 1 %}s{% endif %}</span>
+      <span class="badge ml-1">Last updated {{ version.updated_at | date:'d M Y' }} at {{ version.updated_at | date:'H:i' }}</span>
+    </div>
+  </li>
   {% endfor %}
 </ul>

--- a/templates/opencodelists/that_user.html
+++ b/templates/opencodelists/that_user.html
@@ -13,8 +13,8 @@
 <h4>Codelists</h4>
 
 <ul>
-        {% for codelist in codelists %}
-        <li><a href="{{ codelist.get_absolute_url }}">{{ codelist.name }}</a></li>
+        {% for version in codelists %}
+        <li><a href="{{ version.get_absolute_url }}">{{ version.codelist.name }}</a></li>
         {% endfor %}
 </ul>
 {% endif %}

--- a/templates/opencodelists/that_user.html
+++ b/templates/opencodelists/that_user.html
@@ -12,10 +12,6 @@
 {% if codelists %}
 <h4>Codelists</h4>
 
-<ul>
-        {% for version in codelists %}
-        <li><a href="{{ version.get_absolute_url }}">{{ version.codelist.name }}</a></li>
-        {% endfor %}
-</ul>
+{% include "opencodelists/_codelist_links.html" with codelist_versions=codelists show_ownership=False %}
 {% endif %}
 {% endblock %}

--- a/templates/opencodelists/this_user.html
+++ b/templates/opencodelists/this_user.html
@@ -36,7 +36,7 @@
 
 
 {% if drafts %}
-<h4>Your drafts</h4>
+<h4>Your draft codelists</h4>
 {% include "opencodelists/_codelist_links.html" with codelist_versions=drafts show_ownership=user.organisations.exists %}
 {% endif %}
 {% endblock %}

--- a/templates/opencodelists/this_user.html
+++ b/templates/opencodelists/this_user.html
@@ -20,8 +20,8 @@
 <h4>Your codelists</h4>
 
 <ul>
-        {% for codelist in codelists %}
-        <li><a href="{{ codelist.get_latest_published_url }}">{{ codelist.name }}</a></li>
+        {% for version in codelists %}
+        <li><a href="{{ version.get_absolute_url }}">{{ version.codelist.name }}</a></li>
         {% endfor %}
 </ul>
 {% endif %}
@@ -31,8 +31,8 @@
 <h4>Your organisation codelists</h4>
 
 <ul>
-        {% for codelist in authored_for_organisation %}
-        <li><a href="{{ codelist.get_latest_published_url }}">{{ codelist.name }} (owned by {{ codelist.owner }})</a></li>
+        {% for version in authored_for_organisation %}
+        <li><a href="{{ version.get_absolute_url }}">{{ version.codelist.name }} (owned by {{ version.codelist.owner }})</a></li>
         {% endfor %}
 </ul>
 {% endif %}

--- a/templates/opencodelists/this_user.html
+++ b/templates/opencodelists/this_user.html
@@ -19,43 +19,24 @@
 {% if codelists %}
 <h4>Your codelists</h4>
 
-<ul>
-        {% for version in codelists %}
-        <li><a href="{{ version.get_absolute_url }}">{{ version.codelist.name }}</a></li>
-        {% endfor %}
-</ul>
+{% include "opencodelists/_codelist_links.html" with codelist_versions=codelists show_ownership=False %}
 {% endif %}
 
 
 {% if authored_for_organisation %}
 <h4>Your organisation codelists</h4>
-
-<ul>
-        {% for version in authored_for_organisation %}
-        <li><a href="{{ version.get_absolute_url }}">{{ version.codelist.name }} (owned by {{ version.codelist.owner }})</a></li>
-        {% endfor %}
-</ul>
+{% include "opencodelists/_codelist_links.html" with codelist_versions=authored_for_organisation show_ownership=True %}
 {% endif %}
 
 
 {% if under_review %}
 <h4>Your codelists under review</h4>
-
-<ul>
-        {% for version in under_review %}
-        <li><a href="{{ version.get_absolute_url }}">{{ version.codelist.name }} {% if user.organisations.exists %}(owned by {{ version.codelist.owner }}){% endif %}</a></li>
-        {% endfor %}
-</ul>
+{% include "opencodelists/_codelist_links.html" with codelist_versions=under_review show_ownership=user.organisations.exists %}
 {% endif %}
 
 
 {% if drafts %}
 <h4>Your drafts</h4>
-
-<ul>
-        {% for draft in drafts %}
-        <li><a href="{{ draft.get_absolute_url }}">{{ draft.codelist.name }} {% if user.organisations.exists %}(owned by {{ draft.codelist.owner }}){% endif %}</a></li>
-        {% endfor %}
-</ul>
+{% include "opencodelists/_codelist_links.html" with codelist_versions=drafts show_ownership=user.organisations.exists %}
 {% endif %}
 {% endblock %}

--- a/templates/opencodelists/this_user.html
+++ b/templates/opencodelists/this_user.html
@@ -17,7 +17,7 @@
 <br />
 
 {% if codelists %}
-<h4>Your codelists</h4>
+<h4>Your published codelists</h4>
 
 {% include "opencodelists/_codelist_links.html" with codelist_versions=codelists show_ownership=False %}
 {% endif %}


### PR DESCRIPTION
The list of codelists now displays the metadata of:
- terminology (SNOMED, ICD10 etc.)
- the number of codes
- the last updated time
It look like this:
![image](https://github.com/user-attachments/assets/e1dba2da-d110-432c-9671-645250552200)

Fixes #2489 