### PR TITLE
Include dev dependencies in node-builder image

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -45,11 +45,12 @@ RUN --mount=type=cache,target=/usr/src/app/.npm \
     npm set cache /usr/src/app/.npm && \
     npm ci --include=dev
 
+
 # just copy in the files `npm run build` needs
 COPY vite.config.mjs ./
 COPY assets/src ./assets/src
 COPY templates ./templates
-RUN --mount=type=cache,target=/usr/src/app/.npm npm run build
+RUN --mount=type=cache,target=./npm npm run build
 
 ##################################################
 #

--- a/package.json
+++ b/package.json
@@ -3,8 +3,8 @@
   "scripts": {
     "build": "vite build",
     "dev": "vite",
-    "lint:fix": "biome check --write ./assets/src/**/*",
-    "lint": "biome check ./assets/src/**/*",
+    "lint:fix": "npx @biomejs/biome check --write ./assets/src/**/*",
+    "lint": "npx @biomejs/biome check ./assets/src/**/*",
     "serve": "vite preview",
     "test": "vitest run",
     "test:watch": "vitest",


### PR DESCRIPTION
The node-builder image is used for linting and testing. Both of which use devDependencies. We change the image so that we don't need to use the `npx` commands which were starting to install the wrong versions.

The actual production build does not use node-builder, other than to copy the assets dir, so this is safe to do.