### PR TITLE
Show "no search term" when last search deleted

### DIFF
--- a/builder/views.py
+++ b/builder/views.py
@@ -90,7 +90,7 @@ def _draft(request, draft, search_id):
         for s in draft.searches.order_by("term")
     ]
 
-    if searches and draft.code_objs.filter(results=None).exists():
+    if draft.code_objs.filter(results=None).exists():
         searches.append(
             {
                 "term_or_code": "[no search term]",


### PR DESCRIPTION
Fixes #2534.

The previous behaviour was such that:

1. Enter a search.
1. That search appears in the list of searches.
1. Select a code.
1. Delete the search.
1. See no searches listed at all.
1. Search again.
1. See your search and "no search term" then appear as a search.

This commit changes the behaviour so that "no search term" appears even
with no other valid searches. This makes the UI more consistent by not
making "no search term" appear when you actually enter another search.