### PR TITLE
Move cached hierarchy checking to view wrapper

### DIFF
--- a/codelists/views/decorators.py
+++ b/codelists/views/decorators.py
@@ -64,9 +64,12 @@ def load_version(view_fn):
         if version.is_draft:
             return redirect(version.get_builder_draft_url())
         else:
-            rsp = view_fn(request, version, **view_kwargs)
-            if version.pk and version.has_hierarchy and version.hierarchy.dirty:
+            if version.pk and (
+                not hasattr(version, "cached_hierarchy")
+                or (version.has_hierarchy and version.hierarchy.dirty)
+            ):
                 cache_hierarchy(version=version)
+            rsp = view_fn(request, version, **view_kwargs)
             return rsp
 
     return wrapped_view

--- a/codelists/views/version.py
+++ b/codelists/views/version.py
@@ -2,7 +2,6 @@ from django.contrib import messages
 from django.shortcuts import render
 from django.utils.html import format_html
 
-from ..actions import cache_hierarchy
 from ..models import Status
 from ..presenters import present_search_results
 from ..tree_data import build_tree_data
@@ -19,8 +18,6 @@ def version(request, clv):
     if clv.coding_system.is_builder_compatible():
         coding_system = clv.coding_system
 
-        if not hasattr(clv, "cached_hierarchy"):
-            cache_hierarchy(version=clv)
         hierarchy = clv.codeset.hierarchy
         child_map = {c: list(pp) for c, pp in hierarchy.child_map.items()}
         code_to_term = coding_system.code_to_term(hierarchy.nodes)


### PR DESCRIPTION
f299bfb added a check to see if a codelist version had a cached_hierarchy and to build one if not to the codelist version view.

This was an adequate solution for the view in question, and if users got to the csv download link via this page. However, going directly to the csv download (as would be done by OpenSAFELY CLI for example) would result in a 500 error.

This commit moves the check to the codelist version view wrapper such that in all cases the cached_hierarchy check/build is run.

Fixes #2619 