### PR TITLE
Add comment about published codelist title badges

### DIFF
--- a/templates/codelists/version.html
+++ b/templates/codelists/version.html
@@ -9,6 +9,7 @@
     <div class="d-flex flex-row justify-content-between gap-2 mb-2">
       <h1 class="h3">
         {{ codelist.name }}
+        {# We display a status badge next to 'Draft' and 'Under review' codelist titles. The team decided not to display a 'Published' badge, since the public only sees published codelists and would not notice the absence of a badge. #}
         {% if clv.is_under_review %}
           <span class="align-text-bottom ml-1 badge badge-info">
             Under review


### PR DESCRIPTION
Closes #2563

The team [decided](https://github.com/opensafely-core/opencodelists/issues/2563#issuecomment-2893927190) that we wanted to keep the current behaviour of our codelist title badges.

This work adds a comment to the code documenting the above decision to help future travellers who may wonder why there isn't a title badge for "Published".