### PR TITLE
Tomodwyer/fix broken state

### DIFF
--- a/assets/src/scripts/_hierarchy.ts
+++ b/assets/src/scripts/_hierarchy.ts
@@ -305,8 +305,8 @@ class Hierarchy {
         // the same status as it.
         newDepth = depth + 1;
       } else if (
-        this.getDescendants(code).every((d) =>
-          codeToStatus[d].includes(codeToStatus[code]),
+        this.getDescendants(code).every(
+          (d) => codeToStatus[d] === codeToStatus[code],
         )
       ) {
         // All descendants of code have the same status as code.

--- a/assets/src/scripts/_hierarchy.ts
+++ b/assets/src/scripts/_hierarchy.ts
@@ -305,9 +305,16 @@ class Hierarchy {
         // the same status as it.
         newDepth = depth + 1;
       } else if (
-        this.getDescendants(code).every(
-          (d) => codeToStatus[d] === codeToStatus[code],
-        )
+        this.getDescendants(code).every((d) => {
+          // Replace parentheses with empty string to compare direct and
+          // indirect statuses
+          const status1 = codeToStatus[d]?.replace(/[()]/g, "");
+          const status2 = codeToStatus[code]?.replace(/[()]/g, "");
+
+          // If the statuses are the same, then all descendants of code have the
+          // same status as code
+          return status1 === status2;
+        })
       ) {
         // All descendants of code have the same status as code.
         newDepth = 1;


### PR DESCRIPTION
Closes #2532

The original implementation assumes `codeToStatus[d]` is an array, but `codeToStatus` actually maps codes to single status strings like `"+", "-", "(+)", "(-)", "?", or "!"`. Therefore we should directly compare the status codes.

As some of the statuses have brackets around them, we need to use a regex to remove the brackets and correctly compare the statuses.