### PR TITLE
Fix for builder in broken state

### DIFF
--- a/assets/src/scripts/_hierarchy.ts
+++ b/assets/src/scripts/_hierarchy.ts
@@ -306,7 +306,7 @@ class Hierarchy {
         newDepth = depth + 1;
       } else if (
         this.getDescendants(code).every((d) =>
-          codeToStatus[d].includes(codeToStatus[code]),
+          codeToStatus[d]?.includes(codeToStatus[code]),
         )
       ) {
         // All descendants of code have the same status as code.


### PR DESCRIPTION
Part of #2532 - but does not close the issue ([see comment](https://github.com/opensafely-core/opencodelists/issues/2532#issuecomment-2949199590)).

This simply fixes the issue of the React builder app crashing, so that users can potentially get themselves out of the broken state. it does not fix the underlying code issues.