### PR TITLE
Improve codelist downloadability checking

### DIFF
--- a/codelists/api.py
+++ b/codelists/api.py
@@ -429,12 +429,11 @@ def codelists_check(requests):
                 return JsonResponse(
                     {"status": "error", "data": {"error": f"{line} could not be found"}}
                 )
-        try:
-            codelist_download_data[line] = codelist_version.csv_data_shas()
-        except AssertionError:
+        if not codelist_version.downloadable:
             return JsonResponse(
                 {"status": "error", "data": {"error": f"{line} is not downloadable"}}
             )
+        codelist_download_data[line] = codelist_version.csv_data_shas()
 
     # Compare with manifest file
     # The manifest file is generated when `opensafely codelists update` is run in a study repo

--- a/codelists/models.py
+++ b/codelists/models.py
@@ -709,7 +709,7 @@ class CodelistVersion(models.Model):
         include_mapped_vmps: for dm+d codelists, also map in any previous/subsequent
         VMPs
         """
-        assert self.downloadable
+
         header_row = [header.lower() for header in self.table[0]]
         # Find the first matching header from the possible code and term column headers for this
         # codelist's coding system.  These are listed in order of assumed most-to-least likely,

--- a/codelists/views/version_download.py
+++ b/codelists/views/version_download.py
@@ -7,7 +7,7 @@ from .decorators import load_version
 def version_download(request, clv):
     fixed_headers = "fixed-headers" in request.GET
     omit_mapped_vmps = "omit-mapped-vmps" in request.GET
-    if fixed_headers and not clv.downloadable:
+    if not clv.downloadable:
         return HttpResponseBadRequest("Codelist is not downloadable")
     response = HttpResponse(content_type="text/csv")
     content_disposition = f'attachment; filename="{clv.download_filename()}.csv"'


### PR DESCRIPTION
Previously we relied on an assert in the formatted_table method of a CodelistVersion to check if a codelist version is downloadable.

The version download view didn't account for this in all circumstances, leading to unhandled AssertionErrors.

This commit removes this assert and instead makes both this view and the codelist check API endpoint explicitly check the downloadability of codelists versions and return a suitable error to users if not.

Fixes #2326 