### PR TITLE
Allow users to edit metadata in the draft phase of a codelist

### DIFF
--- a/assets/src/scripts/__tests__/fixtures/version_from_scratch.json
+++ b/assets/src/scripts/__tests__/fixtures/version_from_scratch.json
@@ -912,6 +912,15 @@
     },
     "organisation_name": "Test University",
     "codelist_full_slug": "test-university/new-style-codelist",
-    "hash": "3ce9e642"
+    "hash": "3ce9e642",
+    "description":{
+      "text": "",
+      "html": ""
+    },
+    "methodology":{
+      "text": "",
+      "html": ""
+    },
+    "references": []
   }
 }

--- a/assets/src/scripts/__tests__/fixtures/version_with_complete_searches.json
+++ b/assets/src/scripts/__tests__/fixtures/version_with_complete_searches.json
@@ -912,6 +912,15 @@
     },
     "organisation_name": "Test University",
     "codelist_full_slug": "test-university/new-style-codelist",
-    "hash": "3ce9e642"
+    "hash": "3ce9e642",
+    "description":{
+      "text": "",
+      "html": ""
+    },
+    "methodology":{
+      "text": "",
+      "html": ""
+    },
+    "references": []
   }
 }

--- a/assets/src/scripts/__tests__/fixtures/version_with_no_searches.json
+++ b/assets/src/scripts/__tests__/fixtures/version_with_no_searches.json
@@ -498,6 +498,15 @@
     },
     "organisation_name": "Test University",
     "codelist_full_slug": "test-university/new-style-codelist",
-    "hash": "6f08ccac"
+    "hash": "6f08ccac",
+    "description":{
+      "text": "",
+      "html": ""
+    },
+    "methodology":{
+      "text": "",
+      "html": ""
+    },
+    "references": []
   }
 }

--- a/assets/src/scripts/__tests__/fixtures/version_with_some_searches.json
+++ b/assets/src/scripts/__tests__/fixtures/version_with_some_searches.json
@@ -521,6 +521,15 @@
     },
     "organisation_name": "Test University",
     "codelist_full_slug": "test-university/new-style-codelist",
-    "hash": "55f95977"
+    "hash": "55f95977",
+    "description":{
+      "text": "",
+      "html": ""
+    },
+    "methodology":{
+      "text": "",
+      "html": ""
+    },
+    "references": []
   }
 }

--- a/assets/src/scripts/components/CodelistBuilder.tsx
+++ b/assets/src/scripts/components/CodelistBuilder.tsx
@@ -39,6 +39,30 @@ interface CodelistBuilderProps extends PageData {
   };
 }
 
+/**
+ * Creates a fetch options object with standard headers including CSRF token
+ * @param body - Object to be sent as JSON in the request body
+ * @returns Fetch options object configured for POST requests
+ */
+function getFetchOptions(body: object) {
+  const requestHeaders = new Headers();
+  requestHeaders.append("Accept", "application/json");
+  requestHeaders.append("Content-Type", "application/json");
+
+  const csrfCookie = getCookie("csrftoken");
+  if (csrfCookie) {
+    requestHeaders.append("X-CSRFToken", csrfCookie);
+  }
+  const fetchOptions = {
+    method: "POST",
+    credentials: "include" as RequestCredentials,
+    mode: "same-origin" as RequestMode,
+    headers: requestHeaders,
+    body: JSON.stringify(body),
+  };
+  return fetchOptions;
+}
+
 export default class CodelistBuilder extends React.Component<
   CodelistBuilderProps,
   {
@@ -115,22 +139,9 @@ export default class CodelistBuilder extends React.Component<
   }
 
   postUpdates() {
-    const requestHeaders = new Headers();
-    requestHeaders.append("Accept", "application/json");
-    requestHeaders.append("Content-Type", "application/json");
+    const fetchOptions = getFetchOptions({ updates: this.state.updateQueue });
 
-    const csrfCookie = getCookie("csrftoken");
-    if (csrfCookie) {
-      requestHeaders.append("X-CSRFToken", csrfCookie);
-    }
-
-    fetch(this.props.updateURL, {
-      method: "POST",
-      credentials: "include",
-      mode: "same-origin",
-      headers: requestHeaders,
-      body: JSON.stringify({ updates: this.state.updateQueue }),
-    })
+    fetch(this.props.updateURL, fetchOptions)
       .then((response) => response.json())
       .then((data) => {
         const lastUpdates = data.updates;
@@ -215,22 +226,8 @@ export default class CodelistBuilder extends React.Component<
           ? this.textareaRefs[field].current?.value
           : this.state.metadata.methodology.text,
     };
-    const requestHeaders = new Headers();
-    requestHeaders.append("Accept", "application/json");
-    requestHeaders.append("Content-Type", "application/json");
 
-    const csrfCookie = getCookie("csrftoken");
-    if (csrfCookie) {
-      requestHeaders.append("X-CSRFToken", csrfCookie);
-    }
-
-    const fetchOptions = {
-      method: "POST",
-      credentials: "include" as RequestCredentials,
-      mode: "same-origin" as RequestMode,
-      headers: requestHeaders,
-      body: JSON.stringify(updateBody),
-    };
+    const fetchOptions = getFetchOptions(updateBody);
 
     try {
       fetch(this.props.updateURL, fetchOptions)

--- a/assets/src/scripts/components/CodelistBuilder.tsx
+++ b/assets/src/scripts/components/CodelistBuilder.tsx
@@ -56,6 +56,7 @@ function ReferenceForm({
           ref={textInputRef}
           type="text"
           defaultValue={reference.text}
+          placeholder="Text to display"
         />
       </Form.Group>
       <Form.Group className="mb-3">
@@ -64,6 +65,7 @@ function ReferenceForm({
           ref={urlInputRef}
           type="url"
           defaultValue={reference.url}
+          placeholder="URL to link to"
         />
       </Form.Group>
       <div className="mt-2 d-flex flex-row justify-content-end">
@@ -447,7 +449,7 @@ export default class CodelistBuilder extends React.Component<
     const draftContent = this.state.metadata[field].text;
 
     return (
-      <Form.Group className="card" controlId={field}>
+      <Form.Group className={`card ${field}`} controlId={field}>
         <div className="card-body">
           <div className="card-title d-flex flex-row justify-content-between align-items-center">
             <Form.Label className="h5" as="h3">
@@ -459,6 +461,7 @@ export default class CodelistBuilder extends React.Component<
                   type="button"
                   className="btn btn-primary btn-sm"
                   onClick={() => this.handleSave(field)}
+                  title={`Save ${field}`}
                 >
                   Save
                 </button>
@@ -466,6 +469,7 @@ export default class CodelistBuilder extends React.Component<
                   type="button"
                   className="btn btn-secondary btn-sm ml-2"
                   onClick={() => this.handleCancel(field)}
+                  title={`Cancel ${field} edit`}
                 >
                   Cancel
                 </button>

--- a/opencodelists/templatetags/markdown_filter.py
+++ b/opencodelists/templatetags/markdown_filter.py
@@ -7,8 +7,10 @@ from django.conf import settings
 register = template.Library()
 
 
-@register.filter
-def markdown_filter(text):
+def _convert_markdown_to_html(text):
+    """Internal function to convert markdown to HTML."""
+    if not text:
+        return ""
     text = markdown2.markdown(text)
     html = nh3.clean(
         text,
@@ -16,3 +18,15 @@ def markdown_filter(text):
         attributes=settings.MARKDOWN_FILTER_ALLOWLIST_ATTRIBUTES,
     )
     return html
+
+
+@register.filter
+def markdown_filter(text):
+    """Template filter to convert markdown to safe HTML."""
+    return _convert_markdown_to_html(text)
+
+
+# Function to use in Python code
+def render_markdown(text):
+    """Direct function to convert markdown to HTML for use in Python code."""
+    return _convert_markdown_to_html(text)


### PR DESCRIPTION
A draft codelist now has a metadata tab where users can edit the description/methodology/references sections of the metadata. It looks like this:

[Screencast from 12-06-25 15:22:56.webm](https://github.com/user-attachments/assets/96bd8edf-cad7-4582-ab22-cd488ff11af4)
