### PR TITLE
Pin minimum version of `requests` package to 2.32.4

### DIFF
--- a/requirements.dev.in
+++ b/requirements.dev.in
@@ -12,6 +12,7 @@ pytest-cov
 pytest-django
 pytest-playwright
 responses
+requests>=2.32.4 # mimmum version for security patch
 
 # dev
 litecli

--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -737,11 +737,12 @@ pyyaml==6.0.2 \
     #   -c /home/runner/work/opencodelists/opencodelists/requirements.prod.txt
     #   pre-commit
     #   responses
-requests==2.32.3 \
-    --hash=sha256:55365417734eb18255590a9ff9eb97e9e1da868d4ccd6402399eaf68af20a760 \
-    --hash=sha256:70761cfe03c773ceb22aa2f671b4757976145175cdfca038c02654d061d6dcc6
+requests==2.32.4 \
+    --hash=sha256:27babd3cda2a6d50b30443204ee89830707d396671944c998b5975b031ac2b2c \
+    --hash=sha256:27d0316682c8a29834d3264820024b62a36942083d52caf2f14c0591336d3422
     # via
     #   -c /home/runner/work/opencodelists/opencodelists/requirements.prod.txt
+    #   -r requirements.dev.in
     #   pytest-base-url
     #   responses
 responses==0.25.7 \

--- a/requirements.prod.in
+++ b/requirements.prod.in
@@ -35,3 +35,4 @@ sqlean.py
 structlog
 tqdm
 slippers
+requests>=2.32.4 # mimmum version for security patch

--- a/requirements.prod.txt
+++ b/requirements.prod.txt
@@ -714,10 +714,11 @@ pyyaml==6.0.2 \
     --hash=sha256:f753120cb8181e736c57ef7636e83f31b9c0d1722c516f7e86cf15b7aa57ff12 \
     --hash=sha256:ff3824dc5261f50c9b0dfb3be22b4567a6f938ccce4587b38952d85fd9e9afe4
     # via slippers
-requests==2.32.3 \
-    --hash=sha256:55365417734eb18255590a9ff9eb97e9e1da868d4ccd6402399eaf68af20a760 \
-    --hash=sha256:70761cfe03c773ceb22aa2f671b4757976145175cdfca038c02654d061d6dcc6
+requests==2.32.4 \
+    --hash=sha256:27babd3cda2a6d50b30443204ee89830707d396671944c998b5975b031ac2b2c \
+    --hash=sha256:27d0316682c8a29834d3264820024b62a36942083d52caf2f14c0591336d3422
     # via
+    #   -r requirements.prod.in
     #   django-anymail
     #   opentelemetry-exporter-otlp-proto-http
 sentry-sdk==2.29.1 \


### PR DESCRIPTION
Dependabot want to use requests>=2.32.4 to fix a security vulnerability for both dev and prod, but can't bump it past 2.32.3. I'm not sure why because all the dependencies (django-anymail, and opentelemetry-exporter for prod at least) are pinned to compatible ranges (~=2.7 and >=2.4.3). Manually forcing it to use >=2.32.4 to get round this.