### PR TITLE
Remove stray duplicated comment

### DIFF
--- a/coding_systems/versioning/urls.py
+++ b/coding_systems/versioning/urls.py
@@ -5,8 +5,4 @@ from . import views
 
 app_name = "versioning"
 
-urlpatterns = [
-    # There was a typo in the codelist names.  If this happens a lot, we could
-    # add a "formerly known as" field to Codelist.
-    path("latest-releases", views.latest_releases, name="latest_releases")
-]
+urlpatterns = [path("latest-releases", views.latest_releases, name="latest_releases")]


### PR DESCRIPTION
This comment doesn't belong here; it seems like it's been copied-pasted in error from the identical comment in `codelists/urls.py` which explains some ad hoc redirect URL patterns.