### PR TITLE
Fix npm just commands in CI

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -3,7 +3,10 @@
   "vcs": { "enabled": true, "clientKind": "git", "useIgnoreFile": true },
   "files": {
     "ignoreUnknown": false,
-    "ignore": ["./assets/src/scripts/__tests__/fixtures"]
+    "ignore": [
+      "./assets/src/scripts/__tests__/fixtures",
+      "./assets/src/scripts/coverage/"
+    ]
   },
   "formatter": {
     "enabled": true,

--- a/docker/justfile
+++ b/docker/justfile
@@ -26,8 +26,7 @@ build env="dev":
 
 # run JS linter
 check-js:
-    docker compose run --rm node-assets npm run typecheck && npm run lint
-
+    docker compose run --rm node-assets bash -c "npm run typecheck && npm run lint:ci"
 
 # run python checks
 check-py env="dev": build
@@ -54,7 +53,7 @@ test-functional *args="":
     -m "functional" {{ args }}
 
 test-js:
-    docker compose run --rm node-assets npm run test
+    docker compose run --rm node-assets bash -c "npm run test:coverage"
 
 test: test-js test-py test-functional
 

--- a/justfile
+++ b/justfile
@@ -204,7 +204,7 @@ assets-install *args="":
     # but we negate with || to avoid error exit code
     test package-lock.json -nt node_modules/.written || exit 0
 
-    npm ci {{ args }}
+    npm ci --include=dev {{ args }}
     touch node_modules/.written
 
 

--- a/package.json
+++ b/package.json
@@ -3,13 +3,13 @@
   "scripts": {
     "build": "vite build",
     "dev": "vite",
-    "lint:fix": "npx @biomejs/biome check --write ./assets/src/**/*",
-    "lint": "npx @biomejs/biome check ./assets/src/**/*",
+    "lint:fix": "biome check --write ./assets/src/**/*",
+    "lint": "biome check ./assets/src/**/*",
     "serve": "vite preview",
-    "test": "npx vitest run",
-    "test:watch": "npx vitest",
-    "test:coverage": "npx vitest run --coverage",
-    "test:single": "npx vitest -t",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "test:coverage": "vitest run --coverage",
+    "test:single": "vitest -t",
     "typecheck": "tsc -p ./"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
     "dev": "vite",
     "lint:fix": "biome check --write ./assets/src/**/*",
     "lint": "biome check ./assets/src/**/*",
+    "lint:ci": "biome ci ./assets/src/**/*",
     "serve": "vite preview",
     "test": "vitest run",
     "test:watch": "vitest",


### PR DESCRIPTION
The npm commands when running in CI were using `npx` to download a different version of dependencies than are being specified in the `package-lock.json` file. 

This PR:

- Removes the need for `npx` to run the npm scripts
- Makes sure that CI and local builds install the dev dependencies (`--include=dev`)
- Adds a `lint:ci` npm script for running Biome in CI mode