### PR TITLE
Improve the styling of the My Codelists page

### DIFF
--- a/assets/src/scripts/codelists-list.js
+++ b/assets/src/scripts/codelists-list.js
@@ -1,0 +1,129 @@
+/*
+ * Interactivity for the codelist table.
+ *
+ * Each row in the table represents a single codelist. The behaviour changes
+ * depending on whether the codelist has one visible version, or multiple
+ * visible versions. A codelist can have just a single version when:
+ *  - viewing the latest published versions for another user
+ *  - if a codelist only has one version
+ *  - if filtering the table leads to just one version (e.g. filtering to drafts)
+ *
+ * When just one version is visible then we want the whole row to highlight on
+ * hover, and clicking anywhere in the row open that version. If multiple
+ * versions are visible, then the hover behaviour should only occur in the nested
+ * table containing the versions.
+ *
+ * This file has the logic for the above, and for the search box filtering.
+ */
+
+// Get all the codelist rows into a data array for future use
+const codelistRows = Array.from(
+  document.querySelectorAll(".table-codelist > tbody > tr"),
+).map((element) => {
+  const versionRows = Array.from(element.querySelectorAll("table tr"));
+  return {
+    element,
+    text: element.dataset.codelistText.toLowerCase(),
+    datasetId: element.dataset.codelistId,
+    versions: versionRows.map((element) => {
+      return {
+        element,
+        text: element.dataset.versionText.toLowerCase(),
+      };
+    }),
+    visibleVersions: versionRows.length,
+  };
+});
+
+// We apply the search box filtering:
+// - on initial page load
+// - on the keyup event in the search box
+// - if we navigate back to this page and it is loaded from the cache
+const searchInputEl = document.getElementById("searchInput");
+applyFiltering();
+searchInputEl.addEventListener("keyup", function () {
+  applyFiltering();
+});
+window.addEventListener("pageshow", function (event) {
+  // Only apply if event.persisted i.e. page load is from a cache
+  if (event.persisted) {
+    searchInputEl.focus();
+    applyFiltering();
+  }
+});
+
+// Add click handler for rows
+codelistRows.forEach((codelistRow) => {
+  // Add a click handler for parent row - but only if either no versions (so
+  // it's the that_user page), or if only one currently visible version
+  codelistRow.element.addEventListener("click", function (e) {
+    // Don't trigger if they actually clicked the link
+    if (e.target.tagName.toLowerCase() !== "a") {
+      if (codelistRow.visibleVersions < 2) {
+        // Find and click the link in this row
+        const link = this.querySelector("tr:not(.hidden-row) > td > a");
+        if (link) link.click();
+      }
+    }
+  });
+
+  codelistRow.versions.forEach((versionRow) => {
+    versionRow.element.addEventListener("click", function (e) {
+      // Don't trigger if they actually clicked the link
+      if (e.target.tagName.toLowerCase() !== "a") {
+        // Find and click the link in this row
+        const link = this.querySelector("tr:not(.hidden-row) > td > a");
+        if (link) link.click();
+      }
+    });
+  });
+});
+
+// Helper function to check if all search words are included in a given text
+function matchesAllWords(text, words) {
+  return words.every((word) => text.includes(word));
+}
+
+function applyFiltering() {
+  const searchWords = searchInputEl.value.toLowerCase().trim().split(/\s+/);
+  codelistRows.forEach((row) => {
+    // Does this codelist match all of the words in the search?
+    // This matches the "codelist" level attributes (name, coding system, etc.)
+    // It does not consider version-specific attributes (draft, under review etc).
+    let codelistMatchesSearch = matchesAllWords(row.text, searchWords);
+
+    row.visibleVersions = 0;
+    row.versions.forEach((versionRow) => {
+      // A version matches if all search words are found in the combined text
+      // of the codelist row and the version row.
+      const combinedText = `${row.text} ${versionRow.text}`;
+      const versionMatchesSearch = matchesAllWords(combinedText, searchWords);
+
+      // If the codelist itself matches, or this specific version matches, show
+      // the version row.
+      if (codelistMatchesSearch || versionMatchesSearch) {
+        versionRow.element.classList.remove("hidden-row");
+      }
+      if (versionMatchesSearch) {
+        row.visibleVersions++;
+      } else {
+        versionRow.element.classList.add("hidden-row");
+      }
+    });
+
+    if (codelistMatchesSearch || row.visibleVersions > 0) {
+      // Display the main codelist row if its own text matches the search, or
+      // if any of its versions are visible after filtering.
+      row.element.classList.remove("hidden-row");
+    } else {
+      row.element.classList.add("hidden-row");
+    }
+
+    // Add/remove class for styling based on the number of visible versions.
+    if (row.visibleVersions < 2) {
+      row.element.classList.add("single-version-row");
+    } else {
+      row.element.classList.remove("single-version-row");
+    }
+  });
+}

--- a/assets/src/styles/_codelists_list.css
+++ b/assets/src/styles/_codelists_list.css
@@ -1,0 +1,54 @@
+/*
+ * CODELIST TABLE
+ *
+ * Displays a list of codelists. If a codelist has multiple versions these are
+ * displayed as nested rows.
+ */
+
+/*
+ * We only want the main codelist rows to have a border, so we remove all cell
+ * borders
+ */
+.table-codelist td {
+  border: 0;
+}
+
+/*
+ * Reduce the padding to increase the number of codelists visible on page
+ */
+.table-codelist tbody td,
+.table-codelist thead th {
+  padding: 0.1rem 0.3rem;
+}
+
+/*
+ * Each non-nested row is for a single codelist. This marks the boundary
+ * between each one
+ */
+.table-codelist > tbody > tr {
+  border-bottom: 1px solid rgba(0, 0, 0, 0.1);
+}
+
+/*
+ * If we're hovering a nested row (a codelist version), OR a row that only
+ * contains a single version, then we want the hyperlink in that row to
+ * highlight, a background color and cursor pointer to show that clicking is a
+ * thing.
+ */
+.table-codelist tbody tr.single-version-row:hover a,
+.table-nested tbody tr:hover a {
+  text-decoration: underline;
+}
+
+.table-codelist tbody tr.single-version-row:hover,
+.table-nested tbody tr:hover {
+  cursor: pointer;
+  background-color: rgb(248, 255, 145);
+}
+
+/*
+ * To hide rows not included in the current search filter
+ */
+.table-codelist .hidden-row {
+  display: none;
+}

--- a/assets/src/styles/base.css
+++ b/assets/src/styles/base.css
@@ -1,4 +1,5 @@
 @import "./_builder.css";
+@import "./_codelists_list.css";
 @import "./_tree.css";
 
 html {

--- a/opencodelists/tests/functional/test_build_codelist.py
+++ b/opencodelists/tests/functional/test_build_codelist.py
@@ -312,8 +312,8 @@ def verify_codelist_csv(navigator, search_actions, initial_page_navigation=True)
 )
 @pytest.mark.parametrize(
     # Test with a non-organisation user login, and then organisation user login.
-    "login_context_fixture_name",
-    ["non_organisation_login_context", "organisation_login_context"],
+    "username, org",
+    [("non_org_user", None), ("org_user", "Test University")],
 )
 @pytest.mark.django_db(
     databases=[
@@ -323,15 +323,16 @@ def verify_codelist_csv(navigator, search_actions, initial_page_navigation=True)
     transaction=True,
 )
 def test_build_snomedct_codelist_single_search(
-    login_context_fixture_name,
+    username,
+    org,
+    login_context_for_user,
     search,
     navigate_to_page,
-    request,
     live_server,
     snomedct_data,
 ):
     page = setup_playwright_page(
-        login_context=request.getfixturevalue(login_context_fixture_name),
+        login_context=login_context_for_user(username, org),
         url=live_server.url,
     )
 
@@ -403,8 +404,8 @@ def test_build_snomedct_codelist_single_search(
 )
 @pytest.mark.parametrize(
     # Test with a non-organisation user login, and then organisation user login.
-    "login_context_fixture_name",
-    ["non_organisation_login_context", "organisation_login_context"],
+    "username, org",
+    [("non_org_user", None), ("org_user", "Test University")],
 )
 @pytest.mark.django_db(
     databases=[
@@ -414,10 +415,16 @@ def test_build_snomedct_codelist_single_search(
     transaction=True,
 )
 def test_build_bnf_codelist_single_search(
-    login_context_fixture_name, search, navigate_to_page, request, live_server, bnf_data
+    username,
+    org,
+    login_context_for_user,
+    search,
+    navigate_to_page,
+    live_server,
+    bnf_data,
 ):
     page = setup_playwright_page(
-        login_context=request.getfixturevalue(login_context_fixture_name),
+        login_context=login_context_for_user(username, org),
         url=live_server.url,
     )
 
@@ -484,8 +491,8 @@ def test_build_bnf_codelist_single_search(
 )
 @pytest.mark.parametrize(
     # Test with a non-organisation user login, and then organisation user login.
-    "login_context_fixture_name",
-    ["non_organisation_login_context", "organisation_login_context"],
+    "username, org",
+    [("non_org_user", None), ("org_user", "Test University")],
 )
 @pytest.mark.django_db(
     databases=[
@@ -495,10 +502,15 @@ def test_build_bnf_codelist_single_search(
     transaction=True,
 )
 def test_build_snomedct_codelist_two_searches_no_selections(
-    login_context_fixture_name, navigate_to_page, request, live_server, snomedct_data
+    username,
+    org,
+    login_context_for_user,
+    navigate_to_page,
+    live_server,
+    snomedct_data,
 ):
     page = setup_playwright_page(
-        login_context=request.getfixturevalue(login_context_fixture_name),
+        login_context=login_context_for_user(username, org),
         url=live_server.url,
     )
 
@@ -545,8 +557,8 @@ def test_build_snomedct_codelist_two_searches_no_selections(
 )
 @pytest.mark.parametrize(
     # Test with a non-organisation user login, and then organisation user login.
-    "login_context_fixture_name",
-    ["non_organisation_login_context", "organisation_login_context"],
+    "username, org",
+    [("non_org_user", None), ("org_user", "Test University")],
 )
 @pytest.mark.django_db(
     databases=[
@@ -556,10 +568,15 @@ def test_build_snomedct_codelist_two_searches_no_selections(
     transaction=True,
 )
 def test_build_snomedct_codelist_two_searches(
-    login_context_fixture_name, navigate_to_page, request, live_server, snomedct_data
+    username,
+    org,
+    login_context_for_user,
+    navigate_to_page,
+    live_server,
+    snomedct_data,
 ):
     page = setup_playwright_page(
-        login_context=request.getfixturevalue(login_context_fixture_name),
+        login_context=login_context_for_user(username, org),
         url=live_server.url,
     )
 
@@ -660,8 +677,8 @@ def test_build_snomedct_codelist_two_searches(
 )
 @pytest.mark.parametrize(
     # Test with a non-organisation user login, and then organisation user login.
-    "login_context_fixture_name",
-    ["non_organisation_login_context", "organisation_login_context"],
+    "username, org",
+    [("non_org_user", None), ("org_user", "Test University")],
 )
 @pytest.mark.django_db(
     databases=[
@@ -671,10 +688,16 @@ def test_build_snomedct_codelist_two_searches(
     transaction=True,
 )
 def test_build_dmd_codelist_single_search(
-    login_context_fixture_name, search, navigate_to_page, request, live_server, dmd_data
+    username,
+    org,
+    login_context_for_user,
+    search,
+    navigate_to_page,
+    live_server,
+    dmd_data,
 ):
     page = setup_playwright_page(
-        login_context=request.getfixturevalue(login_context_fixture_name),
+        login_context=login_context_for_user(username, org),
         url=live_server.url,
     )
 

--- a/opencodelists/tests/functional/test_build_codelist.py
+++ b/opencodelists/tests/functional/test_build_codelist.py
@@ -313,6 +313,20 @@ def verify_codelist_csv(navigator, search_actions, initial_page_navigation=True)
     assert codelist_table_from_csv == search_actions.expected_codelist_table
 
 
+def create_new_version(navigator, version_tag, initial_page_navigation=True):
+    """Take a Navigator, and create a new verion of a published codelist."""
+
+    if initial_page_navigation:
+        navigator.go_to_codelist()
+
+    navigator.page.get_by_role("button", name="Create new version").click()
+
+    # update version id
+    navigator.codelist_version_tags[version_tag] = navigator.page.locator(
+        ":text('Version ID') + dd"
+    ).text_content()
+
+
 @pytest.mark.parametrize(
     # Test either by always explicitly navigating to the page that's needed,
     # or follow on from previous navigations where possible.
@@ -403,6 +417,23 @@ def test_build_snomedct_codelist_single_search(
     )
 
     verify_codelist_csv(navigator, search_actions, initial_page_navigation=True)
+
+    create_new_version(navigator, "second_version", initial_page_navigation=False)
+
+    validate_codelist_exists_on_site(
+        navigator,
+        Status.PUBLISHED,
+        username,
+        version_tag=DEFAULT_VERSION_TAG,
+        initial_page_navigation=True,
+    )
+    validate_codelist_exists_on_site(
+        navigator,
+        Status.DRAFT,
+        username,
+        version_tag="second_version",
+        initial_page_navigation=True,
+    )
 
 
 @pytest.mark.parametrize(

--- a/opencodelists/tests/functional/test_build_codelist.py
+++ b/opencodelists/tests/functional/test_build_codelist.py
@@ -1,6 +1,6 @@
 import csv
-from dataclasses import dataclass
-from enum import Enum, StrEnum, auto
+from dataclasses import dataclass, field
+from enum import Enum, auto
 from functools import cached_property
 from urllib.parse import urljoin
 
@@ -8,18 +8,23 @@ import pytest
 from playwright.sync_api import Page, expect
 
 from codelists.coding_systems import CODING_SYSTEMS
+from codelists.models import Status
 
 
 pytestmark = pytest.mark.functional
 
 
-@dataclass(frozen=True)
+DEFAULT_VERSION_TAG = "first_version"
+
+
+@dataclass
 class Navigator:
     """Represents navigation to different OpenCodelists pages using
     a Playwright Page."""
 
     page: Page
     codelist_name: str
+    codelist_version_tags: dict[str, str] = field(default_factory=dict[str, str])
 
     def go_to_create_codelist_page(self, is_experimental=False):
         """Navigates the Playwright Page to the "create a codelist" page."""
@@ -37,7 +42,7 @@ class Navigator:
         else:
             codelist_create_link.click()
 
-    def go_to_codelist(self):
+    def go_to_codelist(self, version_tag=DEFAULT_VERSION_TAG):
         """Navigates the Playwright Page to the link for the codelist
         from the My Codelists page.
 
@@ -46,7 +51,9 @@ class Navigator:
         * it's the builder when creating a codelist
         * it's the codelist page when saved for review."""
         self.go_to_my_codelists_page()
-        codelist_link = self.page.get_by_role("link", name=self.codelist_name)
+        codelist_link = self.page.get_by_role(
+            "link", name=self.codelist_version_tags[version_tag]
+        )
         expect(codelist_link).to_be_visible()
         codelist_link.click()
 
@@ -170,15 +177,6 @@ class SearchActions:
             )
 
 
-class CodelistHeading(StrEnum):
-    """Represents the heading for a codelist on the My Codelists page."""
-
-    USER_OWNED = "Your published codelists"
-    ORGANISATION_OWNED = "Your organisation codelists"
-    REVIEW = "Your codelists under review"
-    DRAFT = "Your draft codelists"
-
-
 def setup_playwright_page(login_context, url):
     """Takes a login context, and returns a Playwright page."""
 
@@ -188,13 +186,22 @@ def setup_playwright_page(login_context, url):
     return page
 
 
-def create_codelist(navigator, coding_system, initial_page_navigation=True):
+def create_codelist(
+    navigator: Navigator,
+    coding_system,
+    version_tag=DEFAULT_VERSION_TAG,
+    initial_page_navigation=True,
+):
     """Takes a Navigator, and a coding system, and, for supported coding
     systems, fills in the form to create a new codelist."""
 
     if coding_system not in ["bnf", "snomedct", "dmd"]:
         # Database fixtures that work with these tests are needed for other coding systems.
         assert False, "Coding system {coding_system} not yet supported by the tests"
+
+    assert version_tag not in navigator.codelist_version_tags, (
+        "You can't create two codelists with the same version tag: {version_tag}"
+    )
 
     if initial_page_navigation:
         navigator.go_to_create_codelist_page(
@@ -206,6 +213,11 @@ def create_codelist(navigator, coding_system, initial_page_navigation=True):
     )
     navigator.page.get_by_label("Coding system *").select_option(coding_system)
     navigator.page.get_by_role("button", name="Create").click()
+
+    # Get codelist version hash
+    navigator.codelist_version_tags[version_tag] = navigator.page.locator(
+        ":text('Version ID') + dd"
+    ).text_content()
 
 
 def save_codelist_for_review(navigator, initial_page_navigation=True):
@@ -220,23 +232,25 @@ def save_codelist_for_review(navigator, initial_page_navigation=True):
 
 
 def validate_codelist_exists_on_site(
-    navigator, codelist_heading, initial_page_navigation=True
+    navigator,
+    codelist_status,
+    codelist_owner,
+    version_tag=DEFAULT_VERSION_TAG,
+    initial_page_navigation=True,
 ):
-    """Takes a Navigator, a codelist name, and CodelistHeading to match,
-    and validates that the codelist name exists under that heading.
-
-    It does not currently go for an exact match because organisation users get
-    "owned by organisation" appended to the codelist name.
-
-    We could improve this matching in future."""
-
+    """Takes a Navigator, a codelist status and owner to match, and validates
+    that the codelist version exists with that status and owner
+    """
     if initial_page_navigation:
         navigator.go_to_my_codelists_page()
-    expect(
-        navigator.page.get_by_role("link", name=navigator.codelist_name)
-        .locator("xpath=preceding::h4")
-        .nth(-1)
-    ).to_have_text(codelist_heading.value)
+    codelist_row = navigator.page.get_by_role("row", name=navigator.codelist_name)
+    expect(codelist_row).to_be_visible()
+    expect(codelist_row).to_contain_text(codelist_owner, ignore_case=True)
+    codelist_version = codelist_row.get_by_role(
+        "row", name=navigator.codelist_version_tags[version_tag]
+    )
+    expect(codelist_version).to_be_visible()
+    expect(codelist_version).to_contain_text(codelist_status.value, ignore_case=True)
 
 
 def verify_review_codelist_codes(
@@ -375,7 +389,7 @@ def test_build_snomedct_codelist_single_search(
 
     save_codelist_for_review(navigator, initial_page_navigation=navigate_to_page)
     validate_codelist_exists_on_site(
-        navigator, CodelistHeading.REVIEW, initial_page_navigation=True
+        navigator, Status.UNDER_REVIEW, username, initial_page_navigation=True
     )
 
     verify_review_codelist_codes(
@@ -385,7 +399,7 @@ def test_build_snomedct_codelist_single_search(
     publish_codelist(navigator, initial_page_navigation=navigate_to_page)
 
     validate_codelist_exists_on_site(
-        navigator, CodelistHeading.USER_OWNED, initial_page_navigation=True
+        navigator, Status.PUBLISHED, username, initial_page_navigation=True
     )
 
     verify_codelist_csv(navigator, search_actions, initial_page_navigation=True)
@@ -467,7 +481,7 @@ def test_build_bnf_codelist_single_search(
 
     save_codelist_for_review(navigator, initial_page_navigation=navigate_to_page)
     validate_codelist_exists_on_site(
-        navigator, CodelistHeading.REVIEW, initial_page_navigation=True
+        navigator, Status.UNDER_REVIEW, username, initial_page_navigation=True
     )
 
     verify_review_codelist_codes(
@@ -477,7 +491,7 @@ def test_build_bnf_codelist_single_search(
     publish_codelist(navigator, initial_page_navigation=navigate_to_page)
 
     validate_codelist_exists_on_site(
-        navigator, CodelistHeading.USER_OWNED, initial_page_navigation=True
+        navigator, Status.PUBLISHED, username, initial_page_navigation=True
     )
 
     verify_codelist_csv(navigator, search_actions, initial_page_navigation=True)
@@ -543,7 +557,7 @@ def test_build_snomedct_codelist_two_searches_no_selections(
     search_actions.apply_all(navigator, initial_page_navigation=navigate_to_page)
 
     validate_codelist_exists_on_site(
-        navigator, CodelistHeading.DRAFT, initial_page_navigation=True
+        navigator, Status.DRAFT, username, initial_page_navigation=True
     )
 
     # No content to verify for an empty draft.
@@ -648,7 +662,7 @@ def test_build_snomedct_codelist_two_searches(
 
     save_codelist_for_review(navigator, initial_page_navigation=navigate_to_page)
     validate_codelist_exists_on_site(
-        navigator, CodelistHeading.REVIEW, initial_page_navigation=True
+        navigator, Status.UNDER_REVIEW, username, initial_page_navigation=True
     )
 
     verify_review_codelist_codes(
@@ -658,7 +672,7 @@ def test_build_snomedct_codelist_two_searches(
     publish_codelist(navigator, initial_page_navigation=navigate_to_page)
 
     validate_codelist_exists_on_site(
-        navigator, CodelistHeading.USER_OWNED, initial_page_navigation=True
+        navigator, Status.PUBLISHED, username, initial_page_navigation=True
     )
 
     verify_codelist_csv(navigator, search_actions, initial_page_navigation=True)
@@ -740,7 +754,7 @@ def test_build_dmd_codelist_single_search(
 
     save_codelist_for_review(navigator, initial_page_navigation=navigate_to_page)
     validate_codelist_exists_on_site(
-        navigator, CodelistHeading.REVIEW, initial_page_navigation=True
+        navigator, Status.UNDER_REVIEW, username, initial_page_navigation=True
     )
 
     verify_review_codelist_codes(
@@ -750,5 +764,5 @@ def test_build_dmd_codelist_single_search(
     publish_codelist(navigator, initial_page_navigation=navigate_to_page)
 
     validate_codelist_exists_on_site(
-        navigator, CodelistHeading.USER_OWNED, initial_page_navigation=True
+        navigator, Status.PUBLISHED, username, initial_page_navigation=True
     )

--- a/opencodelists/tests/views/test_user.py
+++ b/opencodelists/tests/views/test_user.py
@@ -13,12 +13,7 @@ def test_get(client, user_without_organisation):
     assert response.status_code == 200
 
     # user_without_organisation has no codelists
-    for codelist_category in [
-        "codelists",
-        "authored_for_organisation",
-        "under_review",
-        "drafts",
-    ]:
+    for codelist_category in ["codelists", "all_codelists"]:
         assert not response.context[codelist_category]
 
 
@@ -60,10 +55,20 @@ def test_user_codelists(
     assert organisation_user.codelists.count() >= 1
 
     response = client.get(user_url)
-    for codelist_category in ["codelists", "authored_for_organisation", "under_review"]:
-        assert not response.context[codelist_category]
+    assert not response.context["codelists"]
+    assert not [
+        version
+        for codelist in response.context["all_codelists"]
+        for version in codelist["versions"]
+        if version.is_under_review
+    ]
 
-    assert [cl.id for cl in response.context["drafts"]] == [
+    assert [
+        version.id
+        for codelist in response.context["all_codelists"]
+        for version in codelist["versions"]
+        if version.is_draft
+    ] == [
         organisation_codelist.versions.first().id,
         codelist.versions.first().id,
     ]
@@ -72,12 +77,18 @@ def test_user_codelists(
     save_for_review(draft=organisation_codelist.versions.first())
 
     response = client.get(user_url)
-    assert [cl.id for cl in response.context["drafts"]] == [
-        codelist.versions.first().id
-    ]
-    assert [cl.id for cl in response.context["under_review"]] == [
-        organisation_codelist.versions.last().id
-    ]
+    assert [
+        version.id
+        for codelist in response.context["all_codelists"]
+        for version in codelist["versions"]
+        if version.is_draft
+    ] == [codelist.versions.first().id]
+    assert [
+        version.id
+        for codelist in response.context["all_codelists"]
+        for version in codelist["versions"]
+        if version.is_under_review
+    ] == [organisation_codelist.versions.last().id]
 
     # publish both codelists
     save_for_review(draft=codelist.versions.first())
@@ -86,12 +97,24 @@ def test_user_codelists(
     user_codelist_version_id = codelist.latest_published_version().id
     org_codelist_version_id = organisation_codelist.latest_published_version().id
     response = client.get(user_url)
-    for codelist_category in ["under_review", "drafts"]:
-        assert not response.context[codelist_category]
-    assert [cl.id for cl in response.context["codelists"]] == [user_codelist_version_id]
-    assert [cl.id for cl in response.context["authored_for_organisation"]] == [
-        org_codelist_version_id
+    assert not [
+        version
+        for codelist in response.context["all_codelists"]
+        for version in codelist["versions"]
+        if version.is_under_review or version.is_draft
     ]
+    assert [
+        version.id
+        for cl in response.context["all_codelists"]
+        for version in cl["versions"]
+        if not version.organisation
+    ] == [user_codelist_version_id]
+    assert [
+        version.id
+        for cl in response.context["all_codelists"]
+        for version in cl["versions"]
+        if version.organisation
+    ] == [org_codelist_version_id]
 
     # change the owner for the user-owned codelist to an organisation
     update_codelist(
@@ -106,9 +129,18 @@ def test_user_codelists(
     )
     response = client.get(user_url)
     # the previously user-owned codelist now appears under "authored_for_organisation"
-    for codelist_category in ["codelists", "under_review", "drafts"]:
-        assert not response.context[codelist_category]
-    assert [cl.id for cl in response.context["authored_for_organisation"]] == [
+    assert not [
+        version.id
+        for cl in response.context["all_codelists"]
+        for version in cl["versions"]
+        if not version.organisation
+    ]
+    assert [
+        version.id
+        for cl in response.context["all_codelists"]
+        for version in cl["versions"]
+        if version.organisation
+    ] == [
         org_codelist_version_id,
         user_codelist_version_id,
     ]

--- a/opencodelists/tests/views/test_user.py
+++ b/opencodelists/tests/views/test_user.py
@@ -13,7 +13,7 @@ def test_get(client, user_without_organisation):
     assert response.status_code == 200
 
     # user_without_organisation has no codelists
-    for codelist_category in ["codelists", "all_codelists"]:
+    for codelist_category in ["published_codelists", "all_codelists"]:
         assert not response.context[codelist_category]
 
 
@@ -55,7 +55,7 @@ def test_user_codelists(
     assert organisation_user.codelists.count() >= 1
 
     response = client.get(user_url)
-    assert not response.context["codelists"]
+    assert not response.context["published_codelists"]
     assert not [
         version
         for codelist in response.context["all_codelists"]

--- a/opencodelists/tests/views/test_user.py
+++ b/opencodelists/tests/views/test_user.py
@@ -69,8 +69,8 @@ def test_user_codelists(
         for version in codelist["versions"]
         if version.is_draft
     ] == [
-        organisation_codelist.versions.first().id,
         codelist.versions.first().id,
+        organisation_codelist.versions.first().id,
     ]
 
     # make org codelist under-review

--- a/opencodelists/views/user.py
+++ b/opencodelists/views/user.py
@@ -38,7 +38,11 @@ def user(request, username):
                 else []
             ),
         }
-        for codelist in sorted(codelists_to_display, key=lambda x: (x.name))
+        for codelist in sorted(
+            codelists_to_display, key=lambda x: (x.owner != user, str(x.owner), x.name)
+        )
+        # We sort first by owner, then by name - but making sure that the current user's
+        # codelists always come first
         # We can't use a queryset order_by (where versions_under_review/drafts are querysets of CodelistVersion
         # instances), as a codelist can have multiple versions and multiple handles, and this results in duplicates
         # in the returned queryset. See https://code.djangoproject.com/ticket/18165

--- a/opencodelists/views/user.py
+++ b/opencodelists/views/user.py
@@ -13,10 +13,37 @@ def user(request, username):
         handles__is_current=True, versions__status=Status.PUBLISHED
     ).distinct()
 
-    # Find all of the codelists authored (but not owned) by this user with at least one published version.
-    authored_for_organisation = user.authored_for_organisation.distinct().difference(
-        owned_codelists
+    # All codelists authored by the user (either themselves or on behalf of an org)
+    # AND those with a draft or under review version owned by the user
+    codelists_to_display = list(
+        set(user.codelists.union(user.authored_for_organisation))
+        | {
+            version.codelist
+            for version in user.drafts.union(user.versions_under_review)
+        }
     )
+
+    # For each codelist we return it, and a list of versions including:
+    #   - all draft and under review versions
+    #   - the latest published version
+    all_codelists = [
+        {
+            "codelist": codelist,
+            "versions": list(
+                codelist.versions.exclude(status=Status.PUBLISHED).order_by("-id")
+            )
+            + (
+                [codelist.latest_published_version()]
+                if codelist.latest_published_version()
+                else []
+            ),
+        }
+        for codelist in sorted(codelists_to_display, key=lambda x: (x.name))
+        # We can't use a queryset order_by (where versions_under_review/drafts are querysets of CodelistVersion
+        # instances), as a codelist can have multiple versions and multiple handles, and this results in duplicates
+        # in the returned queryset. See https://code.djangoproject.com/ticket/18165
+    ]
+
     ctx = {
         "user": user,
         "codelists": [
@@ -25,24 +52,7 @@ def user(request, username):
         ],
         # note that name is a property on a codelist, not an attribute, and it comes from the current handle.
         # If we want to order codelists or versions by codelist name, we actually need to order them by handle name.
-        # We can't use a queryset order_by in the following cases (where versions_under_review/drafts are querysets of
-        # CodelistVersion instances), as a codelist can have multiple versions and multiple handles,
-        # and this results in duplicates in the returned queryset.
-        # See https://code.djangoproject.com/ticket/18165
-        # Sort by organisation then name
-        "authored_for_organisation": [
-            codelist.latest_published_version()
-            for codelist in sorted(
-                authored_for_organisation, key=lambda x: (x.owner.name, x.name)
-            )
-        ],
-        "under_review": sorted(
-            user.versions_under_review.select_related("codelist"),
-            key=lambda x: x.codelist.name,
-        ),
-        "drafts": sorted(
-            user.drafts.select_related("codelist"), key=lambda x: x.codelist.name
-        ),
+        "all_codelists": all_codelists,
     }
 
     if user == request.user:

--- a/opencodelists/views/user.py
+++ b/opencodelists/views/user.py
@@ -10,7 +10,7 @@ def user(request, username):
 
     # Find all of the codelists owned (in their current version) by this user with at least one published version.
     owned_codelists = user.codelists.filter(
-        handles__is_current=True, versions__status=Status.PUBLISHED
+        versions__status=Status.PUBLISHED
     ).distinct()
 
     # All codelists authored by the user (either themselves or on behalf of an org)
@@ -46,7 +46,7 @@ def user(request, username):
 
     ctx = {
         "user": user,
-        "codelists": [
+        "published_codelists": [
             codelist.latest_published_version()
             for codelist in owned_codelists.order_by("handles__name")
         ],

--- a/templates/opencodelists/_codelist_links.html
+++ b/templates/opencodelists/_codelist_links.html
@@ -1,12 +1,89 @@
-<ul>
-  {% for version in codelist_versions %}
-  <li>
-    <div class="d-flex align-items-center">
-      <a href="{{ version.get_absolute_url }}">{{ version.codelist.name }} {% if show_ownership %}(owned by {{ version.codelist.owner }}){% endif %}</a>
-      <span class="badge badge-secondary ml-2">{{ version.codelist.coding_system_short_name }}</span>
-      <span class="badge badge-primary ml-1">{{ version.codes | length }} code{% if version.codes|length != 1 %}s{% endif %}</span>
-      <span class="badge ml-1">Last updated {{ version.updated_at | date:'d M Y' }} at {{ version.updated_at | date:'H:i' }}</span>
-    </div>
-  </li>
-  {% endfor %}
-</ul>
+{% load django_vite %}
+{% load static %}
+
+<div class="mb-3">
+  <input
+    type="text"
+    id="searchInput"
+    class="form-control"
+    placeholder="Search codelists..."
+    aria-label="Search codelists"
+    autofocus
+  >
+</div>
+
+<table class="table table-sm table-codelist">
+  <thead>
+    <tr>
+      <th>Name</th>
+      {% if show_unpublished %}
+      <th>Owner</th>
+      {% endif %}
+      <th style="white-space: nowrap">Coding system</th>
+      {% if show_unpublished %}
+      <th>Versions</th>
+      {% else %}
+      <th style="white-space: nowrap">Number of codes</th>
+      <th style="white-space: nowrap">Last updated</th>
+      {% endif %}
+    </tr>
+  </thead>
+  <tbody>
+    {% for item in codelists %}
+    <tr data-codelist-id="{{ item.codelist.id }}" data-codelist-text="{{ item.codelist.name }} {{ item.codelist.owner }} {{ item.codelist.coding_system_short_name }}">
+      {% if show_unpublished %}
+          <td>{{ item.codelist.name }}</td>
+          <td>{{ item.codelist.owner }}</td>
+          <td>{{ item.codelist.coding_system_short_name }}</td>
+          <td>
+            <table class="table-nested">
+              <tbody>
+                {% for version in item.versions %}
+                <tr data-version-text="{{ version.status }}">
+                  <td class="text-monospace font-weight-bold" style="width: 10ch">
+                    <a href="{{ version.get_absolute_url }}">{{ version.tag_or_hash }}</a>
+                  </td>
+                  <td style="width: 100px">
+                    {% if version.is_under_review %}
+                      <span class="badge badge-info">Under review</span>
+                    {% elif version.is_draft %}
+                      <span class="badge badge-secondary">Draft</span>
+                    {% elif version.is_published %}
+                      <span class="badge badge-success">Published</span>
+                    {% endif %}
+                  </td>
+                  <td style="width: 120px">
+                    <span class="badge badge-primary">
+                      {{ version.codes | length }} code{% if version.codes|length != 1 %}s{% endif %}
+                    </span>
+                  </td>
+                  <td>
+                    <span class="badge">
+                      Last updated {{ version.updated_at | date:'d M Y' }} at {{ version.updated_at | date:'H:i' }}
+                    </span>
+                  </td>
+                </tr>
+                {% endfor %}
+              </tbody>
+            </table>
+          </td>
+      {% else %}
+          <td>
+            <a href="{{ item.get_absolute_url }}">{{ item.codelist.name }}</a>
+          </td>
+          <td>{{ item.codelist.coding_system_short_name }}</td>
+          <td>
+              {{ item.codes | length }}
+          </td>
+          <td>
+              {{ item.updated_at | date:'d M Y' }}
+          </td>
+      {% endif %}
+    </tr>
+    {% endfor %}
+  </tbody>
+</table>
+
+{% block extra_js %}
+{% vite_asset "assets/src/scripts/codelists-list.js" %}
+{% endblock %}

--- a/templates/opencodelists/that_user.html
+++ b/templates/opencodelists/that_user.html
@@ -11,7 +11,6 @@
 
 {% if codelists %}
 <h4>Codelists</h4>
-
-{% include "opencodelists/_codelist_links.html" with codelist_versions=codelists show_ownership=False %}
+{% include "opencodelists/_codelist_links.html" with codelists=codelists show_unpublished=False %}
 {% endif %}
 {% endblock %}

--- a/templates/opencodelists/that_user.html
+++ b/templates/opencodelists/that_user.html
@@ -9,8 +9,8 @@
 <h3>{{ user.name }}</h3>
 <br />
 
-{% if codelists %}
+{% if published_codelists %}
 <h4>Codelists</h4>
-{% include "opencodelists/_codelist_links.html" with codelists=codelists show_unpublished=False %}
+{% include "opencodelists/_codelist_links.html" with codelists=published_codelists show_unpublished=False %}
 {% endif %}
 {% endblock %}

--- a/templates/opencodelists/this_user.html
+++ b/templates/opencodelists/this_user.html
@@ -16,27 +16,7 @@
 </div>
 <br />
 
-{% if codelists %}
-<h4>Your published codelists</h4>
-
-{% include "opencodelists/_codelist_links.html" with codelist_versions=codelists show_ownership=False %}
-{% endif %}
-
-
-{% if authored_for_organisation %}
-<h4>Your organisation codelists</h4>
-{% include "opencodelists/_codelist_links.html" with codelist_versions=authored_for_organisation show_ownership=True %}
-{% endif %}
-
-
-{% if under_review %}
-<h4>Your codelists under review</h4>
-{% include "opencodelists/_codelist_links.html" with codelist_versions=under_review show_ownership=user.organisations.exists %}
-{% endif %}
-
-
-{% if drafts %}
-<h4>Your draft codelists</h4>
-{% include "opencodelists/_codelist_links.html" with codelist_versions=drafts show_ownership=user.organisations.exists %}
+{% if all_codelists %}
+{% include "opencodelists/_codelist_links.html" with codelists=all_codelists show_unpublished=True %}
 {% endif %}
 {% endblock %}

--- a/vite.config.mjs
+++ b/vite.config.mjs
@@ -13,6 +13,7 @@ export default defineConfig(({ mode }) => ({
         base: "assets/src/scripts/base.js",
         builder: "assets/src/scripts/builder/index.tsx",
         codelist: "assets/src/scripts/codelist.js",
+        "codelists-list": "assets/src/scripts/codelists-list.js",
         tree: "assets/src/scripts/tree/index.tsx",
         "codelists-version": "assets/src/scripts/codelists-version.js",
         tw: "assets/src/scripts/tw.js"


### PR DESCRIPTION
Fixes #2538 

The My Codelists page is now a searchable table as shown here:

[Screencast from 25-06-25 11:34:04.webm](https://github.com/user-attachments/assets/b11dcb1b-3527-42c3-b191-e9fe989bbd08)

When viewing another user's (published) codelists it looks like:

![image](https://github.com/user-attachments/assets/b29c100c-4144-439c-ac35-8c08fed4668f)
