### PR TITLE
Remove duplicate functional test CI step

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -68,10 +68,6 @@ jobs:
           # build docker and run tests with migrations
           just docker-test-py --migrations
 
-      - name: Run functional tests on docker dev image
-        run: |
-          just docker-test-functional --migrations
-
       - name: Run smoke test on prod
         run: |
           just docker-serve prod -d


### PR DESCRIPTION
This happens separately in `test-functional` too.

Removing this duplicate was part of #2421 at one point. However, the relevant commit must have got lost in the final rebasing somehow.

(I skimmed the merged form of #2421 and this looks to be the only anomaly there.)