### PR TITLE
Allow experimental coding systems to be hidden behind a flag

### DIFF
--- a/DEVELOPERS.md
+++ b/DEVELOPERS.md
@@ -367,6 +367,14 @@ On dokku3:
 
 See [codelists/scripts/README.md](codelists/scripts/README.md#bulk-import-codelists-from-an-xlsx-file)
 
+### Experimental coding systems
+
+When adding a new coding system it is possible to get user feedback by deploying it as an experimental coding system. Once the required methods of the parent class `BuilderCompatibleCodingSystem` have been implemented, you can set the `is_experimental` flag to `True`. This then makes the coding system available for new codelists, but only if the user navigates to this URL rather than clicking the "create new codelist" button:
+
+/users/<username>/new-codelist/?include_experimental_coding_systems
+
+The experimental coding systems have visible warnings to ensure they are not used accidentally.
+
 ## Updating mappings
 
 See the relevant README in each of the subdirectories inside [mappings/](mappings/).

--- a/codelists/coding_systems.py
+++ b/codelists/coding_systems.py
@@ -22,12 +22,13 @@ def most_recent_database_alias(coding_system_id):
     )
 
 
-def builder_compatible_coding_systems():
+def builder_compatible_coding_systems(include_experimental=False):
     return sorted(
         [
             system
             for system in CODING_SYSTEMS.values()
             if system.is_builder_compatible()
+            and (include_experimental or not system.is_experimental)
         ],
         key=lambda x: x.name.lower(),
     )

--- a/coding_systems/base/coding_system_base.py
+++ b/coding_systems/base/coding_system_base.py
@@ -125,6 +125,8 @@ class BuilderCompatibleCodingSystem(BaseCodingSystem):
 
     # User-facing description to be rendered in the UI
     description = NotImplemented
+    # When set to true, we only show this in the builder behind a feature flag
+    is_experimental = False
 
     def ancestor_relationships(self, codes):  # pragma: no cover
         """

--- a/coding_systems/versioning/tests/test_views.py
+++ b/coding_systems/versioning/tests/test_views.py
@@ -6,10 +6,15 @@ from codelists.coding_systems import CODING_SYSTEMS
 def test_latest_releases(client, setup_coding_systems):
     response = client.get(reverse("versioning:latest_releases"))
     assert response.status_code == 200
-    # Coding system releases with database aliases (i.e. not "null", "opcs4" "readv2")
+    # Coding system releases with database aliases (i.e. not "null", "opcs4", "readv2", "experiment")
     # are shown
     latest_releases_ids = {
         release.id for release in response.context["latest_releases"]
     }
     assert latest_releases_ids == {"icd10", "snomedct", "ctv3", "dmd", "bnf"}
-    assert set(CODING_SYSTEMS) - latest_releases_ids == {"null", "opcs4", "readv2"}
+    assert set(CODING_SYSTEMS) - latest_releases_ids == {
+        "null",
+        "opcs4",
+        "readv2",
+        "experiment",
+    }

--- a/opencodelists/forms.py
+++ b/opencodelists/forms.py
@@ -43,14 +43,9 @@ class UserPasswordForm(forms.Form):
 
 
 class CodelistCreateForm(forms.Form):
-    CODING_SYSTEM_CHOICES = [("", "---")] + [
-        (system.id, system.name) for system in builder_compatible_coding_systems()
-    ]
     owner = forms.ChoiceField()
     name = forms.CharField(max_length=255, label="Codelist name")
-    coding_system_id = forms.ChoiceField(
-        choices=CODING_SYSTEM_CHOICES, label="Coding system"
-    )
+    coding_system_id = forms.ChoiceField(choices=[], label="Coding system")
     csv_data = forms.FileField(
         label="CSV data",
         required=False,
@@ -59,7 +54,21 @@ class CodelistCreateForm(forms.Form):
 
     def __init__(self, *args, **kwargs):
         owner_choices = kwargs.pop("owner_choices")
+        include_experimental = kwargs.pop("include_experimental")
         super().__init__(*args, **kwargs)
+        coding_systems = [("", "---")] + [
+            (
+                system.id,
+                system.name + " - EXPERIMENTAL PREVIEW"
+                if system.is_experimental
+                else system.name,
+            )
+            for system in builder_compatible_coding_systems(
+                include_experimental=include_experimental
+            )
+        ]
+        self.fields["coding_system_id"].choices = coding_systems
+
         if owner_choices:
             self.fields["owner"] = forms.ChoiceField(choices=owner_choices)
         else:

--- a/opencodelists/tests/fixtures.py
+++ b/opencodelists/tests/fixtures.py
@@ -121,6 +121,7 @@ from codelists.actions import (
 from codelists.coding_systems import CODING_SYSTEMS, most_recent_database_alias
 from codelists.models import Status
 from codelists.search import do_search
+from coding_systems.base.coding_system_base import BuilderCompatibleCodingSystem
 from opencodelists.actions import (
     add_user_to_organisation,
     create_organisation,
@@ -736,6 +737,20 @@ def build_fixtures():
         codelist=null_codelist,
         csv_data="code,term\n5678,Test code1",
         coding_system_database_alias="null_test_20200101",
+    )
+
+    # Add an experimental coding system i.e. one that is only visible behind a flag
+    CODING_SYSTEMS["experiment"] = type(
+        "ExperimentalCodingSystem",
+        (BuilderCompatibleCodingSystem,),
+        {
+            "id": "experiment",
+            "name": "Experimental Coding System",
+            "short_name": "Beta",
+            "description": "An experimental coding system available behind a flag",
+            "is_experimental": True,
+            "has_database": False,
+        },
     )
 
     return locals()

--- a/opencodelists/tests/test_forms.py
+++ b/opencodelists/tests/test_forms.py
@@ -62,6 +62,7 @@ class TestCodelistCreateForm:
                 "csv_data": file,
             },
             owner_choices=[],
+            include_experimental=False,
         )
 
     def test_bound_form_valid(self, disorder_of_elbow_codes):

--- a/templates/opencodelists/user_create_codelist.html
+++ b/templates/opencodelists/user_create_codelist.html
@@ -53,7 +53,12 @@
       {% fragment as coding_system_help_text %}
         <ul>
         {% for coding_system in coding_systems %}
-          <li><strong>{{ coding_system.name }}</strong>: {{ coding_system.description }}</li>
+          <li>
+            <strong>{{ coding_system.name }}</strong>: {{ coding_system.description }}
+            {% if coding_system.is_experimental %}
+            <strong class="text-red-700">WARNING - this coding system is in testing and should only be used if you've been asked to test it.</strong>
+            {% endif %}
+          </li>
         {% endfor %}
         </ul>
       {% endfragment coding_system_help_text %}


### PR DESCRIPTION
Enables any builder-compatible coding system to be marked as experimental (via the `is_experimental` boolean). By default experimental coding systems are not displayed on the create new codelist screen, unless you visit the page with the following query param: `/users/<username>/new-codelist/?include_experimental_coding_systems`

Experimental coding systems are clearly marked as such to ensure that in the unlikely event someone visits the page unintentionally, that they won't inadvertently use an experimental coding system without understanding the risks.

The page looks like this (with CTV3 change temporarily to be experimental):
![image](https://github.com/user-attachments/assets/63be1ec8-c1c8-459e-a259-e85cb650b0b4)

And the drop down:
![image](https://github.com/user-attachments/assets/9515036a-c846-4ab7-9428-6610f73a4ef1)

Fixes #2503.

