### PR TITLE
Use dynamic date in test data

### DIFF
--- a/codelists/tests/test_api.py
+++ b/codelists/tests/test_api.py
@@ -112,7 +112,7 @@ def test_codelists_get(client, organisation):
                     "full_slug": "test-university/dmd-codelist/69a34cc0",
                     "status": "under review",
                     "downloadable": False,
-                    "updated_date": "2025-06-20",
+                    "updated_date": today,
                 },
             ],
         },


### PR DESCRIPTION
This worked on Friday because it was using Friday's date. Now updated to use a dynamic date to match the other test data.