### PR TITLE
Update the styling and content of the tree row modal

### DIFF
--- a/assets/src/scripts/components/CodelistBuilder.tsx
+++ b/assets/src/scripts/components/CodelistBuilder.tsx
@@ -184,7 +184,7 @@ export default class CodelistBuilder extends React.Component<
               <EmptyState />
             </Col>
           ) : (
-            <Col md="9" className="overflow-auto">
+            <Col md="9">
               <h3 className="h4">{resultsHeading}</h3>
               <hr />
               {treeTables.length > 0 ? (

--- a/assets/src/scripts/components/DescendantToggle.tsx
+++ b/assets/src/scripts/components/DescendantToggle.tsx
@@ -14,7 +14,7 @@ export default function DescendantToggle({
 }: DescendantToggleProps) {
   return (
     <button
-      className="p-0 bg-white border-0 text-monospace d-inline-block ml-1 mr-2"
+      className="p-0 bg-transparent border-0 text-monospace d-inline-block ml-1 mr-2"
       onClick={toggleVisibility.bind(null, path)}
       type="button"
     >

--- a/assets/src/scripts/components/MoreInfoModal.tsx
+++ b/assets/src/scripts/components/MoreInfoModal.tsx
@@ -110,8 +110,9 @@ function MoreInfoModal({
       </Button>
 
       <Modal
-        show={showMoreInfoModal}
+        centered
         onHide={() => setShowMoreInfoModal(false)}
+        show={showMoreInfoModal}
       >
         <Modal.Header closeButton>
           <Modal.Title>

--- a/assets/src/scripts/components/MoreInfoModal.tsx
+++ b/assets/src/scripts/components/MoreInfoModal.tsx
@@ -102,11 +102,11 @@ function MoreInfoModal({
   return (
     <>
       <Button
-        className="py-0 border-0"
+        className="builder__more-info-btn"
         onClick={() => setShowMoreInfoModal(true)}
-        variant="outline-secondary"
+        variant="outline-dark"
       >
-        &hellip;
+        More info
       </Button>
 
       <Modal

--- a/assets/src/scripts/components/TreeRow.tsx
+++ b/assets/src/scripts/components/TreeRow.tsx
@@ -58,11 +58,14 @@ export default function TreeRow({
     "?": "text-body",
   };
 
-  const rowSpacing = pipes.length === 0 ? "mt-2" : "mt-0";
-  const className = `${rowSpacing} d-flex`;
-
   return (
-    <div className={className} data-code={code} data-path={path}>
+    <div
+      className={
+        "builder__row" + (pipes.length === 0 ? " builder__row--mt" : "")
+      }
+      data-code={code}
+      data-path={path}
+    >
       <ButtonGroup>
         <StatusToggle
           code={code}
@@ -87,9 +90,15 @@ export default function TreeRow({
             toggleVisibility={toggleVisibility}
           />
         ) : null}
-        <span className={statusToColour[status]}>{term}</span>
-        <span className="ml-1">
-          (<code>{code}</code>)
+        <span className={statusToColour[status]}>
+          {term}{" "}
+          <code
+            className={
+              status === "-" || status === "(-)" ? "text-secondary" : undefined
+            }
+          >
+            {code}
+          </code>
         </span>
       </div>
 

--- a/assets/src/scripts/components/TreeRow.tsx
+++ b/assets/src/scripts/components/TreeRow.tsx
@@ -49,13 +49,22 @@ export default function TreeRow({
   toggleVisibility,
   updateStatus,
 }: TreeRowProps) {
-  const statusToColour = {
+  const statusTermColor = {
     "+": "text-body",
     "(+)": "text-body",
     "-": "text-secondary",
     "(-)": "text-secondary",
     "!": "text-danger",
     "?": "text-body",
+  };
+
+  const statusCodeColor = {
+    "+": "",
+    "(+)": "",
+    "-": "text-secondary",
+    "(-)": "text-secondary",
+    "!": "text-danger",
+    "?": "",
   };
 
   return (
@@ -90,16 +99,8 @@ export default function TreeRow({
             toggleVisibility={toggleVisibility}
           />
         ) : null}
-        <span className={statusToColour[status]}>
-          {term}{" "}
-          <code
-            className={
-              status === "-" || status === "(-)" ? "text-secondary" : undefined
-            }
-          >
-            {code}
-          </code>
-        </span>
+        <span className={statusTermColor[status]}>{term} </span>
+        <code className={statusCodeColor[status]}>{code}</code>
       </div>
 
       {isEditable ? (

--- a/assets/src/scripts/components/TreeTable.tsx
+++ b/assets/src/scripts/components/TreeTable.tsx
@@ -29,7 +29,7 @@ export default function TreeTable({
   visiblePaths,
 }: TreeTableProps) {
   return (
-    <div className="mb-4">
+    <div className="mb-4 overflow-auto">
       <h5>{heading}</h5>
 
       {ancestorCodes.map((ancestorCode) => (

--- a/assets/src/scripts/components/TreeTable.tsx
+++ b/assets/src/scripts/components/TreeTable.tsx
@@ -31,21 +31,22 @@ export default function TreeTable({
   return (
     <div className="mb-4 overflow-auto">
       <h5>{heading}</h5>
-
-      {ancestorCodes.map((ancestorCode) => (
-        <Tree
-          allCodes={allCodes}
-          ancestorCode={ancestorCode}
-          codeToStatus={codeToStatus}
-          codeToTerm={codeToTerm}
-          hierarchy={hierarchy}
-          isEditable={isEditable}
-          key={ancestorCode}
-          toggleVisibility={toggleVisibility}
-          updateStatus={updateStatus}
-          visiblePaths={visiblePaths}
-        />
-      ))}
+      <div className="builder__container">
+        {ancestorCodes.map((ancestorCode) => (
+          <Tree
+            allCodes={allCodes}
+            ancestorCode={ancestorCode}
+            codeToStatus={codeToStatus}
+            codeToTerm={codeToTerm}
+            hierarchy={hierarchy}
+            isEditable={isEditable}
+            key={ancestorCode}
+            toggleVisibility={toggleVisibility}
+            updateStatus={updateStatus}
+            visiblePaths={visiblePaths}
+          />
+        ))}
+      </div>
     </div>
   );
 }

--- a/assets/src/styles/_builder.css
+++ b/assets/src/styles/_builder.css
@@ -1,3 +1,8 @@
+.builder__container {
+  display: inline-block;
+  min-width: 100%;
+}
+
 .builder__row {
   display: flex;
   align-items: center;

--- a/assets/src/styles/_builder.css
+++ b/assets/src/styles/_builder.css
@@ -1,0 +1,33 @@
+.builder__row {
+  display: flex;
+  align-items: center;
+  min-width: fit-content;
+  padding: 0.1rem 0.25rem 0.1rem 0;
+  margin-top: 0;
+  position: relative;
+}
+
+.builder__row:hover {
+  background-color: #eff9ff;
+}
+
+.builder__row--mt {
+  margin-top: 0.5rem;
+}
+
+.builder__more-info-btn {
+  font-size: 0.8rem;
+  line-height: 1;
+  margin: 0 0 0 0.5rem;
+  padding: 0.125rem 0.25rem;
+  transition-duration: 0s;
+  white-space: nowrap;
+}
+
+.builder__row:not(:hover) .builder__more-info-btn {
+  background: transparent;
+  border: none;
+  box-shadow: none;
+  color: transparent;
+  pointer-events: none;
+}

--- a/assets/src/styles/base.css
+++ b/assets/src/styles/base.css
@@ -1,3 +1,4 @@
+@import "./_builder.css";
 @import "./_tree.css";
 
 html {


### PR DESCRIPTION
Closes https://github.com/opensafely-core/opencodelists/issues/2555

Changes made as part of this PR:

- Overflow scrolling is moved to a per section basis, so the whole page no longer scrolls horizontally for one particularly long code name
- The more info modal button now displays the text "More info"
  - This button only shows on hover of a row
  - The row that is being hovered has a background to highlight it
- To simplify the visual design, the brackets have been removed from around the code, and the colouring has been updated to more clearly identify the codes which have been excluded, or are in conflict

## Screenshots and video

### Before

![](https://github.com/user-attachments/assets/a90322de-b94c-4fb3-a17d-57ee46758bda)

### After

![](https://github.com/user-attachments/assets/0f6e0fad-5284-45e0-89de-4d5239aa1a55)

https://github.com/user-attachments/assets/d65c2471-c740-4631-9357-3ffb457dea42