### PR TITLE
Don't persist fixtures in test database between tests

### DIFF
--- a/codelists/tests/test_actions.py
+++ b/codelists/tests/test_actions.py
@@ -8,7 +8,7 @@ from mappings.bnfdmd.models import Mapping as BnfDmdMapping
 from opencodelists.tests.assertions import assert_difference, assert_no_difference
 
 
-def test_create_codelist(organisation):
+def test_create_codelist(snomedct_data, organisation):
     cl = actions.create_old_style_codelist(
         owner=organisation,
         name="Test Codelist",
@@ -34,7 +34,7 @@ def test_create_codelist(organisation):
     assert clv.is_under_review
 
 
-def test_create_codelist_for_user(user):
+def test_create_codelist_for_user(snomedct_data, user):
     cl = actions.create_old_style_codelist(
         owner=user,
         name="Test Codelist",
@@ -56,7 +56,7 @@ def test_create_codelist_for_user(user):
     assert "whilst swimming" in clv.csv_data
 
 
-def test_create_codelist_with_duplicate_name(organisation):
+def test_create_codelist_with_duplicate_name(snomedct_data, organisation):
     actions.create_old_style_codelist(
         owner=organisation,
         name="Test",
@@ -81,7 +81,9 @@ def test_create_codelist_with_duplicate_name(organisation):
     assert Codelist.objects.filter(handles__name="Test").count() == 1
 
 
-def test_create_codelist_with_codes(user, disorder_of_elbow_excl_arthritis_codes):
+def test_create_codelist_with_codes(
+    snomedct_data, user, disorder_of_elbow_excl_arthritis_codes
+):
     cl = actions.create_codelist_with_codes(
         owner=user,
         name="Test",
@@ -110,7 +112,7 @@ def test_create_codelist_with_codes(user, disorder_of_elbow_excl_arthritis_codes
 
 
 def test_create_codelist_with_codes_with_metadata(
-    user, disorder_of_elbow_excl_arthritis_codes
+    snomedct_data, user, disorder_of_elbow_excl_arthritis_codes
 ):
     cl = actions.create_codelist_with_codes(
         owner=user,
@@ -129,7 +131,9 @@ def test_create_codelist_with_codes_with_metadata(
     assert cl.signoffs.count() == 1
 
 
-def test_create_or_update_codelist_create(user, disorder_of_elbow_excl_arthritis_codes):
+def test_create_or_update_codelist_create(
+    snomedct_data, user, disorder_of_elbow_excl_arthritis_codes
+):
     cl = actions.create_or_update_codelist(
         owner=user,
         name="Test",
@@ -151,7 +155,7 @@ def test_create_or_update_codelist_create(user, disorder_of_elbow_excl_arthritis
 
 
 def test_create_or_update_codelist_update(
-    organisation, codelist, disorder_of_elbow_excl_arthritis_codes
+    organisation, codelist, disorder_of_elbow_codes
 ):
     with assert_difference(codelist.versions.count, expected_difference=1):
         actions.create_or_update_codelist(
@@ -159,7 +163,7 @@ def test_create_or_update_codelist_update(
             name=codelist.name,
             coding_system_id="snomedct",
             coding_system_database_alias=most_recent_database_alias("snomedct"),
-            codes=disorder_of_elbow_excl_arthritis_codes,
+            codes=disorder_of_elbow_codes,
             description="This is a test (updated)",
             methodology="This is how we did it (updated)",
         )
@@ -168,11 +172,11 @@ def test_create_or_update_codelist_update(
     assert codelist.description == "This is a test (updated)"
     assert codelist.methodology == "This is how we did it (updated)"
     clv = codelist.versions.order_by("id").last()
-    assert clv.codes == tuple(sorted(disorder_of_elbow_excl_arthritis_codes))
+    assert clv.codes == tuple(sorted(disorder_of_elbow_codes))
 
 
 def test_create_or_update_codelist_update_no_change_to_codes(
-    organisation, codelist, disorder_of_elbow_codes
+    organisation, codelist, disorder_of_elbow_excl_arthritis_codes
 ):
     with assert_no_difference(codelist.versions.count):
         actions.create_or_update_codelist(
@@ -180,7 +184,7 @@ def test_create_or_update_codelist_update_no_change_to_codes(
             name=codelist.name,
             coding_system_id="snomedct",
             coding_system_database_alias=most_recent_database_alias("snomedct"),
-            codes=disorder_of_elbow_codes,
+            codes=disorder_of_elbow_excl_arthritis_codes,
             description="This is a test (updated)",
             methodology="This is how we did it (updated)",
         )
@@ -476,7 +480,7 @@ def test_publish(version_under_review):
     assert version_under_review.is_published
 
 
-def test_delete_version(old_style_codelist):
+def test_delete_version(old_style_codelist, old_style_version):
     # Verify that delete_version deletes the given version, and that when the last
     # remaining version is deleted, the codelist is too.
 

--- a/codelists/tests/test_api.py
+++ b/codelists/tests/test_api.py
@@ -9,7 +9,11 @@ from mappings.dmdvmpprevmap.models import Mapping as VmpPrevMapping
 from opencodelists.tests.assertions import assert_difference, assert_no_difference
 
 
-def test_codelists_get(client, organisation):
+def test_codelists_get(
+    client,
+    organisation,
+    many_organisation_versions,
+):
     rsp = client.get(
         f"/api/v1/codelist/{organisation.slug}/?description&methodology&references"
     )
@@ -238,7 +242,12 @@ def test_codelists_get(client, organisation):
     ]
 
 
-def test_codelists_get_all(client, organisation, organisation_user):
+def test_codelists_get_all(
+    client,
+    organisation,
+    organisation_user,
+    many_organisation_and_user_codelists,
+):
     rsp = client.get("/api/v1/codelist/?include-users")
     data = json.loads(rsp.content)
     assert rsp.status_code == 200
@@ -254,7 +263,9 @@ def test_codelists_get_all(client, organisation, organisation_user):
     assert {cl["user"] for cl in user_codelists} == {organisation_user.username}
 
 
-def test_codelists_get_with_coding_system_id(client, organisation):
+def test_codelists_get_with_coding_system_id(
+    client, organisation, many_organisation_codelists
+):
     rsp = client.get(f"/api/v1/codelist/{organisation.slug}/?coding_system_id=snomedct")
     data = json.loads(rsp.content)
     assert len(data["codelists"]) == 4
@@ -297,7 +308,9 @@ def test_codelists_get_exclude_previous_owner(
     assert len(data["codelists"]) == 0
 
 
-def test_codelists_get_with_no_organisation(client, organisation):
+def test_codelists_get_with_no_organisation(
+    client, organisation, many_organisation_and_user_codelists
+):
     rsp = client.get("/api/v1/codelist/?coding_system_id=snomedct&include-users")
     data = json.loads(rsp.content)
     user_codelists = [
@@ -308,13 +321,15 @@ def test_codelists_get_with_no_organisation(client, organisation):
         assert user_codelist["organisation"] == ""
 
 
-def test_codelists_get_with_tag(client, universe):
+def test_codelists_get_with_tag(client, many_organisation_and_user_codelists):
     rsp = client.get("/api/v1/codelist/?tag=new-style")
     data = json.loads(rsp.content)
     assert len(data["codelists"]) == 2
 
 
-def test_codelists_get_with_tag_and_include_users(client, universe):
+def test_codelists_get_with_tag_and_include_users(
+    client, many_organisation_and_user_codelists
+):
     rsp = client.get("/api/v1/codelist/?tag=new-style&include-users")
     data = json.loads(rsp.content)
     assert len(data["codelists"]) == 4

--- a/codelists/tests/test_models.py
+++ b/codelists/tests/test_models.py
@@ -199,6 +199,7 @@ def test_new_style_is_new_style(new_style_codelist):
 
 def test_visible_versions_user_has_edit_permissions(
     new_style_codelist,
+    version_with_complete_searches,
     user,
 ):
     assert len(new_style_codelist.visible_versions(user)) == 3

--- a/codelists/tests/views/test_codelist_create.py
+++ b/codelists/tests/views/test_codelist_create.py
@@ -34,7 +34,7 @@ def test_post_unauthorised_for_user(client, user):
     assert_post_unauthorised(client, user.get_codelist_create_url())
 
 
-def test_get_for_organisation(client, organisation):
+def test_get_for_organisation(client, organisation, organisation_user):
     force_login(organisation, client)
     response = client.get(organisation.get_codelist_create_url())
     assert response.status_code == 200
@@ -90,7 +90,7 @@ def test_post_success(client, organisation, user, bnf_data):
     assert signoff.user == user
 
 
-def test_post_invalid(client, organisation):
+def test_post_invalid(client, organisation, organisation_user):
     force_login(organisation, client)
 
     csv_data = "code,description\n0301012A0AA,Adrenaline (Asthma)"
@@ -126,7 +126,9 @@ def test_post_invalid(client, organisation):
     assert response.context_data["signoff_formset"].errors
 
 
-def test_post_with_duplicate_name(client, organisation):
+def test_post_with_duplicate_name(
+    client, organisation, organisation_user, bnf_codelist
+):
     force_login(organisation, client)
 
     csv_data = "code,description\n0301012A0AA,Adrenaline (Asthma)"

--- a/codelists/tests/views/test_index.py
+++ b/codelists/tests/views/test_index.py
@@ -25,7 +25,7 @@ def test_search_only_returns_codelists_with_published_versions(
     assert codelist.slug == "new-style-codelist"
 
 
-def test_paginate_codelists(client, organisation, create_codelists):
+def test_paginate_codelists(client, organisation, codelist, create_codelists):
     # Create enough published codelists to paginate (codelist index page is paginated by 15)
     create_codelists(30, owner=organisation, status=Status.PUBLISHED)
     published_for_organisation = [
@@ -95,7 +95,9 @@ def test_under_review_index(
         assert version.status == "under review"
 
 
-def test_paginate_under_review_versions(client, organisation, create_codelists):
+def test_paginate_under_review_versions(
+    client, organisation, version_under_review, create_codelists
+):
     # Create enough published codelists to paginate (under-review index page is paginated by 30)
     create_codelists(40, status=Status.UNDER_REVIEW, owner=organisation)
     under_review_for_organisation = flatten(

--- a/codelists/tests/views/test_version_delete.py
+++ b/codelists/tests/views/test_version_delete.py
@@ -10,7 +10,7 @@ def test_post_unauthorised(client, version):
     assert_post_unauthorised(client, version.get_publish_url())
 
 
-def test_post_success(client, old_style_codelist):
+def test_post_success(client, organisation_user, old_style_codelist, old_style_version):
     codelist = old_style_codelist
     version1, version2 = codelist.versions.order_by("id")
     force_login(codelist, client)

--- a/codelists/tests/views/test_version_upload.py
+++ b/codelists/tests/views/test_version_upload.py
@@ -26,14 +26,14 @@ def test_post_unauthorised(client, old_style_codelist):
     assert_post_unauthorised(client, old_style_codelist.get_version_upload_url())
 
 
-def test_get_success(client, old_style_codelist):
+def test_get_success(client, organisation_user, old_style_codelist):
     force_login(old_style_codelist, client)
     response = client.get(old_style_codelist.get_version_upload_url())
     form = response.context_data["form"]
     assert form.fields["coding_system_id"].initial == "snomedct"
 
 
-def test_post_success(client, old_style_codelist):
+def test_post_success(client, organisation_user, old_style_codelist):
     force_login(old_style_codelist, client)
 
     csv_data = "code,description\n73583000,Epicondylitis (disorder)"
@@ -47,7 +47,7 @@ def test_post_success(client, old_style_codelist):
     assert response.url == clv.get_absolute_url()
 
 
-def test_post_missing_field(client, old_style_codelist):
+def test_post_missing_field(client, organisation_user, old_style_codelist):
     force_login(old_style_codelist, client)
 
     with assert_no_difference(old_style_codelist.versions.count):

--- a/conftest.py
+++ b/conftest.py
@@ -96,6 +96,13 @@ def reset_connections():
         del connections.databases[db]
 
 
+@pytest.fixture(autouse=True)
+def fast_password_hasher(settings):
+    settings.PASSWORD_HASHERS = [
+        "django.contrib.auth.hashers.MD5PasswordHasher",
+    ]
+
+
 ################################################################################################################
 # Setup global tracing infrastructure for testing purposes.
 

--- a/opencodelists/tests/fixtures.py
+++ b/opencodelists/tests/fixtures.py
@@ -99,14 +99,12 @@ AB  239964003  Soft tissue lesion of elbow region                       X
 """
 
 import csv
-from copy import deepcopy
 from io import StringIO
 from pathlib import Path
 
 import pytest
 from django.conf import settings
 from django.core.management import call_command
-from django.db.models import Model
 
 from builder.actions import create_search, save, update_code_statuses
 from codelists.actions import (
@@ -144,30 +142,9 @@ def get_fixture_scope(fixture_name, config):
     return "session"
 
 
-def build_fixture(fixture_name):
-    """Build a fixture function that returns the fixture object with the given name."""
-
-    def fixture(universe):
-        """The actual pytest fixture.
-
-        Returns a copy of the member of the universe with the given name.
-        """
-        obj = universe[fixture_name]
-        if isinstance(obj, Model):
-            # Return instance of fixture loaded from the database.  We cannot use
-            # obj.refresh_from_db(), because it does not work if the object has been
-            # deleted in a test (because obj.pk is set to None when obj is deleted), and
-            # because it does not reset any non-field attributes such as cached
-            # properties.
-            return type(obj).objects.get(pk=obj.pk)
-        else:
-            # Return a deep copy of the fixture.  This allows the fixture to be safely
-            # mutated in tests.
-            return deepcopy(obj)
-
-    # This docstring is used in the output of `pytest --fixtures`
-    fixture.__doc__ = f"Return {fixture_name} from the universe fixture"
-    return pytest.fixture()(fixture)
+#################################################################################
+# Load coding system data
+#################################################################################
 
 
 @pytest.fixture(scope=get_fixture_scope)
@@ -224,7 +201,9 @@ def bnf_data(setup_coding_systems, django_db_setup, django_db_blocker):
 
 
 @pytest.fixture(scope=get_fixture_scope)
-def dmd_bnf_mapping_data(setup_coding_systems, django_db_setup, django_db_blocker):
+def dmd_bnf_mapping_data(
+    setup_coding_systems, dmd_data, bnf_data, django_db_setup, django_db_blocker
+):
     with django_db_blocker.unblock():
         # load a very small amount of the BNF coding system
         call_command(
@@ -234,85 +213,131 @@ def dmd_bnf_mapping_data(setup_coding_systems, django_db_setup, django_db_blocke
         )
 
 
-@pytest.fixture(scope=get_fixture_scope)
-def universe(snomedct_data, dmd_data, bnf_data, django_db_setup, django_db_blocker):
-    """Create universe of fixture objects.
-
-    This fixture will be loaded exactly once per session.  It is not expected that it is
-    used directly, but instead it is a dependency of the fixtures created by
-    build_fixtures below.
-    """
-    with django_db_blocker.unblock():
-        return build_fixtures()
-
-
-def build_fixtures():
-    """Create fixture objects.
-
-    Returns a dict of locals(), mapping a fixture name to the fixture object.
-    """
-
-    # disorder_of_elbow_codes
-    disorder_of_elbow_codes = load_codes_from_csv("disorder-of-elbow.csv")
-
-    # disorder_of_elbow_excl_arthritis_codes
-    disorder_of_elbow_excl_arthritis_codes = load_codes_from_csv(
-        "disorder-of-elbow-excl-arthritis.csv"
+@pytest.fixture
+def icd10_data():
+    path = Path(
+        settings.BASE_DIR,
+        "coding_systems",
+        "icd10",
+        "fixtures",
+        "icd10.icd10_test_20200101.json",
     )
+    call_command("loaddata", path, database="icd10_test_20200101")
 
-    # disorder_of_elbow_csv_data
-    disorder_of_elbow_csv_data = load_csv_data("disorder-of-elbow.csv")
 
-    # disorder_of_elbow_excl_arthritis_csv_data
-    disorder_of_elbow_excl_arthritis_csv_data = load_csv_data(
-        "disorder-of-elbow-excl-arthritis.csv"
-    )
+#################################################################################
+# Load CSV Data
+#################################################################################
 
-    # disorder_of_elbow_csv_data_no_header
-    disorder_of_elbow_csv_data_no_header = load_csv_data_no_header(
-        "disorder-of-elbow.csv"
-    )
 
-    # enthesopathy_of_elbow_region_plus_tennis_toe
-    enthesopathy_of_elbow_region_plus_tennis_toe = load_codes_from_csv(
-        "enthesopathy-of-elbow-region-plus-tennis-toe.csv"
-    )
+def load_csv_data(filename, fixtures_path=None):
+    """Return CSV data in given filename."""
+    fixtures_path = fixtures_path or SNOMED_FIXTURES_PATH
+    with open(fixtures_path / filename) as f:
+        return f.read()
 
-    # asthma_medications_csv_data
-    asthma_medication_csv_data = load_csv_data(
-        "asthma-medication.csv", DMD_FIXTURES_PATH
-    )
 
-    # asthma_medication_csv_data_alternative_headers
-    asthma_medication_csv_data_alternative_headers = load_csv_data(
-        "asthma-medication-alt-headers.csv", DMD_FIXTURES_PATH
-    )
+def load_csv_data_no_header(filename):
+    """Return CSV data in given filename, dropping header."""
+    with open(SNOMED_FIXTURES_PATH / filename) as f:
+        rows = list(csv.reader(f))[1:]
 
-    # asthma_medications_refill_csv_data
-    asthma_medication_refill_csv_data = load_csv_data(
-        "asthma-medication-refill.csv", DMD_FIXTURES_PATH
-    )
+    buffer = StringIO()
+    writer = csv.writer(buffer)
+    writer.writerows(rows)
+    return buffer.getvalue()
 
-    # asthma_medications_refill_csv_data
-    bnf_asthma_csv_data = load_codes_from_csv("asthma.csv", BNF_FIXTURES_PATH)
 
-    # organisation
-    # - has two users:
-    #   - organisation_admin
-    #   - organisation_user
-    # - has three codelists:
-    #   - old_style_codelist
-    #   - new_style_codelist
-    #   - codelist_from_scratch
-    organisation = create_organisation(name="Test University", url="https://test.ac.uk")
+def load_codes_from_csv(filename, fixtures_path=None):
+    """Return codes in CSV file at given filename."""
+    fixtures_path = fixtures_path or SNOMED_FIXTURES_PATH
+    with open(fixtures_path / filename) as f:
+        rows = list(csv.reader(f))
 
-    # another_organisation
-    another_organisation = create_organisation(
-        name="Another University", url="https://another.ac.uk"
-    )
+    return [row[0] for row in rows[1:]]
 
-    # organisation_admin
-    # - is admin for organisation
+
+# These just sit in memory, per-session is fine
+# Maybe we should make them an immutable data structure for safety
+
+
+@pytest.fixture(scope="session")
+def disorder_of_elbow_codes():
+    return load_codes_from_csv("disorder-of-elbow.csv")
+
+
+@pytest.fixture(scope="session")
+def disorder_of_elbow_excl_arthritis_codes():
+    return load_codes_from_csv("disorder-of-elbow-excl-arthritis.csv")
+
+
+@pytest.fixture(scope="session")
+def disorder_of_elbow_csv_data():
+    return load_csv_data("disorder-of-elbow.csv")
+
+
+@pytest.fixture(scope="session")
+def disorder_of_elbow_excl_arthritis_csv_data():
+    return load_csv_data("disorder-of-elbow-excl-arthritis.csv")
+
+
+@pytest.fixture(scope="session")
+def disorder_of_elbow_csv_data_no_header():
+    return load_csv_data_no_header("disorder-of-elbow.csv")
+
+
+@pytest.fixture(scope="session")
+def enthesopathy_of_elbow_region_plus_tennis_toe():
+    return load_codes_from_csv("enthesopathy-of-elbow-region-plus-tennis-toe.csv")
+
+
+@pytest.fixture(scope="session")
+def asthma_medication_csv_data():
+    return load_csv_data("asthma-medication.csv", DMD_FIXTURES_PATH)
+
+
+@pytest.fixture(scope="session")
+def asthma_medication_csv_data_alternative_headers():
+    return load_csv_data("asthma-medication-alt-headers.csv", DMD_FIXTURES_PATH)
+
+
+@pytest.fixture(scope="session")
+def asthma_medication_refill_csv_data():
+    return load_csv_data("asthma-medication-refill.csv", DMD_FIXTURES_PATH)
+
+
+@pytest.fixture(scope="session")
+def bnf_asthma_csv_data():
+    return load_codes_from_csv("asthma.csv", BNF_FIXTURES_PATH)
+
+
+#################################################################################
+# Orgs and users
+#################################################################################
+
+
+# organisation
+# - has two users:
+#   - organisation_admin
+#   - organisation_user
+# - has three codelists:
+#   - old_style_codelist
+#   - new_style_codelist
+#   - codelist_from_scratch
+
+
+@pytest.fixture
+def organisation():
+    return create_organisation(name="Test University", url="https://test.ac.uk")
+
+
+@pytest.fixture
+def another_organisation():
+    return create_organisation(name="Another University", url="https://another.ac.uk")
+
+
+@pytest.fixture
+def organisation_admin(organisation):
     organisation_admin = User.objects.create_user(
         username="alice", password="test", email="alice@test.ac.uk", name="Alice"
     )
@@ -320,12 +345,11 @@ def build_fixtures():
         user=organisation_admin, organisation=organisation, date_joined="2020-02-29"
     )
     make_user_admin_for_organisation(user=organisation_admin, organisation=organisation)
+    return organisation_admin
 
-    # organisation_user
-    # - is non-admin for organisation
-    # - is editing version_from_scratch
-    # - has one codelist:
-    #   - user_codelist
+
+@pytest.fixture
+def organisation_user(organisation):
     organisation_user = User.objects.create_user(
         username="bob", password="test", email="bob@test.ac.uk", name="Bob"
     )
@@ -333,23 +357,28 @@ def build_fixtures():
         user=organisation_user, organisation=organisation, date_joined="2020-02-29"
     )
     set_api_token(user=organisation_user)
+    return organisation_user
 
-    # user
-    # - an alias for organisation_user
-    user = organisation_user
 
-    # collaborator
-    # - is collaborator on new_style_codelist
-    collaborator = User.objects.create_user(
+# collaborator
+# - is collaborator on new_style_codelist
+@pytest.fixture
+def collaborator():
+    return User.objects.create_user(
         username="charlie",
         password="test",
         email="charlie@example.co.uk",
         name="Charlie",
     )
 
-    # user_without_organisation
-    # - does not belong to an organisation
-    # - has no codelists
+
+@pytest.fixture
+def user(organisation_user):
+    return organisation_user
+
+
+@pytest.fixture
+def user_without_organisation():
     user_without_organisation = User.objects.create_user(
         username="dave",
         password="test",
@@ -357,21 +386,39 @@ def build_fixtures():
         name="Dave",
     )
     set_api_token(user=user_without_organisation)
+    return user_without_organisation
 
-    # user_with_no_api_token
+
+@pytest.fixture
+def user_with_no_api_token():
     user_with_no_api_token = User.objects.create_user(
         username="eve",
         password="test",
         email="eve@example.co.uk",
         name="Eve",
     )
+    return user_with_no_api_token
 
-    # old_style_codelist
-    # - owned by organisation
-    # - has one version:
-    #   - old_style_version
-    # - tagged with "old-style"
-    old_style_codelist = create_old_style_codelist(
+
+#################################################################################
+# Codelists and versions - SNOMEDCT coding system
+#################################################################################
+
+
+def check_expected_codes(version, codes):
+    assert sorted(version.codes) == sorted(codes)
+
+
+# old_style_codelist
+# - owned by organisation
+# - has one version:
+#   - old_style_version
+# - tagged with "old-style"
+@pytest.fixture
+def old_style_codelist(
+    snomedct_data, organisation, disorder_of_elbow_excl_arthritis_csv_data
+):
+    codelist = create_old_style_codelist(
         owner=organisation,
         name="Old-style Codelist",
         coding_system_id="snomedct",
@@ -380,107 +427,43 @@ def build_fixtures():
         methodology="How we did it",
         csv_data=disorder_of_elbow_excl_arthritis_csv_data,
     )
-    add_codelist_tag(codelist=old_style_codelist, tag="old-style")
+    add_codelist_tag(codelist=codelist, tag="old-style")
+    return codelist
 
-    # old_style_version
-    # - belongs to old_style_codelist
-    # - includes Disorder of elbow
-    old_style_version = create_old_style_version(
+
+# old_style_version
+# - belongs to old_style_codelist
+# - includes Disorder of elbow
+@pytest.fixture
+def old_style_version(
+    old_style_codelist, disorder_of_elbow_csv_data, disorder_of_elbow_codes
+):
+    version = create_old_style_version(
         codelist=old_style_codelist,
         csv_data=disorder_of_elbow_csv_data,
         coding_system_database_alias=most_recent_database_alias("snomedct"),
     )
+    check_expected_codes(version, disorder_of_elbow_codes)
+    return version
 
-    # Check that this version has the expected codes
-    check_expected_codes(old_style_version, disorder_of_elbow_codes)
 
-    # dmd codelist
-    # - owned by organisation
-    # - has 3 versions:
-    #   - dmd_version_asthma_medication; contains CSV data with converted-from-BNF headers
-    #   - dmd_version_asthma_medication_alt_headers; same data but headers "code" and "term"
-    #   - dmd_version_asthma_medication_refill_csv_data; contains different data, including
-    #     a code which is unknown in the current (test) coding system release
-    dmd_codelist = create_old_style_codelist(
-        owner=organisation,
-        name="DMD Codelist",
-        coding_system_id="dmd",
-        coding_system_database_alias=most_recent_database_alias("dmd"),
-        description="What this is",
-        methodology="How we did it",
-        csv_data=asthma_medication_csv_data,
-    )
-    dmd_version_asthma_medication = dmd_codelist.versions.first()
-    dmd_version_asthma_medication_alt_headers = create_old_style_version(
-        codelist=dmd_codelist,
-        csv_data=asthma_medication_csv_data_alternative_headers,
-        coding_system_database_alias=most_recent_database_alias("dmd"),
-    )
-    # In order to avoid raising and exception in the `create_old_style_version`
-    # action because of the unknown code in the csv data, we create the
-    # version with the csv_data set to asthma_medication_csv_data and
-    # replace it with asthma_medication_refill_csv_data afterwards
-    dmd_version_asthma_medication_refill = create_old_style_version(
-        codelist=dmd_codelist,
-        csv_data=asthma_medication_csv_data,
-        coding_system_database_alias=most_recent_database_alias("dmd"),
-    )
-    dmd_version_asthma_medication_refill.csv_data = asthma_medication_refill_csv_data
-    dmd_version_asthma_medication_refill.save()
-
-    # bnf codelist
-    # - owned by organisation
-    # - has 1 versions:
-    #   - bnf_version_asthma
-    bnf_codelist = create_codelist_with_codes(
-        owner=organisation,
-        name="BNF Codelist",
-        coding_system_id="bnf",
-        coding_system_database_alias=most_recent_database_alias("bnf"),
-        codes=bnf_asthma_csv_data,
-        references=[
-            {"text": "Reference 1", "url": "https://example.com/reference1"},
-            {"text": "Reference 2", "url": "https://example.com/reference2"},
-        ],
-        signoffs=[
-            {"user": organisation_user, "date": "2020-02-29"},
-            {"user": collaborator, "date": "2020-02-29"},
-        ],
-        status=Status.PUBLISHED,
-    )
-    bnf_version_asthma = bnf_codelist.versions.first()
-
-    # bnf_version_with_search
-    # - belongs to bnf_codelist
-    # - has a search, and all codes covered
-    bnf_version_with_search = export_to_builder(
-        version=bnf_version_asthma,
-        author=organisation_user,
-        coding_system_database_alias=most_recent_database_alias("bnf"),
-    )
-    create_search(
-        draft=bnf_version_with_search,
-        term="asthma",
-        codes=codes_for_search_term("asthma", coding_system_id="bnf"),
-    )
-    update_code_statuses(
-        draft=bnf_version_with_search,
-        updates=[
-            ("0301012A0AA", "+"),
-            ("0301012A0AAABAB", "+"),
-            ("0301012A0AAACAC", "+"),
-        ],
-    )
-
-    # new_style_codelist
-    # - belongs to organisation
-    # - is collaborated on by collaborator
-    # - has four versions:
-    #   - version_with_no_searches
-    #   - version_with_some_searches
-    #   - version_with_complete_searches
-    # - tagged with "new-style"
-    new_style_codelist = create_codelist_with_codes(
+# new_style_codelist
+# - belongs to organisation
+# - is collaborated on by collaborator
+# - has four versions:
+#   - version_with_no_searches
+#   - version_with_some_searches
+#   - version_with_complete_searches
+# - tagged with "new-style"
+@pytest.fixture
+def new_style_codelist(
+    snomedct_data,
+    organisation,
+    organisation_user,
+    collaborator,
+    disorder_of_elbow_excl_arthritis_codes,
+):
+    codelist = create_codelist_with_codes(
         owner=organisation,
         name="New-style Codelist",
         coding_system_id="snomedct",
@@ -496,43 +479,72 @@ def build_fixtures():
         ],
         status=Status.PUBLISHED,
     )
-    add_codelist_tag(codelist=new_style_codelist, tag="new-style")
+    add_collaborator(codelist=codelist, collaborator=collaborator)
+    add_codelist_tag(codelist=codelist, tag="new-style")
+    return codelist
 
-    # organisation_codelist
-    # - an alias for new_style_codelist
-    organisation_codelist = new_style_codelist
 
-    # codelist
-    # - an alias for new_style_codelist
-    codelist = new_style_codelist
+# organisation_codelist
+# - an alias for new_style_codelist
+@pytest.fixture
+def organisation_codelist(new_style_codelist):
+    return new_style_codelist
 
-    # version_with_no_searches
-    # - belongs to new_style_codelist
-    # - has no searches
-    # - includes Disorder of elbow, excludes Arthritis
-    version_with_no_searches = new_style_codelist.versions.get()
 
+# codelist
+# - an alias for new_style_codelist
+@pytest.fixture
+def codelist(new_style_codelist):
+    return new_style_codelist
+
+
+# codelist_with_collaborator
+# - an alias for new_style_codelist
+@pytest.fixture
+def codelist_with_collaborator(new_style_codelist):
+    return new_style_codelist
+
+
+# version_with_no_searches
+# - belongs to new_style_codelist
+# - has no searches
+# - includes Disorder of elbow, excludes Arthritis
+@pytest.fixture
+def version_with_no_searches(
+    new_style_codelist, disorder_of_elbow_excl_arthritis_codes
+):
+    version = new_style_codelist.versions.get()
     # Check that no code_objs are linked to searches
-    assert not version_with_no_searches.code_objs.filter(results__isnull=False).exists()
+    assert not version.code_objs.filter(results__isnull=False).exists()
 
     # Check that this version has the expected codes
-    check_expected_codes(
-        version_with_no_searches, disorder_of_elbow_excl_arthritis_codes
-    )
+    check_expected_codes(version, disorder_of_elbow_excl_arthritis_codes)
+    return version
 
-    # latest_published_version
-    # - an alias for version_with_no_searches
-    latest_published_version = version_with_no_searches
-    assert latest_published_version.is_published
 
-    # version_with_excluded_codes
-    # - an alias for version_with_no_searches
-    version_with_excluded_codes = version_with_no_searches
+# latest_published_version
+# - an alias for version_with_no_searches
+@pytest.fixture
+def latest_published_version(version_with_no_searches):
+    assert version_with_no_searches.is_published
+    return version_with_no_searches
 
-    # version_with_some_searches
-    # - belongs to new_style_codelist
-    # - has single search, but not all codes covered
-    # - includes Disorder of elbow
+
+# version_with_excluded_codes
+# - an alias for version_with_no_searches
+@pytest.fixture
+def version_with_excluded_codes(version_with_no_searches):
+    return version_with_no_searches
+
+
+# version_with_some_searches
+# - belongs to new_style_codelist
+# - has single search, but not all codes covered
+# - includes Disorder of elbow
+@pytest.fixture
+def version_with_some_searches(
+    version_with_no_searches, organisation_user, disorder_of_elbow_codes
+):
     version_with_some_searches = export_to_builder(
         version=version_with_no_searches,
         author=organisation_user,
@@ -564,10 +576,17 @@ def build_fixtures():
     # Check that this version has the expected codes
     check_expected_codes(version_with_some_searches, disorder_of_elbow_codes)
 
-    # version_with_complete_searches
-    # - belongs to new_style_codelist
-    # - has some searches, and all codes covered
-    # - includes Disorder of elbow
+    return version_with_some_searches
+
+
+# version_with_complete_searches
+# - belongs to new_style_codelist
+# - has some searches, and all codes covered
+# - includes Disorder of elbow
+@pytest.fixture
+def version_with_complete_searches(
+    version_with_some_searches, organisation_user, disorder_of_elbow_codes
+):
     version_with_complete_searches = export_to_builder(
         version=version_with_some_searches,
         author=organisation_user,
@@ -612,28 +631,37 @@ def build_fixtures():
     # Check that this version has the expected codes
     check_expected_codes(version_with_complete_searches, disorder_of_elbow_codes)
 
-    # version
-    # - an alias for version_with_complete_searches
-    version = version_with_complete_searches
+    return version_with_complete_searches
 
-    # version_under_review
-    # - an alias for version_with_complete_searches
-    version_under_review = version_with_complete_searches
 
-    # latest_version
-    # - an alias for version_with_complete_searches
-    latest_version = version_with_complete_searches
+# version
+# - an alias for version_with_complete_searches
+@pytest.fixture
+def version(version_with_complete_searches):
+    return version_with_complete_searches
 
-    # codelist_with_collaborator
-    # - an alias for new_style_codelist
-    codelist_with_collaborator = new_style_codelist
-    add_collaborator(codelist=codelist_with_collaborator, collaborator=collaborator)
 
-    # codelist_from_scratch
-    # - belongs to organisation
-    # - has single version, being edited:
-    #   - version_from_scratch
-    # - tagged with "new-style"
+# version_under_review
+# - an alias for version_with_complete_searches
+@pytest.fixture
+def version_under_review(version_with_complete_searches):
+    return version_with_complete_searches
+
+
+# latest_version
+# - an alias for version_with_complete_searches
+@pytest.fixture
+def latest_version(version_with_complete_searches):
+    return version_with_complete_searches
+
+
+# codelist_from_scratch
+# - belongs to organisation
+# - has single version, being edited:
+#   - version_from_scratch
+# - tagged with "new-style"
+@pytest.fixture
+def codelist_from_scratch(snomedct_data, organisation, organisation_user):
     codelist_from_scratch = create_codelist_from_scratch(
         owner=organisation,
         name="Codelist From Scratch",
@@ -642,12 +670,16 @@ def build_fixtures():
         author=organisation_user,
     )
     add_codelist_tag(codelist=codelist_from_scratch, tag="new-style")
+    return codelist_from_scratch
 
-    # user_codelist_from_scratch
-    # - belongs to user
-    # - has single version, being edited:
-    #   - version_from_scratch
-    # - tagged with "new-style"
+
+# user_codelist_from_scratch
+# - belongs to user
+# - has single version, being edited:
+#   - version_from_scratch
+# - tagged with "new-style"
+@pytest.fixture
+def user_codelist_from_scratch(snomedct_data, organisation_user):
     user_codelist_from_scratch = create_codelist_from_scratch(
         owner=organisation_user,
         name="User Codelist From Scratch",
@@ -656,20 +688,28 @@ def build_fixtures():
         author=organisation_user,
     )
     add_codelist_tag(codelist=user_codelist_from_scratch, tag="new-style")
+    return user_codelist_from_scratch
 
-    # version_from_scratch
-    # - belongs to codelist_from_scratch
-    # - being edited by organisation_user
+
+# version_from_scratch
+# - belongs to codelist_from_scratch
+# - being edited by organisation_user
+@pytest.fixture
+def version_from_scratch(codelist_from_scratch):
     version_from_scratch = codelist_from_scratch.versions.get()
-
-    # Check that this version has no codes
     assert version_from_scratch.codes == ()
+    return version_from_scratch
 
-    # user_codelist
-    # - belongs to organisation_user
-    # - has one version:
-    #   - user_version
-    # - tagged with "new-style"
+
+# user_codelist
+# - belongs to organisation_user
+# - has one version:
+#   - user_version
+# - tagged with "new-style"
+@pytest.fixture
+def user_codelist(
+    snomedct_data, organisation_user, disorder_of_elbow_excl_arthritis_codes
+):
     user_codelist = create_codelist_with_codes(
         owner=organisation_user,
         name="User-owned Codelist",
@@ -679,17 +719,26 @@ def build_fixtures():
         status=Status.PUBLISHED,
     )
     add_codelist_tag(codelist=user_codelist, tag="new-style")
+    return user_codelist
 
-    # user_version
-    # - belongs to user_codelist
-    user_version = user_codelist.versions.get()
 
-    # minimal codelist with codes
-    # - belongs to organisation
-    # - has 4 codes matching searches
-    # - has one version
-    #   - minimal_version_with_codes
-    minimal_codelist = create_codelist_with_codes(
+# user_version
+# - belongs to user_codelist
+@pytest.fixture
+def user_version(user_codelist):
+    return user_codelist.versions.get()
+
+
+# minimal codelist with codes
+# - belongs to organisation
+# - has 4 codes matching searches
+# - has one version
+#   - minimal_version_with_codes
+@pytest.fixture
+def minimal_codelist(
+    snomedct_data, organisation, enthesopathy_of_elbow_region_plus_tennis_toe
+):
+    return create_codelist_with_codes(
         owner=organisation,
         name="Minimal Codelist",
         coding_system_id="snomedct",
@@ -697,8 +746,12 @@ def build_fixtures():
         codes=enthesopathy_of_elbow_region_plus_tennis_toe,
         status=Status.PUBLISHED,
     )
-    # minimal_version
-    # - belongs to minimal_codelist
+
+
+# minimal_version
+# - belongs to minimal_codelist
+@pytest.fixture
+def minimal_draft(minimal_codelist, organisation_user):
     minimal_version = minimal_codelist.versions.get()
     minimal_draft = export_to_builder(
         version=minimal_version,
@@ -717,11 +770,20 @@ def build_fixtures():
     )
     # Check that all code_objs are linked to searches
     assert not minimal_draft.code_objs.filter(results__isnull=True).exists()
+    return minimal_draft
 
-    # null codelist
-    # A codelist using the "null" coding system, which isn't associated with
-    # a coding system database
-    # Has 2 versions
+
+#################################################################################
+# Codelists and versions - Null coding system
+#################################################################################
+
+
+# null codelist
+# A codelist using the "null" coding system, which isn't associated with
+# a coding system database
+# Has 2 versions
+@pytest.fixture
+def null_codelist(organisation):
     null_codelist = create_old_style_codelist(
         owner=organisation,
         name="Null Codelist",
@@ -731,41 +793,195 @@ def build_fixtures():
         description="",
         methodology="",
     )
-    null_version1 = null_codelist.versions.get()
-    null_version2 = create_old_style_version(
+    null_codelist.versions.get()
+    create_old_style_version(
         codelist=null_codelist,
         csv_data="code,term\n5678,Test code1",
         coding_system_database_alias="null_test_20200101",
     )
-
-    return locals()
-
-
-def load_csv_data(filename, fixtures_path=None):
-    """Return CSV data in given filename."""
-    fixtures_path = fixtures_path or SNOMED_FIXTURES_PATH
-    with open(fixtures_path / filename) as f:
-        return f.read()
+    return null_codelist
 
 
-def load_csv_data_no_header(filename):
-    """Return CSV data in given filename, dropping header."""
-    with open(SNOMED_FIXTURES_PATH / filename) as f:
-        rows = list(csv.reader(f))[1:]
-
-    buffer = StringIO()
-    writer = csv.writer(buffer)
-    writer.writerows(rows)
-    return buffer.getvalue()
+#################################################################################
+# Codelists and versions - DMD coding system
+#################################################################################
 
 
-def load_codes_from_csv(filename, fixtures_path=None):
-    """Return codes in CSV file at given filename."""
-    fixtures_path = fixtures_path or SNOMED_FIXTURES_PATH
-    with open(fixtures_path / filename) as f:
-        rows = list(csv.reader(f))
+# dmd codelist
+# - owned by organisation
+# - has 3 versions:
+#   - dmd_version_asthma_medication; contains CSV data with converted-from-BNF headers
+#   - dmd_version_asthma_medication_alt_headers; same data but headers "code" and "term"
+#   - dmd_version_asthma_medication_refill_csv_data; contains different data, including
+#     a code which is unknown in the current (test) coding system release
+@pytest.fixture
+def dmd_codelist(dmd_data, organisation, asthma_medication_csv_data):
+    return create_old_style_codelist(
+        owner=organisation,
+        name="DMD Codelist",
+        coding_system_id="dmd",
+        coding_system_database_alias=most_recent_database_alias("dmd"),
+        description="What this is",
+        methodology="How we did it",
+        csv_data=asthma_medication_csv_data,
+    )
 
-    return [row[0] for row in rows[1:]]
+
+@pytest.fixture
+def dmd_version_asthma_medication(dmd_codelist):
+    return dmd_codelist.versions.first()
+
+
+@pytest.fixture
+def dmd_version_asthma_medication_alt_headers(
+    dmd_codelist, asthma_medication_csv_data_alternative_headers
+):
+    return create_old_style_version(
+        codelist=dmd_codelist,
+        csv_data=asthma_medication_csv_data_alternative_headers,
+        coding_system_database_alias=most_recent_database_alias("dmd"),
+    )
+
+
+@pytest.fixture
+def dmd_version_asthma_medication_refill(
+    dmd_codelist, asthma_medication_csv_data, asthma_medication_refill_csv_data
+):
+    # In order to avoid raising and exception in the `create_old_style_version`
+    # action because of the unknown code in the csv data, we create the
+    # version with the csv_data set to asthma_medication_csv_data and
+    # replace it with asthma_medication_refill_csv_data afterwards
+    dmd_version_asthma_medication_refill = create_old_style_version(
+        codelist=dmd_codelist,
+        csv_data=asthma_medication_csv_data,
+        coding_system_database_alias=most_recent_database_alias("dmd"),
+    )
+    dmd_version_asthma_medication_refill.csv_data = asthma_medication_refill_csv_data
+    dmd_version_asthma_medication_refill.save()
+    return dmd_version_asthma_medication_refill
+
+
+#################################################################################
+# Codelists and versions - BNF coding system
+#################################################################################
+# bnf codelist
+# - owned by organisation
+# - has 1 versions:
+#   - bnf_version_asthma
+@pytest.fixture
+def bnf_codelist(
+    bnf_data, organisation, organisation_user, collaborator, bnf_asthma_csv_data
+):
+    return create_codelist_with_codes(
+        owner=organisation,
+        name="BNF Codelist",
+        coding_system_id="bnf",
+        coding_system_database_alias=most_recent_database_alias("bnf"),
+        codes=bnf_asthma_csv_data,
+        references=[
+            {"text": "Reference 1", "url": "https://example.com/reference1"},
+            {"text": "Reference 2", "url": "https://example.com/reference2"},
+        ],
+        signoffs=[
+            {"user": organisation_user, "date": "2020-02-29"},
+            {"user": collaborator, "date": "2020-02-29"},
+        ],
+        status=Status.PUBLISHED,
+    )
+
+
+@pytest.fixture
+def bnf_version_asthma(bnf_codelist):
+    return bnf_codelist.versions.first()
+
+
+# bnf_version_with_search
+# - belongs to bnf_codelist
+# - has a search, and all codes covered
+@pytest.fixture
+def bnf_version_with_search(organisation_user, bnf_version_asthma):
+    bnf_version_with_search = export_to_builder(
+        version=bnf_version_asthma,
+        author=organisation_user,
+        coding_system_database_alias=most_recent_database_alias("bnf"),
+    )
+    create_search(
+        draft=bnf_version_with_search,
+        term="asthma",
+        codes=codes_for_search_term("asthma", coding_system_id="bnf"),
+    )
+    update_code_statuses(
+        draft=bnf_version_with_search,
+        updates=[
+            ("0301012A0AA", "+"),
+            ("0301012A0AAABAB", "+"),
+            ("0301012A0AAACAC", "+"),
+        ],
+    )
+    return bnf_version_with_search
+
+
+#################################################################################
+# Fixtures combining many of the above codelists
+#################################################################################
+
+
+@pytest.fixture
+def many_organisation_codelists(
+    bnf_codelist,
+    codelist_from_scratch,
+    dmd_codelist,
+    minimal_codelist,
+    new_style_codelist,
+    null_codelist,
+    old_style_codelist,
+):
+    pass
+
+
+@pytest.fixture
+def many_organisation_versions(
+    bnf_version_asthma,
+    bnf_version_with_search,
+    version_from_scratch,
+    dmd_version_asthma_medication,
+    dmd_version_asthma_medication_alt_headers,
+    dmd_version_asthma_medication_refill,
+    minimal_draft,
+    version_with_no_searches,
+    version_with_some_searches,
+    version_with_complete_searches,
+    null_codelist,
+    old_style_version,
+):
+    pass
+
+
+@pytest.fixture
+def many_organisation_and_user_codelists(
+    many_organisation_codelists, user_codelist, user_codelist_from_scratch
+):
+    pass
+
+
+@pytest.fixture
+def all_fixtures(
+    many_organisation_and_user_codelists,
+    many_organisation_versions,
+    another_organisation,
+    organisation_admin,
+    collaborator,
+    user_without_organisation,
+    user_with_no_api_token,
+    user_version,
+    codelist_with_collaborator,
+):
+    pass
+
+
+#################################################################################
+# misc
+#################################################################################
 
 
 def codes_for_search_term(term, coding_system_id=None):
@@ -780,63 +996,6 @@ def codes_for_search_code(code):
 
     coding_system = CODING_SYSTEMS["snomedct"].get_by_release_or_most_recent()
     return do_search(coding_system, code=code)["all_codes"]
-
-
-def check_expected_codes(version, codes):
-    assert sorted(version.codes) == sorted(codes)
-
-
-disorder_of_elbow_codes = build_fixture("disorder_of_elbow_codes")
-disorder_of_elbow_excl_arthritis_codes = build_fixture(
-    "disorder_of_elbow_excl_arthritis_codes"
-)
-disorder_of_elbow_csv_data = build_fixture("disorder_of_elbow_csv_data")
-disorder_of_elbow_excl_arthritis_csv_data = build_fixture(
-    "disorder_of_elbow_excl_arthritis_csv_data"
-)
-disorder_of_elbow_csv_data_no_header = build_fixture(
-    "disorder_of_elbow_csv_data_no_header"
-)
-organisation = build_fixture("organisation")
-another_organisation = build_fixture("another_organisation")
-organisation_admin = build_fixture("organisation_admin")
-organisation_user = build_fixture("organisation_user")
-collaborator = build_fixture("collaborator")
-user_without_organisation = build_fixture("user_without_organisation")
-user = build_fixture("user")
-user_with_no_api_token = build_fixture("user_with_no_api_token")
-old_style_codelist = build_fixture("old_style_codelist")
-old_style_version = build_fixture("old_style_version")
-dmd_codelist = build_fixture("dmd_codelist")
-dmd_version_asthma_medication = build_fixture("dmd_version_asthma_medication")
-dmd_version_asthma_medication_alt_headers = build_fixture(
-    "dmd_version_asthma_medication_alt_headers"
-)
-dmd_version_asthma_medication_refill = build_fixture(
-    "dmd_version_asthma_medication_refill"
-)
-bnf_version_asthma = build_fixture("bnf_version_asthma")
-bnf_version_with_search = build_fixture("bnf_version_with_search")
-
-new_style_codelist = build_fixture("new_style_codelist")
-organisation_codelist = build_fixture("organisation_codelist")
-codelist = build_fixture("codelist")
-version_with_no_searches = build_fixture("version_with_no_searches")
-version_with_some_searches = build_fixture("version_with_some_searches")
-version_with_complete_searches = build_fixture("version_with_complete_searches")
-version_with_excluded_codes = build_fixture("version_with_excluded_codes")
-latest_published_version = build_fixture("latest_published_version")
-latest_version = build_fixture("latest_version")
-version = build_fixture("version")
-version_under_review = build_fixture("version_under_review")
-codelist_with_collaborator = build_fixture("codelist_with_collaborator")
-codelist_from_scratch = build_fixture("codelist_from_scratch")
-user_codelist_from_scratch = build_fixture("user_codelist_from_scratch")
-version_from_scratch = build_fixture("version_from_scratch")
-user_codelist = build_fixture("user_codelist")
-user_version = build_fixture("user_version")
-minimal_draft = build_fixture("minimal_draft")
-null_codelist = build_fixture("null_codelist")
 
 
 # These extra fixtures make modifications to those built in build_fixtures
@@ -882,8 +1041,18 @@ def draft(draft_with_complete_searches):
         "version_with_complete_searches",
     ],
 )
-def new_style_version(universe, request):
-    version = universe[request.param]
+def new_style_version(
+    request,
+    version_with_no_searches,
+    version_with_some_searches,
+    version_with_complete_searches,
+):
+    available_versions = {
+        "version_with_no_searches": version_with_no_searches,
+        "version_with_some_searches": version_with_some_searches,
+        "version_with_complete_searches": version_with_complete_searches,
+    }
+    version = available_versions[request.param]
     return type(version).objects.get(pk=version.pk)
 
 
@@ -894,8 +1063,20 @@ def new_style_version(universe, request):
         "version_with_complete_searches",
     ],
 )
-def new_style_draft(universe, request, organisation_user):
-    version = universe[request.param]
+def new_style_draft(
+    organisation_user,
+    request,
+    version_with_no_searches,
+    version_with_some_searches,
+    version_with_complete_searches,
+):
+    available_versions = {
+        "version_with_no_searches": version_with_no_searches,
+        "version_with_some_searches": version_with_some_searches,
+        "version_with_complete_searches": version_with_complete_searches,
+    }
+
+    version = available_versions[request.param]
     return export_to_builder(
         version=version,
         author=organisation_user,
@@ -926,15 +1107,3 @@ def create_codelists(organisation):
         ]
 
     return make_codelist
-
-
-@pytest.fixture
-def icd10_data():
-    path = Path(
-        settings.BASE_DIR,
-        "coding_systems",
-        "icd10",
-        "fixtures",
-        "icd10.icd10_test_20200101.json",
-    )
-    call_command("loaddata", path, database="icd10_test_20200101")

--- a/opencodelists/tests/integration/test_sanitise_backup.py
+++ b/opencodelists/tests/integration/test_sanitise_backup.py
@@ -24,8 +24,8 @@ class TestBackupSanitisation:
     otherwise could have been assumed to be saved there.
     """
 
-    def test_api_keys_removed(self, universe, tmp_path):
-        original_users = [v for v in universe.values() if isinstance(v, User)]
+    def test_api_keys_removed(self, all_fixtures, tmp_path):
+        original_users = User.objects.all()
 
         # Other tests may modify the api_tokens in the db, so save the in-memory users to db
         # and create new tokens for a subset of them.
@@ -45,9 +45,9 @@ class TestBackupSanitisation:
 
         assert api_tokens.isdisjoint(sanitised_tokens)
 
-    def test_user_fields_sanitised(self, universe, tmp_path):
+    def test_user_fields_sanitised(self, all_fixtures, tmp_path):
         personal_data_fields = ["username", "email", "name", "password"]
-        original_users = [v for v in universe.values() if isinstance(v, User)]
+        original_users = User.objects.all()
 
         backup_path = backup_db(tmp_path)
 
@@ -65,7 +65,7 @@ class TestBackupSanitisation:
             sanitised_values = {user[i] for user in sanitised_users}
             assert original_values.isdisjoint(sanitised_values)
 
-    def test_freetexts_replaced(self, universe, tmp_path):
+    def test_freetexts_replaced(self, all_fixtures, universe, tmp_path):
         """
         Test that all Text typed fields in fixtures (where populated)
         have been replaced with sanitised values.
@@ -107,7 +107,7 @@ class TestBackupSanitisation:
 
             assert sanitised_freetexts.isdisjoint(original_freetexts)
 
-    def test_user_references_intact(self, universe, tmp_path):
+    def test_user_references_intact(self, all_fixtures, tmp_path):
         """
         Test that objects owned by users before sanitisation are still owned by them after.
 
@@ -135,8 +135,7 @@ class TestBackupSanitisation:
             ("logentry_set", "django_admin_log", "object_id"),
             ("logentry_set", "django_admin_log", "object_repr"),
         ]
-
-        original_users = [v for v in universe.values() if isinstance(v, User)]
+        original_users = User.objects.all()
 
         original_related_object_counts = {}
         for original_user in original_users:

--- a/opencodelists/tests/views/test_user.py
+++ b/opencodelists/tests/views/test_user.py
@@ -28,6 +28,7 @@ def test_user_codelists(
     organisation_user,
     user_without_organisation,
     codelist_from_scratch,
+    user_codelist,
     user_codelist_from_scratch,
 ):
     test_user = user_without_organisation

--- a/opencodelists/tests/views/test_user_create_codelist.py
+++ b/opencodelists/tests/views/test_user_create_codelist.py
@@ -16,7 +16,9 @@ def test_get_for_user_without_organisation(client, user_without_organisation):
     assert response.status_code == 200
 
 
-def test_post_with_csv(client, organisation_user, disorder_of_elbow_csv_data_no_header):
+def test_post_with_csv(
+    client, organisation_user, snomedct_data, disorder_of_elbow_csv_data_no_header
+):
     client.force_login(organisation_user)
     data = {
         "name": "Test",
@@ -36,7 +38,7 @@ def test_post_with_csv(client, organisation_user, disorder_of_elbow_csv_data_no_
     assert version.author == organisation_user
 
 
-def test_post_without_csv(client, organisation_user):
+def test_post_without_csv(client, organisation_user, snomedct_data):
     client.force_login(organisation_user)
     data = {
         "name": "Test",
@@ -55,7 +57,9 @@ def test_post_without_csv(client, organisation_user):
     assert version.author == organisation_user
 
 
-def test_post_create_organisation_codelist(client, organisation_user, organisation):
+def test_post_create_organisation_codelist(
+    client, organisation_user, snomedct_data, organisation
+):
     client.force_login(organisation_user)
     data = {
         "name": "Test",
@@ -75,7 +79,11 @@ def test_post_create_organisation_codelist(client, organisation_user, organisati
 
 
 def test_post_create_organisation_codelist_with_csv(
-    client, organisation_user, organisation, disorder_of_elbow_csv_data_no_header
+    client,
+    organisation_user,
+    snomedct_data,
+    organisation,
+    disorder_of_elbow_csv_data_no_header,
 ):
     client.force_login(organisation_user)
     data = {
@@ -96,7 +104,7 @@ def test_post_create_organisation_codelist_with_csv(
     assert version.author == organisation_user
 
 
-def test_post_invalid_with_csv(client, organisation_user):
+def test_post_invalid_with_csv(client, organisation_user, snomedct_data):
     client.force_login(organisation_user)
     csv_data = "256307007,Banana (substance)"
     data = {
@@ -113,7 +121,7 @@ def test_post_invalid_with_csv(client, organisation_user):
 
 
 def test_post_invalid_with_csv_multiple_bad_codes(
-    client, organisation_user, disorder_of_elbow_csv_data_no_header
+    client, organisation_user, snomedct_data, disorder_of_elbow_csv_data_no_header
 ):
     client.force_login(organisation_user)
     # Add an invalid entries at line 3, 7, 9; 11 rows in total
@@ -139,7 +147,7 @@ def test_post_invalid_with_csv_multiple_bad_codes(
     )
 
 
-def test_post_invalid_duplicate_name(client, organisation_user):
+def test_post_invalid_duplicate_name(client, organisation_user, user_codelist):
     client.force_login(organisation_user)
     data = {
         "name": "User-owned Codelist",


### PR DESCRIPTION
Addresses #2523.

Replaces the process-level universe fixture that puts instances in the database that persist through the session and builds fixtures to retrieve copies of them with standard pytest-style fixture functions. This is work-in-progress and there's still quite a lot to do but I'd like some feedback on the approach.

The commits could made clearer by separating out moving things around within fixtures.py from other changes and so on. But I haven't spent the time to do that yet. There's still likely to be a Big Commit that changes the approach and fixes the tests. I don't currently think it's worth the effort of adding the new fixtures one at a time in separate commits, and those intermediate steps with a hybrid approach would look a bit confusing.

This means the universe of instances isn't always the same. Fixtures declare which other fixtures they depend upon. Several tests have been modified to explicitly declare things they depend on. I've provided fixtures for "instantiate lots of codelists and versions" where there are tests that want that such as the API tests. There were comments describing things like "this codelist has 4 versions" -- I haven't updated these yet to something more accurate. I also noted those weren't always up-to-date before these changes.

Coding system releases instances are still loaded into the core database once per session (setup_coding_systems). I think this can be improved by having a function-level fixture that loads the coding system release for a specific coding system and depends on the session-level fixtures that load data to the secondary coding system databases.

There are still a handful of test failures I need to resolve.

- codelists/tests/test_api.py has a test that gets a representation of many different codelists and versions including version hashes which are tested for and have changed slightly -- need to work out why they change and whether this can be fixed, the hashes updated, or change the test approach slightly.
- coding_systems/base/tests/test_import_data_utils.py -- possibly dependencies again, was a bit harder to reason about as multiple databases changing.
- opencodelists/tests/integration/test_sanitise_backup.py -- need to tweak how these get the fixtures and iterate through all the instances.
- opencodelists/tests/management/commands/test_setup_local_dev_databases.py -- see next point.

Making this change has knock-on implications I haven't resolved/investigated yet:

- setup_local_dev_databases management command used the fixture building codes to populate some development data -- I think this can just import and call the individual functions in an appropriate order, respecting the dependencies.
- I need to look at the implications on the Playwright fixtures.

I've changed the password hasher in tests to a faster less secure one as we now create users frequently (conftest.py).

The tests currently run a few second faster than before but probably due to the test errors and failures above. But I'm hopeful this approach is approximately as fast as before. We could look at multi-worker pytest-xdist.

We could possibly benefit by having FactoryBoy-style factories for different objects. create_codelists is a factory fixture, for example.

I've removed some asserts that didn't make sense in isolation and that we don't want to run every time the fixture is called (previously they would only have been called once). We could add these back in as tests of the fixtures.

There were two tests where the use of codes fixtures seemed to be the wrong way around between them, I haven't fully understood these yet:

- codelists/tests/test_actions.py::test_create_or_update_codelist_update
- codelists/tests/test_actions.py::test_create_or_update_codelist_update_no_change_to_codes - assert