### PR TITLE
Remove call to deprecated env_var_or_default

### DIFF
--- a/justfile
+++ b/justfile
@@ -12,7 +12,7 @@ export COMPILE := BIN + "/pip-compile --allow-unsafe --generate-hashes"
 set dotenv-load := true
 
 # set docker environment to one with mounted database dir if DATABASE_DIR env var is set
-docker_env := if env_var_or_default("DATABASE_DIR", "unset") == "unset" { "dev" } else { "dev-mount-db-dir" }
+docker_env := if env("DATABASE_DIR", "unset") == "unset" { "dev" } else { "dev-mount-db-dir" }
 
 # list available commands
 default:


### PR DESCRIPTION
a3a4192 introduced a call to env_var_or_default which has been deprecated since just v1.15.

At the time `opensafely/setup-actions` was stuck on just v1.11.0 This has now been updated to v1.34.0 so this deprecated call can be removed.