### PR TITLE
Better help and layout on the "no results" page in the builder

### DIFF
--- a/assets/src/scripts/components/CodelistBuilder.tsx
+++ b/assets/src/scripts/components/CodelistBuilder.tsx
@@ -3,6 +3,7 @@ import { Col, Row } from "react-bootstrap";
 import Hierarchy from "../_hierarchy";
 import { getCookie } from "../_utils";
 import { Code, PageData, Status } from "../types";
+import EmptySearch from "./EmptySearch";
 import EmptyState from "./EmptyState";
 import ManagementForm from "./ManagementForm";
 import Metadata from "./Metadata";
@@ -182,17 +183,21 @@ export default class CodelistBuilder extends React.Component<
             <Col md="9" className="overflow-auto">
               <h3 className="h4">{resultsHeading}</h3>
               <hr />
-              <TreeTables
-                allCodes={allCodes}
-                codeToStatus={this.state.codeToStatus}
-                codeToTerm={codeToTerm}
-                hierarchy={hierarchy}
-                isEditable={isEditable}
-                toggleVisibility={() => null}
-                treeTables={treeTables}
-                updateStatus={this.updateStatus}
-                visiblePaths={visiblePaths}
-              />
+              {treeTables.length > 0 ? (
+                <TreeTables
+                  allCodes={allCodes}
+                  codeToStatus={this.state.codeToStatus}
+                  codeToTerm={codeToTerm}
+                  hierarchy={hierarchy}
+                  isEditable={isEditable}
+                  toggleVisibility={() => null}
+                  treeTables={treeTables}
+                  updateStatus={this.updateStatus}
+                  visiblePaths={visiblePaths}
+                />
+              ) : (
+                <EmptySearch />
+              )}
             </Col>
           )}
         </Row>

--- a/assets/src/scripts/components/EmptySearch.tsx
+++ b/assets/src/scripts/components/EmptySearch.tsx
@@ -1,0 +1,24 @@
+import React from "react";
+
+export default function EmptyState() {
+  return (
+    <section style={{ maxWidth: "80ch" }}>
+      <p className="lead">Your search returned no concepts. You may want to:</p>
+      <ol>
+        <li>Double check the spelling</li>
+        <li>
+          Make sure that if you're searching for a code (rather than a search
+          term) that you have selected the correct option ("Search by code"
+          above the search box on the left)
+        </li>
+        <li>Try searching for a similar term</li>
+      </ol>
+      <p>
+        If this search was an error, you can click "Remove" from the "Previous
+        searches" box on the left to get rid of it. However, if you want other
+        people to know that you tried this search, but it returned no results,
+        then you can leave it as a blank search.
+      </p>
+    </section>
+  );
+}

--- a/assets/src/scripts/components/EmptySearch.tsx
+++ b/assets/src/scripts/components/EmptySearch.tsx
@@ -5,19 +5,18 @@ export default function EmptyState() {
     <section style={{ maxWidth: "80ch" }}>
       <p className="lead">Your search returned no concepts. You may want to:</p>
       <ol>
-        <li>Double check the spelling</li>
-        <li>
-          Make sure that if you're searching for a code (rather than a search
-          term) that you have selected the correct option ("Search by code"
-          above the search box on the left)
-        </li>
+        <li>Check your spelling</li>
         <li>Try searching for a similar term</li>
+        <li>
+            Ensure you have selected the correct option above the search box
+            ("Search by code" if searching by code rather than term)
+        </li>
       </ol>
       <p>
-        If this search was an error, you can click "Remove" from the "Previous
-        searches" box on the left to get rid of it. However, if you want other
-        people to know that you tried this search, but it returned no results,
-        then you can leave it as a blank search.
+        If this search was an error, click "Remove" in the "Previous searches"
+        box on the left to delete it. If you'd like to record that you
+        performed this search but it returned no results, you can leave it as
+        is.
       </p>
     </section>
   );

--- a/assets/src/scripts/components/EmptySearch.tsx
+++ b/assets/src/scripts/components/EmptySearch.tsx
@@ -8,15 +8,14 @@ export default function EmptyState() {
         <li>Check your spelling</li>
         <li>Try searching for a similar term</li>
         <li>
-            Ensure you have selected the correct option above the search box
-            ("Search by code" if searching by code rather than term)
+          Ensure you have selected the correct option above the search box
+          ("Search by code" if searching by code rather than term)
         </li>
       </ol>
       <p>
         If this search was an error, click "Remove" in the "Previous searches"
-        box on the left to delete it. If you'd like to record that you
-        performed this search but it returned no results, you can leave it as
-        is.
+        box on the left to delete it. If you'd like to record that you performed
+        this search but it returned no results, you can leave it as is.
       </p>
     </section>
   );

--- a/builder/views.py
+++ b/builder/views.py
@@ -262,9 +262,6 @@ def new_search(request, draft):
 
     search = actions.create_search(draft=draft, term=term, code=code, codes=codes)
 
-    if not codes:
-        messages.info(request, f'There are no results for "{code or term}"')
-
     return redirect(draft.get_builder_search_url(search.id, search.slug))
 
 


### PR DESCRIPTION
If you do a search that returns no results we now:

- display some helpful text so it's both clearer that nothing was found, but also what you might want to do next
- no longer display the banner at the top as it duplicates info elsewhere

Now looks like this:

![image](https://github.com/user-attachments/assets/3116a475-4e78-4777-a57b-a0ad9e49e743)

Fixes #2522 
