### PR TITLE
Jongmassey/update dmd codelist headers

### DIFF
--- a/codelists/models.py
+++ b/codelists/models.py
@@ -503,6 +503,7 @@ class CodelistVersion(models.Model):
             # check the headers to identify the most likely one
             # These represent the valid case-insensitive code column names across all existing
             # old-style codelists
+            ix = 0
             for header in [
                 "ctv3id",
                 "ctv3code",
@@ -534,8 +535,6 @@ class CodelistVersion(models.Model):
                             ix = headers.index(header)
                             rows.append([header])
                             break
-                else:
-                    ix = 0
 
             return tuple(sorted({row[ix] for row in rows}))
 

--- a/codelists/models.py
+++ b/codelists/models.py
@@ -510,6 +510,7 @@ class CodelistVersion(models.Model):
                 "ctv3_id",
                 "snomedct_id",
                 "snomedcode",
+                "snomed_id",
                 "dmd",
                 "dmd_id",
                 "icd10",


### PR DESCRIPTION
Two bugs:
* the code didn't fall correctly into the default case of ix=0 when trying to derive the header index for the "id" column
* there were some existing dm+d codelists with "snomed_id" as the "id" column header and this value was not added to the list of known headers

Fixes #2622