### PR TITLE
Remove "Remove" link from builder page `Search` if not editable.

### DIFF
--- a/assets/src/scripts/__tests__/components/Search.spec.tsx
+++ b/assets/src/scripts/__tests__/components/Search.spec.tsx
@@ -27,27 +27,32 @@ describe("Search Component", () => {
   };
 
   it("renders the search card with header", () => {
-    render(<Search {...baseProps} />);
+    render(<Search {...baseProps} isEditable={true} />);
     expect(
       screen.getByRole("heading", { name: "Previous searches" }),
     ).toBeVisible();
   });
 
-  it("renders remove link only when delete_url exists", () => {
-    render(<Search {...baseProps} />);
+  it("renders remove link only when isEditable is true and delete_url exists", () => {
+    render(<Search {...baseProps} isEditable={true} />);
     const removeLinks = screen.getAllByRole("link", { name: /Remove/ });
     expect(removeLinks.length).toBe(1); // Only one item has delete_url.
     expect(removeLinks[0]).toBeVisible();
   });
 
+  it("does not render remove link when isEditable is false", () => {
+    render(<Search {...baseProps} isEditable={false} />);
+    expect(screen.queryByRole("link", { name: /Remove/ })).toBeNull();
+  });
+
   it("renders the correct number of search items", () => {
-    render(<Search {...baseProps} />);
+    render(<Search {...baseProps} isEditable={true} />);
     const items = screen.getAllByRole("link");
     expect(items.length).toBe(mockSearches.length + 1); // +1 for the "show all" item.
   });
 
   it("renders 'show all' link when there's an active search", () => {
-    render(<Search {...baseProps} />);
+    render(<Search {...baseProps} isEditable={true} />);
     expect(screen.queryByRole("link", { name: "show all" })).toBeVisible();
   });
 
@@ -67,7 +72,13 @@ describe("Search Component", () => {
       },
     ];
 
-    render(<Search {...baseProps} searches={mockSearchesNoActiveSearch} />);
+    render(
+      <Search
+        {...baseProps}
+        searches={mockSearchesNoActiveSearch}
+        isEditable={true}
+      />,
+    );
     expect(screen.queryByRole("link", { name: "show all" })).toBeNull();
   });
 });

--- a/assets/src/scripts/__tests__/components/Search.spec.tsx
+++ b/assets/src/scripts/__tests__/components/Search.spec.tsx
@@ -1,0 +1,73 @@
+import "@testing-library/jest-dom";
+import { render, screen } from "@testing-library/react";
+import React from "react";
+import { describe, expect, it } from "vitest";
+import Search from "../../components/Search";
+import { PageData } from "../../types";
+
+describe("Search Component", () => {
+  const mockSearches: PageData["searches"] = [
+    {
+      active: true,
+      term_or_code: "test search 1",
+      url: "/search/1/",
+      delete_url: "/delete/1/",
+    },
+    {
+      active: false,
+      term_or_code: "test search 2",
+      url: "/search/2/",
+      delete_url: "",
+    },
+  ];
+
+  const baseProps = {
+    draftURL: "/draft/",
+    searches: mockSearches,
+  };
+
+  it("renders the search card with header", () => {
+    render(<Search {...baseProps} />);
+    expect(
+      screen.getByRole("heading", { name: "Previous searches" }),
+    ).toBeVisible();
+  });
+
+  it("renders remove link only when delete_url exists", () => {
+    render(<Search {...baseProps} />);
+    const removeLinks = screen.getAllByRole("link", { name: /Remove/ });
+    expect(removeLinks.length).toBe(1); // Only one item has delete_url.
+    expect(removeLinks[0]).toBeVisible();
+  });
+
+  it("renders the correct number of search items", () => {
+    render(<Search {...baseProps} />);
+    const items = screen.getAllByRole("link");
+    expect(items.length).toBe(mockSearches.length + 1); // +1 for the "show all" item.
+  });
+
+  it("renders 'show all' link when there's an active search", () => {
+    render(<Search {...baseProps} />);
+    expect(screen.queryByRole("link", { name: "show all" })).toBeVisible();
+  });
+
+  it("does not render 'show all' link when no active search", () => {
+    const mockSearchesNoActiveSearch: PageData["searches"] = [
+      {
+        active: false,
+        term_or_code: "test search 1",
+        url: "/search/1/",
+        delete_url: "/delete/1/",
+      },
+      {
+        active: false,
+        term_or_code: "test search 2",
+        url: "/search/2/",
+        delete_url: "",
+      },
+    ];
+
+    render(<Search {...baseProps} searches={mockSearchesNoActiveSearch} />);
+    expect(screen.queryByRole("link", { name: "show all" })).toBeNull();
+  });
+});

--- a/assets/src/scripts/components/CodelistBuilder.tsx
+++ b/assets/src/scripts/components/CodelistBuilder.tsx
@@ -162,7 +162,11 @@ export default class CodelistBuilder extends React.Component<
             )}
 
             {searches.length > 0 && (
-              <Search draftURL={draftURL} searches={searches} />
+              <Search
+                draftURL={draftURL}
+                isEditable={isEditable}
+                searches={searches}
+              />
             )}
 
             {isEditable && (

--- a/assets/src/scripts/components/Search.tsx
+++ b/assets/src/scripts/components/Search.tsx
@@ -5,10 +5,15 @@ import { PageData } from "../types";
 
 interface SearchProps {
   draftURL: PageData["draftURL"];
+  isEditable: PageData["isEditable"];
   searches: PageData["searches"];
 }
 
-export default function Search({ draftURL, searches }: SearchProps) {
+export default function Search({
+  draftURL,
+  isEditable,
+  searches,
+}: SearchProps) {
   const [activeUrl, setActiveUrl] = useState<string>(
     () => searches.find((search) => search.active)?.url || "",
   );
@@ -28,7 +33,7 @@ export default function Search({ draftURL, searches }: SearchProps) {
       <ListGroup variant="flush">
         {searches.map((search) => (
           <React.Fragment key={search.url}>
-            {search.delete_url ? (
+            {search.delete_url && isEditable ? (
               <ListGroup.Item
                 action
                 active={search.url === activeUrl}


### PR DESCRIPTION
Builder pages are currently publicly visible, so that researchers can share links of work in progress codelists. We expect this to continue. Therefore it's possible to view a codelist Builder with Searches that have a delete URL but where the user doesn't have permission -- this is exactly when `isEditable` is `false`. We should not display the button if the user does not have permission to delete the search.

Fixes #2528.