### PR TITLE
Implement VTM-VMP-AMP hierarchy

### DIFF
--- a/codelists/coding_systems.py
+++ b/codelists/coding_systems.py
@@ -12,8 +12,22 @@ for path in glob.glob(
 ):
     coding_system_id = path.split(os.path.sep)[-2]
     mod = import_module(f"coding_systems.{coding_system_id}.coding_system")
-    CODING_SYSTEMS[coding_system_id] = mod.CodingSystem
+    coding_system = mod.CodingSystem
+    CODING_SYSTEMS[coding_system.id] = coding_system
 
 
-def most_recent_database_alias(coding_system):
-    return CODING_SYSTEMS[coding_system].get_by_release_or_most_recent().database_alias
+def most_recent_database_alias(coding_system_id):
+    return (
+        CODING_SYSTEMS[coding_system_id].get_by_release_or_most_recent().database_alias
+    )
+
+
+def builder_compatible_coding_systems():
+    return sorted(
+        [
+            system
+            for system in CODING_SYSTEMS.values()
+            if system.is_builder_compatible()
+        ],
+        key=lambda x: x.name.lower(),
+    )

--- a/codelists/models.py
+++ b/codelists/models.py
@@ -6,7 +6,6 @@ from django.urls import reverse
 from django.utils.functional import cached_property
 from taggit.managers import TaggableManager
 
-from coding_systems.base.coding_system_base import BuilderCompatibleCodingSystem
 from mappings.bnfdmd.mappers import bnf_to_dmd
 from mappings.dmdvmpprevmap.mappers import vmpprev_full_mappings
 from opencodelists.csv_utils import (
@@ -411,7 +410,7 @@ class CodelistVersion(models.Model):
 
     @property
     def has_hierarchy(self):
-        return issubclass(self.coding_system.__class__, BuilderCompatibleCodingSystem)
+        return self.coding_system.is_builder_compatible()
 
     def calculate_hierarchy(self):
         """Return Hierarchy of codes related to this CodelistVersion."""

--- a/codelists/models.py
+++ b/codelists/models.py
@@ -6,6 +6,7 @@ from django.urls import reverse
 from django.utils.functional import cached_property
 from taggit.managers import TaggableManager
 
+from coding_systems.base.coding_system_base import BuilderCompatibleCodingSystem
 from mappings.bnfdmd.mappers import bnf_to_dmd
 from mappings.dmdvmpprevmap.mappers import vmpprev_full_mappings
 from opencodelists.csv_utils import (
@@ -410,7 +411,7 @@ class CodelistVersion(models.Model):
 
     @property
     def has_hierarchy(self):
-        return hasattr(self.coding_system, "ancestor_relationships")
+        return issubclass(self.coding_system.__class__, BuilderCompatibleCodingSystem)
 
     def calculate_hierarchy(self):
         """Return Hierarchy of codes related to this CodelistVersion."""

--- a/codelists/views/version.py
+++ b/codelists/views/version.py
@@ -2,8 +2,6 @@ from django.contrib import messages
 from django.shortcuts import render
 from django.utils.html import format_html
 
-from coding_systems.base.coding_system_base import BuilderCompatibleCodingSystem
-
 from ..models import Status
 from ..presenters import present_search_results
 from ..tree_data import build_tree_data
@@ -18,7 +16,7 @@ def version(request, clv):
     parent_map = None
     tree_tables = None
     tree_data = None
-    if isinstance(clv.coding_system, BuilderCompatibleCodingSystem):
+    if clv.coding_system.is_builder_compatible():
         coding_system = clv.coding_system
 
         hierarchy = clv.codeset.hierarchy

--- a/codelists/views/version_diff.py
+++ b/codelists/views/version_diff.py
@@ -3,6 +3,7 @@ from django.db.models import Q
 from django.http import Http404, HttpResponseBadRequest
 from django.shortcuts import get_object_or_404, render
 
+from coding_systems.base.coding_system_base import BuilderCompatibleCodingSystem
 from opencodelists.hash_utils import unhash
 
 from ..hierarchy import Hierarchy
@@ -78,7 +79,7 @@ def summarise(codes, coding_system, csv_data_codes_to_terms=None):
             term = f"[Unknown] {csv_data_codes_to_terms[code]}"
         return term
 
-    if not hasattr(coding_system, "ancestor_relationships"):
+    if not issubclass(coding_system.__class__, BuilderCompatibleCodingSystem):
         # if the coding system has no hierarchy to look up, just return the codes
         # themselves with their terms
         summary = [{"code": code, "term": get_term(code)} for code in codes]

--- a/codelists/views/version_diff.py
+++ b/codelists/views/version_diff.py
@@ -3,7 +3,6 @@ from django.db.models import Q
 from django.http import Http404, HttpResponseBadRequest
 from django.shortcuts import get_object_or_404, render
 
-from coding_systems.base.coding_system_base import BuilderCompatibleCodingSystem
 from opencodelists.hash_utils import unhash
 
 from ..hierarchy import Hierarchy
@@ -79,7 +78,7 @@ def summarise(codes, coding_system, csv_data_codes_to_terms=None):
             term = f"[Unknown] {csv_data_codes_to_terms[code]}"
         return term
 
-    if not issubclass(coding_system.__class__, BuilderCompatibleCodingSystem):
+    if not coding_system.is_builder_compatible():
         # if the coding system has no hierarchy to look up, just return the codes
         # themselves with their terms
         summary = [{"code": code, "term": get_term(code)} for code in codes]

--- a/coding_systems/base/coding_system_base.py
+++ b/coding_systems/base/coding_system_base.py
@@ -42,6 +42,10 @@ class BaseCodingSystem(ABC):
     # are not guaranteed to be exhaustive in future.
     csv_headers = {"code": ["code"], "term": ["term"]}
 
+    @classmethod
+    def is_builder_compatible(self):
+        return issubclass(self, BuilderCompatibleCodingSystem)
+
     def __init__(self, database_alias):
         self.database_alias = database_alias
 

--- a/coding_systems/dmd/fixtures/asthma-medication.dmd_test_20200101.json
+++ b/coding_systems/dmd/fixtures/asthma-medication.dmd_test_20200101.json
@@ -1,816 +1,972 @@
 [
-{
-    "model": "dmd.vmp",
-    "pk": "10514511000001106",
-    "fields": {
-        "vpiddt": null,
-        "vpidprev": null,
-        "vtm": "65502005",
-        "invalid": false,
-        "nm": "Adrenaline (base) 220micrograms/dose inhaler",
-        "abbrevnm": null,
-        "basis": 2,
-        "nmdt": "2012-02-28",
-        "nmprev": "Adrenaline 220micrograms/dose inhaler",
-        "basis_prev": 2,
-        "nmchange": 4,
-        "combprod": null,
-        "pres_stat": 1,
-        "sug_f": false,
-        "glu_f": false,
-        "pres_f": false,
-        "cfc_f": false,
-        "non_avail": 1,
-        "non_availdt": "2013-03-18",
-        "df_ind": 1,
-        "udfs": "1.000",
-        "udfs_uom": "3317411000001100",
-        "unit_dose_uom": "3317411000001100"
+    {
+        "model": "dmd.vmp",
+        "pk": "10514511000001106",
+        "fields": {
+            "vpiddt": null,
+            "vpidprev": null,
+            "vtm": "65502005",
+            "invalid": false,
+            "nm": "Adrenaline (base) 220micrograms/dose inhaler",
+            "abbrevnm": null,
+            "basis": 2,
+            "nmdt": "2012-02-28",
+            "nmprev": "Adrenaline 220micrograms/dose inhaler",
+            "basis_prev": 2,
+            "nmchange": 4,
+            "combprod": null,
+            "pres_stat": 1,
+            "sug_f": false,
+            "glu_f": false,
+            "pres_f": false,
+            "cfc_f": false,
+            "non_avail": 1,
+            "non_availdt": "2013-03-18",
+            "df_ind": 1,
+            "udfs": "1.000",
+            "udfs_uom": "3317411000001100",
+            "unit_dose_uom": "3317411000001100"
+        }
+    },
+    {
+        "model": "dmd.vmp",
+        "pk": "10525011000001107",
+        "fields": {
+            "vpiddt": null,
+            "vpidprev": null,
+            "vtm": "65502005",
+            "invalid": false,
+            "nm": "Adrenaline (base) 220micrograms/dose inhaler refill",
+            "abbrevnm": null,
+            "basis": 2,
+            "nmdt": "2012-02-28",
+            "nmprev": "Adrenaline 220micrograms/dose inhaler refill",
+            "basis_prev": 2,
+            "nmchange": 4,
+            "combprod": null,
+            "pres_stat": 1,
+            "sug_f": false,
+            "glu_f": false,
+            "pres_f": false,
+            "cfc_f": false,
+            "non_avail": 1,
+            "non_availdt": "2013-03-18",
+            "df_ind": 1,
+            "udfs": "1.000",
+            "udfs_uom": "3317411000001100",
+            "unit_dose_uom": "3317411000001100"
+        }
+    },
+    {
+        "model": "dmd.vmpp",
+        "pk": "10514611000001105",
+        "fields": {
+            "invalid": false,
+            "nm": "Adrenaline (base) 220micrograms/dose inhaler 15 ml",
+            "vmp": "10514511000001106",
+            "qtyval": "15.00",
+            "qty_uom": "258773002",
+            "combpack": null,
+            "bnf_code": null
+        }
+    },
+    {
+        "model": "dmd.vmpp",
+        "pk": "10525411000001103",
+        "fields": {
+            "invalid": false,
+            "nm": "Adrenaline (base) 220micrograms/dose inhaler refill 15 ml",
+            "vmp": "10525011000001107",
+            "qtyval": "15.00",
+            "qty_uom": "258773002",
+            "combpack": null,
+            "bnf_code": null
+        }
+    },
+    {
+        "model": "dmd.vtm",
+        "pk": "65502005",
+        "fields": {
+            "invalid": false,
+            "nm": "Adrenaline",
+            "abbrevnm": null,
+            "vtmidprev": null,
+            "vtmiddt": "2006-06-05"
+        }
+    },
+    {
+        "model": "dmd.unitofmeasure",
+        "pk": "3317411000001100",
+        "fields": {
+            "cddt": null,
+            "cdprev": null,
+            "descr": "dose"
+        }
+    },
+    {
+        "model": "dmd.unitofmeasure",
+        "pk": "258773002",
+        "fields": {
+            "cddt": null,
+            "cdprev": null,
+            "descr": "ml"
+        }
+    },
+    {
+        "model": "dmd.unitofmeasure",
+        "pk": "408102007",
+        "fields": {
+            "cd": "408102007",
+            "cddt": "2022-01-17",
+            "cdprev": "3319711000001103",
+            "descr": "unit dose"
+        }
+    },
+    {
+        "model": "dmd.basisofname",
+        "pk": 1,
+        "fields": {
+            "descr": "rINN - Recommended International Non-proprietary"
+        }
+    },
+    {
+        "model": "dmd.basisofname",
+        "pk": 2,
+        "fields": {
+            "descr": "BAN - British Approved Name"
+        }
+    },
+    {
+        "model": "dmd.basisofname",
+        "pk": 7,
+        "fields": {
+            "cd": 7,
+            "descr": "Other"
+        }
+    },
+    {
+        "model": "dmd.dfindicator",
+        "pk": 1,
+        "fields": {
+            "descr": "Discrete"
+        }
+    },
+    {
+        "model": "dmd.dfindicator",
+        "pk": 3,
+        "fields": {
+            "descr": "Not applicable"
+        }
+    },
+    {
+        "model": "dmd.virtualproductnonavail",
+        "pk": 1,
+        "fields": {
+            "descr": "Actual Products not Available"
+        }
+    },
+    {
+        "model": "dmd.virtualproductpresstatus",
+        "pk": 1,
+        "fields": {
+            "descr": "Valid as a prescribable product"
+        }
+    },
+    {
+        "model": "dmd.namechangereason",
+        "pk": 4,
+        "fields": {
+            "descr": "Other"
+        }
+    },
+    {
+        "model": "dmd.ing",
+        "pk": "372897005",
+        "fields": {
+            "isiddt": null,
+            "isidprev": null,
+            "invalid": false,
+            "nm": "Salbutamol"
+        }
+    },
+    {
+        "model": "dmd.vtm",
+        "pk": "777483005",
+        "fields": {
+            "invalid": false,
+            "nm": "Salbutamol",
+            "abbrevnm": null,
+            "vtmidprev": "91143003",
+            "vtmiddt": "2023-2-6"
+        }
+    },
+    {
+        "model": "dmd.vmp",
+        "pk": "35936411000001109",
+        "fields": {
+            "vpiddt": "2018-10-22",
+            "vpidprev": "320136009",
+            "vtm_id": "777483005",
+            "invalid": false,
+            "nm": "Salbutamol 100micrograms/dose breath actuated inhaler",
+            "abbrevnm": null,
+            "basis_id": 1,
+            "nmdt": "2006-08-16",
+            "nmprev": "Salbutamol 100micrograms/actuation breath actuated inhaler",
+            "basis_prev_id": 1,
+            "nmchange_id": 4,
+            "combprod_id": null,
+            "pres_stat_id": 1,
+            "sug_f": false,
+            "glu_f": false,
+            "pres_f": false,
+            "cfc_f": false,
+            "non_avail_id": 1,
+            "non_availdt": "2003-09-02",
+            "df_ind_id": 1,
+            "udfs": "1.000",
+            "udfs_uom_id": "3317411000001100",
+            "unit_dose_uom_id": "3317411000001100"
+        }
+    },
+    {
+        "model": "dmd.vmp",
+        "pk": "39112711000001103",
+        "fields": {
+            "vpiddt": "2020-10-21",
+            "vpidprev": "320151000",
+            "vtm_id": "777483005",
+            "invalid": false,
+            "nm": "Salbutamol 100micrograms/dose breath actuated inhaler CFC free",
+            "abbrevnm": null,
+            "basis_id": 1,
+            "nmdt": "2006-08-16",
+            "nmprev": "Salbutamol 100micrograms/actuation breath actuated inhaler CFC free",
+            "basis_prev_id": 1,
+            "nmchange_id": 4,
+            "combprod_id": null,
+            "pres_stat_id": 9,
+            "sug_f": false,
+            "glu_f": false,
+            "pres_f": false,
+            "cfc_f": true,
+            "non_avail_id": null,
+            "non_availdt": null,
+            "df_ind_id": 1,
+            "udfs": "1.000",
+            "udfs_uom_id": "3317411000001100",
+            "unit_dose_uom_id": "3317411000001100"
+        }
+    },
+    {
+        "model": "dmd.vmp",
+        "pk": "13566111000001109",
+        "fields": {
+            "vpiddt": null,
+            "vpidprev": null,
+            "vtm_id": "777483005",
+            "invalid": false,
+            "nm": "Salbutamol 100micrograms/dose dry powder inhalation cartridge",
+            "abbrevnm": "Salbutamol 100micrograms/dose dry pdr inhalation cartridge",
+            "basis_id": 1,
+            "nmdt": null,
+            "nmprev": null,
+            "basis_prev_id": null,
+            "nmchange_id": null,
+            "combprod_id": null,
+            "pres_stat_id": 1,
+            "sug_f": false,
+            "glu_f": false,
+            "pres_f": false,
+            "cfc_f": false,
+            "non_avail_id": null,
+            "non_availdt": null,
+            "df_ind_id": 1,
+            "udfs": "1.000",
+            "udfs_uom_id": "3317411000001100",
+            "unit_dose_uom_id": "3317411000001100"
+        }
+    },
+    {
+        "model": "dmd.vmp",
+        "pk": "13566211000001103",
+        "fields": {
+            "vpiddt": null,
+            "vpidprev": null,
+            "vtm_id": "777483005",
+            "invalid": false,
+            "nm": "Salbutamol 100micrograms/dose dry powder inhalation cartridge with device",
+            "abbrevnm": "Salbutamol 100microg/dose dry pdr inhalation cart with dev",
+            "basis_id": 1,
+            "nmdt": null,
+            "nmprev": null,
+            "basis_prev_id": null,
+            "nmchange_id": null,
+            "combprod_id": null,
+            "pres_stat_id": 1,
+            "sug_f": false,
+            "glu_f": false,
+            "pres_f": false,
+            "cfc_f": false,
+            "non_avail_id": null,
+            "non_availdt": null,
+            "df_ind_id": 1,
+            "udfs": "1.000",
+            "udfs_uom_id": "3317411000001100",
+            "unit_dose_uom_id": "3317411000001100"
+        }
+    },
+    {
+        "model": "dmd.vmp",
+        "pk": "9207411000001106",
+        "fields": {
+            "vpiddt": null,
+            "vpidprev": null,
+            "vtm_id": "777483005",
+            "invalid": false,
+            "nm": "Salbutamol 100micrograms/dose dry powder inhaler",
+            "abbrevnm": null,
+            "basis_id": 1,
+            "nmdt": "2006-08-16",
+            "nmprev": "Salbutamol 100micrograms/actuation dry powder inhaler",
+            "basis_prev_id": 1,
+            "nmchange_id": 4,
+            "combprod_id": null,
+            "pres_stat_id": 1,
+            "sug_f": false,
+            "glu_f": false,
+            "pres_f": false,
+            "cfc_f": false,
+            "non_avail_id": null,
+            "non_availdt": null,
+            "df_ind_id": 1,
+            "udfs": "1.000",
+            "udfs_uom_id": "3317411000001100",
+            "unit_dose_uom_id": "3317411000001100"
+        }
+    },
+    {
+        "model": "dmd.vmp",
+        "pk": "35936511000001108",
+        "fields": {
+            "vpiddt": "2018-10-22",
+            "vpidprev": "320176004",
+            "vtm_id": "777483005",
+            "invalid": false,
+            "nm": "Salbutamol 100micrograms/dose inhaler",
+            "abbrevnm": null,
+            "basis_id": 1,
+            "nmdt": "2006-08-16",
+            "nmprev": "Salbutamol 100micrograms/actuation inhaler",
+            "basis_prev_id": 1,
+            "nmchange_id": 4,
+            "combprod_id": null,
+            "pres_stat_id": 1,
+            "sug_f": false,
+            "glu_f": false,
+            "pres_f": false,
+            "cfc_f": false,
+            "non_avail_id": 1,
+            "non_availdt": "2009-02-25",
+            "df_ind_id": 1,
+            "udfs": "1.000",
+            "udfs_uom_id": "3317411000001100",
+            "unit_dose_uom_id": "3317411000001100"
+        }
+    },
+    {
+        "model": "dmd.vmp",
+        "pk": "39113611000001102",
+        "fields": {
+            "vpiddt": "2020-10-21",
+            "vpidprev": "320139002",
+            "vtm_id": "777483005",
+            "invalid": false,
+            "nm": "Salbutamol 100micrograms/dose inhaler CFC free",
+            "abbrevnm": null,
+            "basis_id": 1,
+            "nmdt": "2006-08-16",
+            "nmprev": "Salbutamol 100micrograms/actuation inhaler CFC free",
+            "basis_prev_id": 1,
+            "nmchange_id": 4,
+            "combprod_id": null,
+            "pres_stat_id": 9,
+            "sug_f": false,
+            "glu_f": false,
+            "pres_f": false,
+            "cfc_f": true,
+            "non_avail_id": null,
+            "non_availdt": null,
+            "df_ind_id": 1,
+            "udfs": "1.000",
+            "udfs_uom_id": "3317411000001100",
+            "unit_dose_uom_id": "3317411000001100"
+        }
+    },
+    {
+        "model": "dmd.vmp",
+        "pk": "43207011000001101",
+        "fields": {
+            "vpiddt": null,
+            "vpidprev": null,
+            "vtm_id": "777483005",
+            "invalid": false,
+            "nm": "Salbutamol 2.5mg/2.5ml nebuliser liquid unit dose ampoules",
+            "abbrevnm": null,
+            "basis_id": 1,
+            "nmdt": null,
+            "nmprev": null,
+            "basis_prev_id": null,
+            "nmchange_id": null,
+            "combprod_id": null,
+            "pres_stat_id": 1,
+            "sug_f": false,
+            "glu_f": false,
+            "pres_f": false,
+            "cfc_f": false,
+            "non_avail_id": null,
+            "non_availdt": null,
+            "df_ind_id": 1,
+            "udfs": "2.500",
+            "udfs_uom_id": "258773002",
+            "unit_dose_uom_id": "408102007"
+        }
+    },
+    {
+        "model": "dmd.vmp",
+        "pk": "39709611000001109",
+        "fields": {
+            "vpiddt": "2021-05-26",
+            "vpidprev": "320177008",
+            "vtm_id": "777483005",
+            "invalid": false,
+            "nm": "Salbutamol 2.5mg/2.5ml nebuliser liquid unit dose vials",
+            "abbrevnm": null,
+            "basis_id": 1,
+            "nmdt": "2010-02-01",
+            "nmprev": "Salbutamol 1mg/ml nebuliser liquid 2.5ml unit dose vials",
+            "basis_prev_id": 1,
+            "nmchange_id": 4,
+            "combprod_id": null,
+            "pres_stat_id": 1,
+            "sug_f": false,
+            "glu_f": false,
+            "pres_f": false,
+            "cfc_f": false,
+            "non_avail_id": null,
+            "non_availdt": null,
+            "df_ind_id": 1,
+            "udfs": "2.500",
+            "udfs_uom_id": "258773002",
+            "unit_dose_uom_id": "408102007"
+        }
+    },
+    {
+        "model": "dmd.vmp",
+        "pk": "42718411000001106",
+        "fields": {
+            "vpiddt": null,
+            "vpidprev": null,
+            "vtm_id": "777483005",
+            "invalid": false,
+            "nm": "Salbutamol 2.5mg/3ml nebuliser liquid unit dose vials",
+            "abbrevnm": null,
+            "basis_id": 1,
+            "nmdt": null,
+            "nmprev": null,
+            "basis_prev_id": null,
+            "nmchange_id": null,
+            "combprod_id": null,
+            "pres_stat_id": 1,
+            "sug_f": false,
+            "glu_f": false,
+            "pres_f": false,
+            "cfc_f": false,
+            "non_avail_id": null,
+            "non_availdt": null,
+            "df_ind_id": 1,
+            "udfs": "3.000",
+            "udfs_uom_id": "258773002",
+            "unit_dose_uom_id": "408102007"
+        }
+    },
+    {
+        "model": "dmd.amp",
+        "pk": "3293111000001105",
+        "fields": {
+            "invalid": false,
+            "vmp_id": "35936411000001109",
+            "nm": "Aerolin 100micrograms/dose Autohaler",
+            "abbrevnm": null,
+            "descr": "Aerolin 100micrograms/dose Autohaler (3M Health Care Ltd)",
+            "nmdt": "2006-08-16",
+            "nm_prev": "Aerolin 100micrograms/actuation Autohaler",
+            "supp_id": "2075901000001102",
+            "lic_auth_id": 1,
+            "lic_auth_prev_id": null,
+            "lic_authchange_id": null,
+            "lic_authchangedt": null,
+            "combprod_id": null,
+            "flavour_id": null,
+            "ema": false,
+            "parallel_import": false,
+            "avail_restrict_id": 9,
+            "bnf_code": null
+        }
+    },
+    {
+        "model": "dmd.amp",
+        "pk": "22503111000001109",
+        "fields": {
+            "invalid": false,
+            "vmp_id": "39113611000001102",
+            "nm": "AirSalb 100micrograms/dose inhaler CFC free",
+            "abbrevnm": null,
+            "descr": "AirSalb 100micrograms/dose inhaler CFC free (Sandoz Ltd)",
+            "nmdt": null,
+            "nm_prev": null,
+            "supp_id": "2074301000001102",
+            "lic_auth_id": 1,
+            "lic_auth_prev_id": null,
+            "lic_authchange_id": null,
+            "lic_authchangedt": null,
+            "combprod_id": null,
+            "flavour_id": null,
+            "ema": false,
+            "parallel_import": false,
+            "avail_restrict_id": 9,
+            "bnf_code": null
+        }
+    },
+    {
+        "model": "dmd.amp",
+        "pk": "3214311000001108",
+        "fields": {
+            "invalid": false,
+            "vmp_id": "39112711000001103",
+            "nm": "Airomir 100micrograms/dose Autohaler",
+            "abbrevnm": null,
+            "descr": "Airomir 100micrograms/dose Autohaler (Teva UK Ltd)",
+            "nmdt": "2006-08-16",
+            "nm_prev": "Airomir 100micrograms/actuation Autohaler",
+            "supp_id": "3849901000001105",
+            "lic_auth_id": 1,
+            "lic_auth_prev_id": null,
+            "lic_authchange_id": null,
+            "lic_authchangedt": null,
+            "combprod_id": null,
+            "flavour_id": null,
+            "ema": false,
+            "parallel_import": false,
+            "avail_restrict_id": 1,
+            "bnf_code": null
+        }
+    },
+    {
+        "model": "dmd.amp",
+        "pk": "597011000001101",
+        "fields": {
+            "invalid": false,
+            "vmp_id": "39113611000001102",
+            "nm": "Airomir 100micrograms/dose inhaler",
+            "abbrevnm": null,
+            "descr": "Airomir 100micrograms/dose inhaler (Teva UK Ltd)",
+            "nmdt": "2006-08-16",
+            "nm_prev": "Airomir 100micrograms/actuation inhaler",
+            "supp_id": "3849901000001105",
+            "lic_auth_id": 1,
+            "lic_auth_prev_id": null,
+            "lic_authchange_id": null,
+            "lic_authchangedt": null,
+            "combprod_id": null,
+            "flavour_id": null,
+            "ema": false,
+            "parallel_import": false,
+            "avail_restrict_id": 9,
+            "bnf_code": null
+        }
+    },
+    {
+        "model": "dmd.amp",
+        "pk": "18148111000001107",
+        "fields": {
+            "invalid": false,
+            "vmp_id": "39113611000001102",
+            "nm": "Asmavent 100micrograms/dose inhaler CFC free",
+            "abbrevnm": null,
+            "descr": "Asmavent 100micrograms/dose inhaler CFC free (Kent Pharma (UK) Ltd)",
+            "nmdt": null,
+            "nm_prev": null,
+            "supp_id": "2073701000001100",
+            "lic_auth_id": 1,
+            "lic_auth_prev_id": null,
+            "lic_authchange_id": null,
+            "lic_authchangedt": null,
+            "combprod_id": null,
+            "flavour_id": null,
+            "ema": false,
+            "parallel_import": false,
+            "avail_restrict_id": 9,
+            "bnf_code": null
+        }
+    },
+    {
+        "model": "dmd.amp",
+        "pk": "41346811000001102",
+        "fields": {
+            "invalid": true,
+            "vmp_id": "39709611000001109",
+            "nm": "Brodilaten 2.5mg/2.5ml nebuliser solution unit dose ampoules",
+            "abbrevnm": null,
+            "descr": "Brodilaten 2.5mg/2.5ml nebuliser solution unit dose ampoules (Kent Pharma (UK) Ltd)",
+            "nmdt": null,
+            "nm_prev": null,
+            "supp_id": "2073701000001100",
+            "lic_auth_id": 1,
+            "lic_auth_prev_id": null,
+            "lic_authchange_id": null,
+            "lic_authchangedt": null,
+            "combprod_id": null,
+            "flavour_id": null,
+            "ema": false,
+            "parallel_import": false,
+            "avail_restrict_id": 9,
+            "bnf_code": null
+        }
+    },
+    {
+        "model": "dmd.amp",
+        "pk": "43188611000001108",
+        "fields": {
+            "invalid": false,
+            "vmp_id": "43207011000001101",
+            "nm": "Brodilaten 2.5mg/2.5ml nebuliser solution unit dose ampoules",
+            "abbrevnm": null,
+            "descr": "Brodilaten 2.5mg/2.5ml nebuliser solution unit dose ampoules (Kent Pharma (UK) Ltd)",
+            "nmdt": null,
+            "nm_prev": null,
+            "supp_id": "2073701000001100",
+            "lic_auth_id": 1,
+            "lic_auth_prev_id": null,
+            "lic_authchange_id": null,
+            "lic_authchangedt": null,
+            "combprod_id": null,
+            "flavour_id": null,
+            "ema": false,
+            "parallel_import": false,
+            "avail_restrict_id": 9,
+            "bnf_code": null
+        }
+    },
+    {
+        "model": "dmd.amp",
+        "pk": "38131211000001109",
+        "fields": {
+            "invalid": false,
+            "vmp_id": "9207411000001106",
+            "nm": "Easyhaler Salbutamol sulfate 100micrograms/dose dry powder inhaler",
+            "abbrevnm": "Easyhaler Salbutamol sulfate 100micrograms/dose dry pdr inh",
+            "descr": "Easyhaler Salbutamol sulfate 100micrograms/dose dry powder inhaler (DE Pharmaceuticals)",
+            "nmdt": null,
+            "nm_prev": null,
+            "supp_id": "2268901000001109",
+            "lic_auth_id": 1,
+            "lic_auth_prev_id": null,
+            "lic_authchange_id": null,
+            "lic_authchangedt": null,
+            "combprod_id": null,
+            "flavour_id": null,
+            "ema": false,
+            "parallel_import": true,
+            "avail_restrict_id": 9,
+            "bnf_code": null
+        }
+    },
+    {
+        "model": "dmd.amp",
+        "pk": "9205211000001104",
+        "fields": {
+            "invalid": false,
+            "vmp_id": "9207411000001106",
+            "nm": "Easyhaler Salbutamol sulfate 100micrograms/dose dry powder inhaler",
+            "abbrevnm": "Easyhaler Salbutamol sulfate 100micrograms/dose dry pdr inh",
+            "descr": "Easyhaler Salbutamol sulfate 100micrograms/dose dry powder inhaler (Orion Pharma (UK) Ltd)",
+            "nmdt": "2013-08-01",
+            "nm_prev": "Easyhaler Salbutamol sulphate 100micrograms/dose dry powder inhaler",
+            "supp_id": "2574501000001106",
+            "lic_auth_id": 1,
+            "lic_auth_prev_id": null,
+            "lic_authchange_id": null,
+            "lic_authchangedt": null,
+            "combprod_id": null,
+            "flavour_id": null,
+            "ema": false,
+            "parallel_import": false,
+            "avail_restrict_id": 1,
+            "bnf_code": null
+        }
+    },
+    {
+        "model": "dmd.amp",
+        "pk": "3386411000001100",
+        "fields": {
+            "invalid": false,
+            "vmp_id": "39709611000001109",
+            "nm": "Maxivent 2.5mg/2.5ml nebuliser liquid unit dose Steripoule vials",
+            "abbrevnm": "Maxivent 2.5mg/2.5ml neb liq unit dose Steripoule vials",
+            "descr": "Maxivent 2.5mg/2.5ml nebuliser liquid unit dose Steripoule vials (Ashbourne Pharmaceuticals Ltd)",
+            "nmdt": "2010-03-30",
+            "nm_prev": "Maxivent 2.5mg nebuliser liquid 2.5ml unit dose Steripoule vials",
+            "supp_id": "2268401000001100",
+            "lic_auth_id": 1,
+            "lic_auth_prev_id": null,
+            "lic_authchange_id": null,
+            "lic_authchangedt": null,
+            "combprod_id": null,
+            "flavour_id": null,
+            "ema": false,
+            "parallel_import": false,
+            "avail_restrict_id": 9,
+            "bnf_code": null
+        }
+    },
+    {
+        "model": "dmd.supplier",
+        "pk": "2075901000001102",
+        "fields": {
+            "cddt": null,
+            "cdprev": null,
+            "invalid": false,
+            "descr": "3M Health Care Ltd"
+        }
+    },
+    {
+        "model": "dmd.supplier",
+        "pk": "2574501000001106",
+        "fields": {
+            "cddt": null,
+            "cdprev": null,
+            "invalid": false,
+            "descr": "Orion Pharma (UK) Ltd"
+        }
+    },
+    {
+        "model": "dmd.supplier",
+        "pk": "2268401000001100",
+        "fields": {
+            "cddt": null,
+            "cdprev": null,
+            "invalid": false,
+            "descr": "Ashbourne Pharmaceuticals Ltd"
+        }
+    },
+    {
+        "model": "dmd.supplier",
+        "pk": "2073701000001100",
+        "fields": {
+            "cddt": null,
+            "cdprev": null,
+            "invalid": false,
+            "descr": "Kent Pharma (UK) Ltd"
+        }
+    },
+    {
+        "model": "dmd.supplier",
+        "pk": "3849901000001105",
+        "fields": {
+            "cddt": null,
+            "cdprev": null,
+            "invalid": false,
+            "descr": "Teva UK Ltd"
+        }
+    },
+    {
+        "model": "dmd.supplier",
+        "pk": "2268901000001109",
+        "fields": {
+            "cddt": null,
+            "cdprev": null,
+            "invalid": false,
+            "descr": "DE Pharmaceuticals"
+        }
+    },
+    {
+        "model": "dmd.supplier",
+        "pk": "2074301000001102",
+        "fields": {
+            "cddt": null,
+            "cdprev": null,
+            "invalid": false,
+            "descr": "Sandoz Ltd"
+        }
+    },
+    {
+        "model": "dmd.licensingauthority",
+        "pk": "1",
+        "fields": {
+            "descr": "Medicines - MHRA/EMA"
+        }
+    },
+    {
+        "model": "dmd.licensingauthority",
+        "pk": "2",
+        "fields": {
+            "descr": "Devices"
+        }
+    },
+    {
+        "model": "dmd.availabilityrestriction",
+        "pk": "9",
+        "fields": {
+            "descr": "Not available"
+        }
+    },
+    {
+        "model": "dmd.availabilityrestriction",
+        "pk": "1",
+        "fields": {
+            "descr": "None"
+        }
+    },
+    {
+        "model": "dmd.virtualproductpresstatus",
+        "pk": "9",
+        "fields": {
+            "descr": "Caution - AMP level prescribing advised"
+        }
+    },
+    {
+        "model": "dmd.vmp",
+        "pk": "3436211000001104",
+        "fields": {
+            "vpiddt": null,
+            "vpidprev": null,
+            "vtm_id": null,
+            "invalid": true,
+            "nm": "Oxygen composite cylinders 1360litres with integral headset",
+            "abbrevnm": null,
+            "basis_id": 7,
+            "nmdt": "2005-10-06",
+            "nmprev": "Oxygen composite cylinders 1360 litres with integral headset",
+            "basis_prev_id": 7,
+            "nmchange_id": 4,
+            "combprod_id": null,
+            "pres_stat_id": 1,
+            "sug_f": false,
+            "glu_f": false,
+            "pres_f": false,
+            "cfc_f": false,
+            "non_avail_id": 1,
+            "non_availdt": "2016-12-13",
+            "df_ind_id": 3,
+            "udfs": null,
+            "udfs_uom_id": null,
+            "unit_dose_uom_id": null
+        }
+    },
+    {
+        "model": "dmd.amp",
+        "pk": "4086311000001109",
+        "fields": {
+            "invalid": false,
+            "vmp_id": "3436211000001104",
+            "nm": "Oxygen composite cylinders 1360litres B10C with integral headset",
+            "abbrevnm": null,
+            "descr": "Oxygen composite cylinders 1360litres B10C with integral headset (Air Products Plc)",
+            "nmdt": "2005-10-06",
+            "nm_prev": "Oxygen composite cylinders 1360 litres B10C with integral headset",
+            "supp_id": "4110011000001103",
+            "lic_auth_id": 1,
+            "lic_auth_prev_id": null,
+            "lic_authchange_id": null,
+            "lic_authchangedt": null,
+            "combprod_id": null,
+            "flavour_id": null,
+            "ema": false,
+            "parallel_import": false,
+            "avail_restrict_id": 9,
+            "bnf_code": null
+        }
+    },
+    {
+        "model": "dmd.amp",
+        "pk": "4086111000001107",
+        "fields": {
+            "invalid": false,
+            "vmp_id": "3436211000001104",
+            "nm": "Oxygen composite cylinders 1360litres size DF with integral headset",
+            "abbrevnm": null,
+            "descr": "Oxygen composite cylinders 1360litres size DF with integral headset (BOC Ltd)",
+            "nmdt": "2005-10-06",
+            "nm_prev": "Oxygen composite cylinders 1360 litres size DF with integral headset",
+            "supp_id": "2819101000001108",
+            "lic_auth_id": 1,
+            "lic_auth_prev_id": null,
+            "lic_authchange_id": null,
+            "lic_authchangedt": null,
+            "combprod_id": null,
+            "flavour_id": null,
+            "ema": false,
+            "parallel_import": false,
+            "avail_restrict_id": 9,
+            "bnf_code": null
+        }
+    },
+    {
+        "model": "dmd.amp",
+        "pk": "3106411000001109",
+        "fields": {
+            "invalid": false,
+            "vmp_id": "3436211000001104",
+            "nm": "Oxygen composite cylinders 1360litres size F with integral headset",
+            "abbrevnm": null,
+            "descr": "Oxygen composite cylinders 1360litres size F with integral headset (Medigas Ltd)",
+            "nmdt": "2005-10-06",
+            "nm_prev": "Oxygen composite cylinders1360 litres size F with integral headset",
+            "supp_id": "3810501000001100",
+            "lic_auth_id": 1,
+            "lic_auth_prev_id": 2,
+            "lic_authchange_id": null,
+            "lic_authchangedt": null,
+            "combprod_id": null,
+            "flavour_id": null,
+            "ema": false,
+            "parallel_import": false,
+            "avail_restrict_id": 9,
+            "bnf_code": null
+        }
+    },
+    {
+        "model": "dmd.supplier",
+        "pk": "4110011000001103",
+        "fields": {
+            "cd": "4110011000001103",
+            "cddt": null,
+            "cdprev": null,
+            "invalid": false,
+            "descr": "Air Products Plc"
+        }
+    },
+    {
+        "model": "dmd.supplier",
+        "pk": "2819101000001108",
+        "fields": {
+            "cd": "2819101000001108",
+            "cddt": null,
+            "cdprev": null,
+            "invalid": false,
+            "descr": "BOC Ltd"
+        }
+    },
+    {
+        "model": "dmd.supplier",
+        "pk": "3810501000001100",
+        "fields": {
+            "cd": "3810501000001100",
+            "cddt": null,
+            "cdprev": null,
+            "invalid": false,
+            "descr": "Medigas Ltd"
+        }
     }
-},
-{
-    "model": "dmd.vmp",
-    "pk": "10525011000001107",
-    "fields": {
-        "vpiddt": null,
-        "vpidprev": null,
-        "vtm": "65502005",
-        "invalid": false,
-        "nm": "Adrenaline (base) 220micrograms/dose inhaler refill",
-        "abbrevnm": null,
-        "basis": 2,
-        "nmdt": "2012-02-28",
-        "nmprev": "Adrenaline 220micrograms/dose inhaler refill",
-        "basis_prev": 2,
-        "nmchange": 4,
-        "combprod": null,
-        "pres_stat": 1,
-        "sug_f": false,
-        "glu_f": false,
-        "pres_f": false,
-        "cfc_f": false,
-        "non_avail": 1,
-        "non_availdt": "2013-03-18",
-        "df_ind": 1,
-        "udfs": "1.000",
-        "udfs_uom": "3317411000001100",
-        "unit_dose_uom": "3317411000001100"
-    }
-},
-{
-    "model": "dmd.vmpp",
-    "pk": "10514611000001105",
-    "fields": {
-        "invalid": false,
-        "nm": "Adrenaline (base) 220micrograms/dose inhaler 15 ml",
-        "vmp": "10514511000001106",
-        "qtyval": "15.00",
-        "qty_uom": "258773002",
-        "combpack": null,
-        "bnf_code": null
-    }
-},
-{
-    "model": "dmd.vmpp",
-    "pk": "10525411000001103",
-    "fields": {
-        "invalid": false,
-        "nm": "Adrenaline (base) 220micrograms/dose inhaler refill 15 ml",
-        "vmp": "10525011000001107",
-        "qtyval": "15.00",
-        "qty_uom": "258773002",
-        "combpack": null,
-        "bnf_code": null
-    }
-},
-{
-    "model": "dmd.vtm",
-    "pk": "65502005",
-    "fields": {
-        "invalid": false,
-        "nm": "Adrenaline",
-        "abbrevnm": null,
-        "vtmidprev": null,
-        "vtmiddt": "2006-06-05"
-    }
-},
-{
-    "model": "dmd.unitofmeasure",
-    "pk": "3317411000001100",
-    "fields": {
-        "cddt": null,
-        "cdprev": null,
-        "descr": "dose"
-    }
-},
-{
-    "model": "dmd.unitofmeasure",
-    "pk": "258773002",
-    "fields": {
-        "cddt": null,
-        "cdprev": null,
-        "descr": "ml"
-    }
-},
-{
-    "model": "dmd.unitofmeasure",
-    "pk": "408102007",
-    "fields": {
-        "cd": "408102007",
-        "cddt": "2022-01-17",
-        "cdprev": "3319711000001103",
-        "descr": "unit dose"
-    }
-},
-{
-    "model": "dmd.basisofname",
-    "pk": 1,
-    "fields": {
-        "descr": "rINN - Recommended International Non-proprietary"
-    }
-},
-{
-    "model": "dmd.basisofname",
-    "pk": 2,
-    "fields": {
-        "descr": "BAN - British Approved Name"
-    }
-},
-{
-    "model": "dmd.dfindicator",
-    "pk": 1,
-    "fields": {
-        "descr": "Discrete"
-    }
-},
-{
-    "model": "dmd.virtualproductnonavail",
-    "pk": 1,
-    "fields": {
-        "descr": "Actual Products not Available"
-    }
-},
-{
-    "model": "dmd.virtualproductpresstatus",
-    "pk": 1,
-    "fields": {
-        "descr": "Valid as a prescribable product"
-    }
-},
-{
-    "model": "dmd.namechangereason",
-    "pk": 4,
-    "fields": {
-        "descr": "Other"
-    }
-},
-{
-    "model": "dmd.ing",
-    "pk": "372897005",
-    "fields": {
-        "isiddt": null,
-        "isidprev": null,
-        "invalid": false,
-        "nm": "Salbutamol"
-    }
-},
-{
-    "model": "dmd.vtm",
-    "pk": "777483005",
-    "fields": {
-        "invalid": false,
-        "nm": "Salbutamol",
-        "abbrevnm": null,
-        "vtmidprev": "91143003",
-        "vtmiddt": "2023-2-6"
-    }
-},
-{
-    "model": "dmd.vmp",
-    "pk": "35936411000001109",
-    "fields": {
-        "vpiddt": "2018-10-22",
-        "vpidprev": "320136009",
-        "vtm_id": "777483005",
-        "invalid": false,
-        "nm": "Salbutamol 100micrograms/dose breath actuated inhaler",
-        "abbrevnm": null,
-        "basis_id": 1,
-        "nmdt": "2006-08-16",
-        "nmprev": "Salbutamol 100micrograms/actuation breath actuated inhaler",
-        "basis_prev_id": 1,
-        "nmchange_id": 4,
-        "combprod_id": null,
-        "pres_stat_id": 1,
-        "sug_f": false,
-        "glu_f": false,
-        "pres_f": false,
-        "cfc_f": false,
-        "non_avail_id": 1,
-        "non_availdt": "2003-09-02",
-        "df_ind_id": 1,
-        "udfs": "1.000",
-        "udfs_uom_id": "3317411000001100",
-        "unit_dose_uom_id": "3317411000001100"
-    }
-},
-{
-    "model": "dmd.vmp",
-    "pk": "39112711000001103",
-    "fields": {
-        "vpiddt": "2020-10-21",
-        "vpidprev": "320151000",
-        "vtm_id": "777483005",
-        "invalid": false,
-        "nm": "Salbutamol 100micrograms/dose breath actuated inhaler CFC free",
-        "abbrevnm": null,
-        "basis_id": 1,
-        "nmdt": "2006-08-16",
-        "nmprev": "Salbutamol 100micrograms/actuation breath actuated inhaler CFC free",
-        "basis_prev_id": 1,
-        "nmchange_id": 4,
-        "combprod_id": null,
-        "pres_stat_id": 9,
-        "sug_f": false,
-        "glu_f": false,
-        "pres_f": false,
-        "cfc_f": true,
-        "non_avail_id": null,
-        "non_availdt": null,
-        "df_ind_id": 1,
-        "udfs": "1.000",
-        "udfs_uom_id": "3317411000001100",
-        "unit_dose_uom_id": "3317411000001100"
-    }
-},
-{
-    "model": "dmd.vmp",
-    "pk": "13566111000001109",
-    "fields": {
-        "vpiddt": null,
-        "vpidprev": null,
-        "vtm_id": "777483005",
-        "invalid": false,
-        "nm": "Salbutamol 100micrograms/dose dry powder inhalation cartridge",
-        "abbrevnm": "Salbutamol 100micrograms/dose dry pdr inhalation cartridge",
-        "basis_id": 1,
-        "nmdt": null,
-        "nmprev": null,
-        "basis_prev_id": null,
-        "nmchange_id": null,
-        "combprod_id": null,
-        "pres_stat_id": 1,
-        "sug_f": false,
-        "glu_f": false,
-        "pres_f": false,
-        "cfc_f": false,
-        "non_avail_id": null,
-        "non_availdt": null,
-        "df_ind_id": 1,
-        "udfs": "1.000",
-        "udfs_uom_id": "3317411000001100",
-        "unit_dose_uom_id": "3317411000001100"
-    }
-},
-{
-    "model": "dmd.vmp",
-    "pk": "13566211000001103",
-    "fields": {
-        "vpiddt": null,
-        "vpidprev": null,
-        "vtm_id": "777483005",
-        "invalid": false,
-        "nm": "Salbutamol 100micrograms/dose dry powder inhalation cartridge with device",
-        "abbrevnm": "Salbutamol 100microg/dose dry pdr inhalation cart with dev",
-        "basis_id": 1,
-        "nmdt": null,
-        "nmprev": null,
-        "basis_prev_id": null,
-        "nmchange_id": null,
-        "combprod_id": null,
-        "pres_stat_id": 1,
-        "sug_f": false,
-        "glu_f": false,
-        "pres_f": false,
-        "cfc_f": false,
-        "non_avail_id": null,
-        "non_availdt": null,
-        "df_ind_id": 1,
-        "udfs": "1.000",
-        "udfs_uom_id": "3317411000001100",
-        "unit_dose_uom_id": "3317411000001100"
-    }
-},
-{
-    "model": "dmd.vmp",
-    "pk": "9207411000001106",
-    "fields": {
-        "vpiddt": null,
-        "vpidprev": null,
-        "vtm_id": "777483005",
-        "invalid": false,
-        "nm": "Salbutamol 100micrograms/dose dry powder inhaler",
-        "abbrevnm": null,
-        "basis_id": 1,
-        "nmdt": "2006-08-16",
-        "nmprev": "Salbutamol 100micrograms/actuation dry powder inhaler",
-        "basis_prev_id": 1,
-        "nmchange_id": 4,
-        "combprod_id": null,
-        "pres_stat_id": 1,
-        "sug_f": false,
-        "glu_f": false,
-        "pres_f": false,
-        "cfc_f": false,
-        "non_avail_id": null,
-        "non_availdt": null,
-        "df_ind_id": 1,
-        "udfs": "1.000",
-        "udfs_uom_id": "3317411000001100",
-        "unit_dose_uom_id": "3317411000001100"
-    }
-},
-{
-    "model": "dmd.vmp",
-    "pk": "35936511000001108",
-    "fields": {
-        "vpiddt": "2018-10-22",
-        "vpidprev": "320176004",
-        "vtm_id": "777483005",
-        "invalid": false,
-        "nm": "Salbutamol 100micrograms/dose inhaler",
-        "abbrevnm": null,
-        "basis_id": 1,
-        "nmdt": "2006-08-16",
-        "nmprev": "Salbutamol 100micrograms/actuation inhaler",
-        "basis_prev_id": 1,
-        "nmchange_id": 4,
-        "combprod_id": null,
-        "pres_stat_id": 1,
-        "sug_f": false,
-        "glu_f": false,
-        "pres_f": false,
-        "cfc_f": false,
-        "non_avail_id": 1,
-        "non_availdt": "2009-02-25",
-        "df_ind_id": 1,
-        "udfs": "1.000",
-        "udfs_uom_id": "3317411000001100",
-        "unit_dose_uom_id": "3317411000001100"
-    }
-},
-{
-    "model": "dmd.vmp",
-    "pk": "39113611000001102",
-    "fields": {
-        "vpiddt": "2020-10-21",
-        "vpidprev": "320139002",
-        "vtm_id": "777483005",
-        "invalid": false,
-        "nm": "Salbutamol 100micrograms/dose inhaler CFC free",
-        "abbrevnm": null,
-        "basis_id": 1,
-        "nmdt": "2006-08-16",
-        "nmprev": "Salbutamol 100micrograms/actuation inhaler CFC free",
-        "basis_prev_id": 1,
-        "nmchange_id": 4,
-        "combprod_id": null,
-        "pres_stat_id": 9,
-        "sug_f": false,
-        "glu_f": false,
-        "pres_f": false,
-        "cfc_f": true,
-        "non_avail_id": null,
-        "non_availdt": null,
-        "df_ind_id": 1,
-        "udfs": "1.000",
-        "udfs_uom_id": "3317411000001100",
-        "unit_dose_uom_id": "3317411000001100"
-    }
-},
-{
-    "model": "dmd.vmp",
-    "pk": "43207011000001101",
-    "fields": {
-        "vpiddt": null,
-        "vpidprev": null,
-        "vtm_id": "777483005",
-        "invalid": false,
-        "nm": "Salbutamol 2.5mg/2.5ml nebuliser liquid unit dose ampoules",
-        "abbrevnm": null,
-        "basis_id": 1,
-        "nmdt": null,
-        "nmprev": null,
-        "basis_prev_id": null,
-        "nmchange_id": null,
-        "combprod_id": null,
-        "pres_stat_id": 1,
-        "sug_f": false,
-        "glu_f": false,
-        "pres_f": false,
-        "cfc_f": false,
-        "non_avail_id": null,
-        "non_availdt": null,
-        "df_ind_id": 1,
-        "udfs": "2.500",
-        "udfs_uom_id": "258773002",
-        "unit_dose_uom_id": "408102007"
-    }
-},
-{
-    "model": "dmd.vmp",
-    "pk": "39709611000001109",
-    "fields": {
-        "vpiddt": "2021-05-26",
-        "vpidprev": "320177008",
-        "vtm_id": "777483005",
-        "invalid": false,
-        "nm": "Salbutamol 2.5mg/2.5ml nebuliser liquid unit dose vials",
-        "abbrevnm": null,
-        "basis_id": 1,
-        "nmdt": "2010-02-01",
-        "nmprev": "Salbutamol 1mg/ml nebuliser liquid 2.5ml unit dose vials",
-        "basis_prev_id": 1,
-        "nmchange_id": 4,
-        "combprod_id": null,
-        "pres_stat_id": 1,
-        "sug_f": false,
-        "glu_f": false,
-        "pres_f": false,
-        "cfc_f": false,
-        "non_avail_id": null,
-        "non_availdt": null,
-        "df_ind_id": 1,
-        "udfs": "2.500",
-        "udfs_uom_id": "258773002",
-        "unit_dose_uom_id": "408102007"
-    }
-},
-{
-    "model": "dmd.vmp",
-    "pk": "42718411000001106",
-    "fields": {
-        "vpiddt": null,
-        "vpidprev": null,
-        "vtm_id": "777483005",
-        "invalid": false,
-        "nm": "Salbutamol 2.5mg/3ml nebuliser liquid unit dose vials",
-        "abbrevnm": null,
-        "basis_id": 1,
-        "nmdt": null,
-        "nmprev": null,
-        "basis_prev_id": null,
-        "nmchange_id": null,
-        "combprod_id": null,
-        "pres_stat_id": 1,
-        "sug_f": false,
-        "glu_f": false,
-        "pres_f": false,
-        "cfc_f": false,
-        "non_avail_id": null,
-        "non_availdt": null,
-        "df_ind_id": 1,
-        "udfs": "3.000",
-        "udfs_uom_id": "258773002",
-        "unit_dose_uom_id": "408102007"
-    }
-},
-{
-    "model": "dmd.amp",
-    "pk": "3293111000001105",
-    "fields": {
-        "invalid": false,
-        "vmp_id": "35936411000001109",
-        "nm": "Aerolin 100micrograms/dose Autohaler",
-        "abbrevnm": null,
-        "descr": "Aerolin 100micrograms/dose Autohaler (3M Health Care Ltd)",
-        "nmdt": "2006-08-16",
-        "nm_prev": "Aerolin 100micrograms/actuation Autohaler",
-        "supp_id": "2075901000001102",
-        "lic_auth_id": 1,
-        "lic_auth_prev_id": null,
-        "lic_authchange_id": null,
-        "lic_authchangedt": null,
-        "combprod_id": null,
-        "flavour_id": null,
-        "ema": false,
-        "parallel_import": false,
-        "avail_restrict_id": 9,
-        "bnf_code": null
-    }
-},
-{
-    "model": "dmd.amp",
-    "pk": "22503111000001109",
-    "fields": {
-        "invalid": false,
-        "vmp_id": "39113611000001102",
-        "nm": "AirSalb 100micrograms/dose inhaler CFC free",
-        "abbrevnm": null,
-        "descr": "AirSalb 100micrograms/dose inhaler CFC free (Sandoz Ltd)",
-        "nmdt": null,
-        "nm_prev": null,
-        "supp_id": "2074301000001102",
-        "lic_auth_id": 1,
-        "lic_auth_prev_id": null,
-        "lic_authchange_id": null,
-        "lic_authchangedt": null,
-        "combprod_id": null,
-        "flavour_id": null,
-        "ema": false,
-        "parallel_import": false,
-        "avail_restrict_id": 9,
-        "bnf_code": null
-    }
-},
-{
-    "model": "dmd.amp",
-    "pk": "3214311000001108",
-    "fields": {
-        "invalid": false,
-        "vmp_id": "39112711000001103",
-        "nm": "Airomir 100micrograms/dose Autohaler",
-        "abbrevnm": null,
-        "descr": "Airomir 100micrograms/dose Autohaler (Teva UK Ltd)",
-        "nmdt": "2006-08-16",
-        "nm_prev": "Airomir 100micrograms/actuation Autohaler",
-        "supp_id": "3849901000001105",
-        "lic_auth_id": 1,
-        "lic_auth_prev_id": null,
-        "lic_authchange_id": null,
-        "lic_authchangedt": null,
-        "combprod_id": null,
-        "flavour_id": null,
-        "ema": false,
-        "parallel_import": false,
-        "avail_restrict_id": 1,
-        "bnf_code": null
-    }
-},
-{
-    "model": "dmd.amp",
-    "pk": "597011000001101",
-    "fields": {
-        "invalid": false,
-        "vmp_id": "39113611000001102",
-        "nm": "Airomir 100micrograms/dose inhaler",
-        "abbrevnm": null,
-        "descr": "Airomir 100micrograms/dose inhaler (Teva UK Ltd)",
-        "nmdt": "2006-08-16",
-        "nm_prev": "Airomir 100micrograms/actuation inhaler",
-        "supp_id": "3849901000001105",
-        "lic_auth_id": 1,
-        "lic_auth_prev_id": null,
-        "lic_authchange_id": null,
-        "lic_authchangedt": null,
-        "combprod_id": null,
-        "flavour_id": null,
-        "ema": false,
-        "parallel_import": false,
-        "avail_restrict_id": 9,
-        "bnf_code": null
-    }
-},
-{
-    "model": "dmd.amp",
-    "pk": "18148111000001107",
-    "fields": {
-        "invalid": false,
-        "vmp_id": "39113611000001102",
-        "nm": "Asmavent 100micrograms/dose inhaler CFC free",
-        "abbrevnm": null,
-        "descr": "Asmavent 100micrograms/dose inhaler CFC free (Kent Pharma (UK) Ltd)",
-        "nmdt": null,
-        "nm_prev": null,
-        "supp_id": "2073701000001100",
-        "lic_auth_id": 1,
-        "lic_auth_prev_id": null,
-        "lic_authchange_id": null,
-        "lic_authchangedt": null,
-        "combprod_id": null,
-        "flavour_id": null,
-        "ema": false,
-        "parallel_import": false,
-        "avail_restrict_id": 9,
-        "bnf_code": null
-    }
-},
-{
-    "model": "dmd.amp",
-    "pk": "41346811000001102",
-    "fields": {
-        "invalid": true,
-        "vmp_id": "39709611000001109",
-        "nm": "Brodilaten 2.5mg/2.5ml nebuliser solution unit dose ampoules",
-        "abbrevnm": null,
-        "descr": "Brodilaten 2.5mg/2.5ml nebuliser solution unit dose ampoules (Kent Pharma (UK) Ltd)",
-        "nmdt": null,
-        "nm_prev": null,
-        "supp_id": "2073701000001100",
-        "lic_auth_id": 1,
-        "lic_auth_prev_id": null,
-        "lic_authchange_id": null,
-        "lic_authchangedt": null,
-        "combprod_id": null,
-        "flavour_id": null,
-        "ema": false,
-        "parallel_import": false,
-        "avail_restrict_id": 9,
-        "bnf_code": null
-    }
-},
-{
-    "model": "dmd.amp",
-    "pk": "43188611000001108",
-    "fields": {
-        "invalid": false,
-        "vmp_id": "43207011000001101",
-        "nm": "Brodilaten 2.5mg/2.5ml nebuliser solution unit dose ampoules",
-        "abbrevnm": null,
-        "descr": "Brodilaten 2.5mg/2.5ml nebuliser solution unit dose ampoules (Kent Pharma (UK) Ltd)",
-        "nmdt": null,
-        "nm_prev": null,
-        "supp_id": "2073701000001100",
-        "lic_auth_id": 1,
-        "lic_auth_prev_id": null,
-        "lic_authchange_id": null,
-        "lic_authchangedt": null,
-        "combprod_id": null,
-        "flavour_id": null,
-        "ema": false,
-        "parallel_import": false,
-        "avail_restrict_id": 9,
-        "bnf_code": null
-    }
-},
-{
-    "model": "dmd.amp",
-    "pk": "38131211000001109",
-    "fields": {
-        "invalid": false,
-        "vmp_id": "9207411000001106",
-        "nm": "Easyhaler Salbutamol sulfate 100micrograms/dose dry powder inhaler",
-        "abbrevnm": "Easyhaler Salbutamol sulfate 100micrograms/dose dry pdr inh",
-        "descr": "Easyhaler Salbutamol sulfate 100micrograms/dose dry powder inhaler (DE Pharmaceuticals)",
-        "nmdt": null,
-        "nm_prev": null,
-        "supp_id": "2268901000001109",
-        "lic_auth_id": 1,
-        "lic_auth_prev_id": null,
-        "lic_authchange_id": null,
-        "lic_authchangedt": null,
-        "combprod_id": null,
-        "flavour_id": null,
-        "ema": false,
-        "parallel_import": true,
-        "avail_restrict_id": 9,
-        "bnf_code": null
-    }
-},
-{
-    "model": "dmd.amp",
-    "pk": "9205211000001104",
-    "fields": {
-        "invalid": false,
-        "vmp_id": "9207411000001106",
-        "nm": "Easyhaler Salbutamol sulfate 100micrograms/dose dry powder inhaler",
-        "abbrevnm": "Easyhaler Salbutamol sulfate 100micrograms/dose dry pdr inh",
-        "descr": "Easyhaler Salbutamol sulfate 100micrograms/dose dry powder inhaler (Orion Pharma (UK) Ltd)",
-        "nmdt": "2013-08-01",
-        "nm_prev": "Easyhaler Salbutamol sulphate 100micrograms/dose dry powder inhaler",
-        "supp_id": "2574501000001106",
-        "lic_auth_id": 1,
-        "lic_auth_prev_id": null,
-        "lic_authchange_id": null,
-        "lic_authchangedt": null,
-        "combprod_id": null,
-        "flavour_id": null,
-        "ema": false,
-        "parallel_import": false,
-        "avail_restrict_id": 1,
-        "bnf_code": null
-    }
-},
-{
-    "model": "dmd.amp",
-    "pk": "3386411000001100",
-    "fields": {
-        "invalid": false,
-        "vmp_id": "39709611000001109",
-        "nm": "Maxivent 2.5mg/2.5ml nebuliser liquid unit dose Steripoule vials",
-        "abbrevnm": "Maxivent 2.5mg/2.5ml neb liq unit dose Steripoule vials",
-        "descr": "Maxivent 2.5mg/2.5ml nebuliser liquid unit dose Steripoule vials (Ashbourne Pharmaceuticals Ltd)",
-        "nmdt": "2010-03-30",
-        "nm_prev": "Maxivent 2.5mg nebuliser liquid 2.5ml unit dose Steripoule vials",
-        "supp_id": "2268401000001100",
-        "lic_auth_id": 1,
-        "lic_auth_prev_id": null,
-        "lic_authchange_id": null,
-        "lic_authchangedt": null,
-        "combprod_id": null,
-        "flavour_id": null,
-        "ema": false,
-        "parallel_import": false,
-        "avail_restrict_id": 9,
-        "bnf_code": null
-    }
-},
-{
-    "model": "dmd.supplier",
-    "pk": "2075901000001102",
-    "fields": {
-        "cddt": null,
-        "cdprev": null,
-        "invalid": false,
-        "descr": "3M Health Care Ltd"
-    }
-},
-{
-    "model": "dmd.supplier",
-    "pk": "2574501000001106",
-    "fields": {
-        "cddt": null,
-        "cdprev": null,
-        "invalid": false,
-        "descr": "Orion Pharma (UK) Ltd"
-    }
-},
-{
-    "model": "dmd.supplier",
-    "pk": "2268401000001100",
-    "fields": {
-        "cddt": null,
-        "cdprev": null,
-        "invalid": false,
-        "descr": "Ashbourne Pharmaceuticals Ltd"
-    }
-},
-{
-    "model": "dmd.supplier",
-    "pk": "2073701000001100",
-    "fields": {
-        "cddt": null,
-        "cdprev": null,
-        "invalid": false,
-        "descr": "Kent Pharma (UK) Ltd"
-    }
-},
-{
-    "model": "dmd.supplier",
-    "pk": "3849901000001105",
-    "fields": {
-        "cddt": null,
-        "cdprev": null,
-        "invalid": false,
-        "descr": "Teva UK Ltd"
-    }
-},
-{
-    "model": "dmd.supplier",
-    "pk": "2268901000001109",
-    "fields": {
-        "cddt": null,
-        "cdprev": null,
-        "invalid": false,
-        "descr": "DE Pharmaceuticals"
-    }
-},
-{
-    "model": "dmd.supplier",
-    "pk": "2074301000001102",
-    "fields": {
-        "cddt": null,
-        "cdprev": null,
-        "invalid": false,
-        "descr": "Sandoz Ltd"
-    }
-},
-{
-    "model": "dmd.licensingauthority",
-    "pk": "1",
-    "fields": {
-        "descr": "Medicines - MHRA/EMA"
-    }
-},
-{
-    "model": "dmd.availabilityrestriction",
-    "pk": "9",
-    "fields": {
-        "descr": "Not available"
-    }
-},
-{
-    "model": "dmd.availabilityrestriction",
-    "pk": "1",
-    "fields": {
-        "descr": "None"
-    }
-},
-{
-    "model": "dmd.virtualproductpresstatus",
-    "pk": "9",
-    "fields": {
-        "descr": "Caution - AMP level prescribing advised"
-    }
-}
 ]

--- a/coding_systems/dmd/tests/test_coding_system.py
+++ b/coding_systems/dmd/tests/test_coding_system.py
@@ -73,6 +73,13 @@ def test_ancestor_relationships(dmd_data, coding_system):
         == expected_relationships
     )
 
+    # 3436211000001104: "Oxygen composite cylinders 1360litres B10C with integral headset" has no VTM
+    # and three descendant AMPS: 4086311000001109,4086111000001107,3106411000001109
+    oxygen_vmp = "3436211000001104"
+    oxygen_amps = ["4086311000001109", "4086111000001107", "3106411000001109"]
+    expected_relationships = {(oxygen_vmp, amp) for amp in oxygen_amps}
+    assert coding_system.ancestor_relationships(oxygen_amps) == expected_relationships
+
 
 def test_descendant_relationships(dmd_data, coding_system):
     """
@@ -109,3 +116,12 @@ def test_descendant_relationships(dmd_data, coding_system):
     # 10 VTM-VMP relationships + 10 VMP-AMP == 20
     # minus the four we have manually declared above
     assert len(descendant_relationships - expected_relationships) == 16
+
+    # 3436211000001104: "Oxygen composite cylinders 1360litres B10C with integral headset" has no VTM
+    # and three descendant AMPS: 4086311000001109,4086111000001107,3106411000001109
+    oxygen_vmp = "3436211000001104"
+    oxygen_amps = ["4086311000001109", "4086111000001107", "3106411000001109"]
+    expected_relationships = {(oxygen_vmp, amp) for amp in oxygen_amps}
+    assert (
+        coding_system.descendant_relationships([oxygen_vmp]) == expected_relationships
+    )

--- a/coding_systems/dmd/tests/test_coding_system.py
+++ b/coding_systems/dmd/tests/test_coding_system.py
@@ -25,3 +25,87 @@ def test_code_to_term(dmd_data, coding_system):
         "10525011000001107": "Adrenaline (base) 220micrograms/dose inhaler refill (VMP)",
         "99999": "Unknown",
     }
+
+
+def test_ancestor_relationships(dmd_data, coding_system):
+    """
+    Test that given each of a code of type [AMP, VMP, VTM]
+    the ancestor relationships all the way up to the ultimate
+    ancestor VTM(s) are returned
+    """
+
+    # "Salbutamol" VTM has no ancestors
+    salbutamol_vtm = "777483005"
+    expected_relationships = set()
+
+    assert (
+        coding_system.ancestor_relationships([salbutamol_vtm]) == expected_relationships
+    )
+
+    # 35936411000001109:"Salbutamol 100micrograms/dose breath actuated inhaler"
+    # and 39112711000001103:"Salbutamol 100micrograms/dose breath actuated inhaler CFC free"
+    # share a common ancestor of 777483005:"Salbutamol"
+
+    salbutamol_vmps = ["35936411000001109", "39112711000001103"]
+    expected_relationships |= {(salbutamol_vtm, vmp) for vmp in salbutamol_vmps}
+
+    assert (
+        coding_system.ancestor_relationships(salbutamol_vmps) == expected_relationships
+    )
+
+    # "Adrenaline" VTM has no ancestors
+    adrenaline_vtm = "65502005"
+
+    # "Adrenaline (base) 220micrograms/dose inhaler" has an ancestor of "Adrenaline" VTM
+    # and no relation to Salbutamol
+    adrenaline_vmps = ["10514511000001106"]
+
+    assert coding_system.ancestor_relationships(salbutamol_vmps + adrenaline_vmps) == (
+        expected_relationships | {(adrenaline_vtm, vmp) for vmp in adrenaline_vmps}
+    )
+
+    # 3293111000001105:"Aerolin 100micrograms/dose Autohaler" has an ancestor of VMP 35936411000001109
+    # and, in turn, VTM 777483005
+    salbutamol_amps = ["3293111000001105"]
+    expected_relationships |= {("35936411000001109", "3293111000001105")}
+    assert (
+        coding_system.ancestor_relationships(salbutamol_vmps + salbutamol_amps)
+        == expected_relationships
+    )
+
+
+def test_descendant_relationships(dmd_data, coding_system):
+    """
+    Test that given each of a code of type [AMP, VMP, VTM]
+    the descendant relationships all the way down to the ultimate
+    descendant AMP(s) are returned
+    """
+
+    # A section of the AMP-VMP-VTM hierarchy for Salbutamol
+    salbutamol_amps = ["597011000001101", "18148111000001107", "22503111000001109"]
+    salbutamol_vmp = "39113611000001102"
+    salbutamol_vtm = "777483005"
+
+    # AMPs have no descendants
+    expected_relationships = set()
+    assert (
+        coding_system.descendant_relationships(salbutamol_amps)
+        == expected_relationships
+    )
+
+    # Given VMP has three descendant AMPs
+    expected_relationships |= {(salbutamol_vmp, amp) for amp in salbutamol_amps}
+    assert (
+        coding_system.descendant_relationships([salbutamol_vmp])
+        == expected_relationships
+    )
+
+    # Given VTM has 10 descendant VMPs, which have in total 10 descendant AMPs
+    expected_relationships |= {(salbutamol_vtm, salbutamol_vmp)}
+    descendant_relationships = coding_system.descendant_relationships([salbutamol_vtm])
+
+    assert expected_relationships.issubset(descendant_relationships)
+
+    # 10 VTM-VMP relationships + 10 VMP-AMP == 20
+    # minus the four we have manually declared above
+    assert len(descendant_relationships - expected_relationships) == 16

--- a/opencodelists/forms.py
+++ b/opencodelists/forms.py
@@ -5,8 +5,7 @@ from io import StringIO
 from django import forms
 from django.contrib.auth import password_validation
 
-from codelists.coding_systems import CODING_SYSTEMS
-from coding_systems.base.coding_system_base import BuilderCompatibleCodingSystem
+from codelists.coding_systems import CODING_SYSTEMS, builder_compatible_coding_systems
 
 from .models import User
 
@@ -44,15 +43,9 @@ class UserPasswordForm(forms.Form):
 
 
 class CodelistCreateForm(forms.Form):
-    CODING_SYSTEM_CHOICES = [("", "---")] + sorted(
-        [
-            (id, system.name)
-            for id, system in CODING_SYSTEMS.items()
-            if issubclass(system, BuilderCompatibleCodingSystem)
-        ],
-        key=lambda x: x[1].lower(),
-    )
-
+    CODING_SYSTEM_CHOICES = [("", "---")] + [
+        (system.id, system.name) for system in builder_compatible_coding_systems()
+    ]
     owner = forms.ChoiceField()
     name = forms.CharField(max_length=255, label="Codelist name")
     coding_system_id = forms.ChoiceField(

--- a/opencodelists/views/user_create_codelist.py
+++ b/opencodelists/views/user_create_codelist.py
@@ -4,8 +4,10 @@ from django.db.utils import IntegrityError
 from django.shortcuts import get_object_or_404, redirect, render
 
 from codelists.actions import create_codelist_from_scratch, create_codelist_with_codes
-from codelists.coding_systems import CODING_SYSTEMS, most_recent_database_alias
-from coding_systems.base.coding_system_base import BuilderCompatibleCodingSystem
+from codelists.coding_systems import (
+    builder_compatible_coding_systems,
+    most_recent_database_alias,
+)
 
 from ..forms import CodelistCreateForm
 from ..models import Organisation, User
@@ -30,14 +32,10 @@ def user_create_codelist(request, username):
 
 
 def handle_get(request, user, owner_choices):
-    coding_systems = sorted(
-        [
-            {"name": system.name, "description": system.description}
-            for id, system in CODING_SYSTEMS.items()
-            if issubclass(system, BuilderCompatibleCodingSystem)
-        ],
-        key=lambda x: x["name"].lower(),
-    )
+    coding_systems = [
+        {"name": system.name, "description": system.description}
+        for system in builder_compatible_coding_systems()
+    ]
     ctx = {
         "user": user,
         "form": CodelistCreateForm(owner_choices=owner_choices),


### PR DESCRIPTION
Define a hierarchy of entites from a subset of the dm+d coding_system which will be presented to the builder via the `ancestor_relationships` and `descendant_relationships` methods.

All AMPs have an ancestor VMP, most but not all VMPs have an ancestor VTM so this must be handled in these methods.

AMPPs and VMPPs are excluded from this hierarchy as no user need for them has been determined, and codes for these types of entity are not present in the data sets made available through OpenSAFELY. Additionally, AMPPs have dual ancestors of AMPs and VMPPs which would be challenging to represent in these methods.

fixes #2506 