### PR TITLE
Mount DATABASE_DIR in dev container if defined

### DIFF
--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -87,3 +87,9 @@ services:
       - PLAYWRIGHT_BROWSER_EXECUTABLE_PATH=/app/.playwright-browsers/chrome-linux/chrome
     # override command
     command: python -m pytest --cov=. --cov-report html --cov-report term-missing:skip-covered
+
+  # development service with overridden db path mounted
+  dev-mount-db-dir:
+    extends: dev
+    volumes:
+    - ${DATABASE_DIR}:${DATABASE_DIR}

--- a/docker/justfile
+++ b/docker/justfile
@@ -30,11 +30,11 @@ check-js:
 
 
 # run python checks
-check-py: build
-    docker compose run --rm dev /app/docker/entrypoints/check.sh
+check-py env="dev": build
+    docker compose run --rm {{ env }} /app/docker/entrypoints/check.sh
 
-check-migrations *args="": build
-    docker compose run --rm dev python manage.py makemigrations --check {{ args }}
+check-migrations env="dev" *args="": build
+    docker compose run --rm {{ env }} python manage.py makemigrations --check {{ args }}
 
 # run Python (non-functional) tests in docker container
 test-py *args="":
@@ -77,13 +77,13 @@ serve env="dev" *args="": (_create_storage env)
 
 
 # run command in dev container
-run *args="bash":
-    docker compose run dev {{ args }}
+run env="dev" *args="bash":
+    docker compose run {{ env }} {{ args }}
 
 
 # exec command in existing dev container
-exec *args="bash":
-    docker compose exec dev {{ args }}
+exec env="dev" *args="bash":
+    docker compose exec {{ env }} {{ args }}
 
 
 # run a basic functional smoke test against a running opencodelists

--- a/justfile
+++ b/justfile
@@ -11,6 +11,8 @@ export COMPILE := BIN + "/pip-compile --allow-unsafe --generate-hashes"
 # Load .env files by default
 set dotenv-load := true
 
+# set docker environment to one with mounted database dir if DATABASE_DIR env var is set
+docker_env := if env_var_or_default("DATABASE_DIR", "unset") == "unset" { "dev" } else { "dev-mount-db-dir" }
 
 # list available commands
 default:
@@ -302,7 +304,7 @@ docker-check-js: _env
 
 # run js checks in docker container
 docker-check-py: _env
-    {{ just_executable() }} docker/check-py
+    {{ just_executable() }} docker/check-py {{ docker_env }}
 
 
 # run python non-functional tests in docker container
@@ -325,17 +327,17 @@ docker-test: _env
 
 # run dev server in docker container
 docker-serve env="dev" *args="": _env
-    {{ just_executable() }} docker/serve {{ env }} {{ args }}
+    {{ just_executable() }} docker/serve {{ if env == "dev" { docker_env } else { env } }} {{ args }}
 
 
 # run cmd in dev docker continer
 docker-run *args="bash": _env
-    {{ just_executable() }} docker/run {{ args }}
+    {{ just_executable() }} docker/run {{ docker_env }} {{ args }}
 
 
 # exec command in an existing dev docker container
 docker-exec *args="bash": _env
-    {{ just_executable() }} docker/exec {{ args }}
+    {{ just_executable() }} docker/exec {{ docker_env }} {{ args }}
 
 
 # run tests in docker container
@@ -345,4 +347,4 @@ docker-smoke-test host="http://localhost:7000": _env
 
 # check migrations in the dev docker container
 docker-check-migrations *args="":
-    {{ just_executable() }} docker/check-migrations {{ args }}
+    {{ just_executable() }} docker/check-migrations {{ docker_env }} {{ args }}


### PR DESCRIPTION
Fixes #2479 


If the `DATABASE_DIR` env var is set, mount this path under the same path inside the dev docker container so the dev docker container behaviour mirrors that of the local environment.

Change any hard-coded "dev" environment strings in docker just recipes to use `env` variable instead so all recipes respect this new behaviour.

Ensure `docker-serve` recipe is unaffected if called with an environment other than "dev" (i.e. "prod").