### PR TITLE
Add a warning banner to medication codelists

### DIFF
--- a/codelists/tests/views/test_version.py
+++ b/codelists/tests/views/test_version.py
@@ -1,3 +1,10 @@
+from builder.actions import save as save_for_review
+from codelists.actions import publish_version
+from codelists.models import Status
+
+from .helpers import force_login
+
+
 def test_get_old_style_version(client, old_style_version):
     rsp = client.get(old_style_version.get_absolute_url())
     assert rsp.status_code == 200
@@ -32,3 +39,66 @@ def test_get_user_has_edit_permissions(client, user, version_with_no_searches):
 def test_non_builder_compatible_coding_system(client, dmd_version_asthma_medication):
     rsp = client.get(dmd_version_asthma_medication.get_absolute_url())
     assert rsp.status_code == 200
+
+
+def test_medication_banner_only_on_published(client, dmd_version_asthma_medication):
+    # The banner is not visible on an unpublished dm+d codelist version
+    rsp = client.get(dmd_version_asthma_medication.get_absolute_url())
+    assert rsp.status_code == 200
+    assert b"Medication codelists can quickly become outdated" not in rsp.content
+
+    # The banner is visible on a published dm+d codelist version
+    publish_version(version=dmd_version_asthma_medication)
+    rsp = client.get(dmd_version_asthma_medication.get_absolute_url())
+    assert rsp.status_code == 200
+    assert b"Medication codelists can quickly become outdated" in rsp.content
+
+
+def test_medication_banner_only_on_medication(
+    client, bnf_version_asthma, latest_published_version
+):
+    # The banner is not visible on a published SNOMED CT codelist (latest_published_version)
+    rsp = client.get(latest_published_version.get_absolute_url())
+    assert rsp.status_code == 200
+    assert b"Medication codelists can quickly become outdated" not in rsp.content
+
+    # The banner is visible on a published BNF codelist (bnf_version_asthma)
+    rsp = client.get(bnf_version_asthma.get_absolute_url())
+    assert rsp.status_code == 200
+    assert b"Medication codelists can quickly become outdated" in rsp.content
+
+
+def test_medication_banner_for_owner_of_codelist(client, bnf_version_asthma):
+    # If you can't create a new version (not the owner or in the org) then you
+    # are offered to "create your own" rather than "create a new version"
+    rsp = client.get(bnf_version_asthma.get_absolute_url())
+    assert rsp.status_code == 200
+    assert b"create your own" in rsp.content
+    assert b"create a new version" not in rsp.content
+
+    # If you can create a new version (the owner or in the org), but there is
+    # already a draft version, then you are told about this
+    force_login(bnf_version_asthma, client)
+    rsp = client.get(bnf_version_asthma.get_absolute_url())
+    assert rsp.status_code == 200
+    assert b"create your own" not in rsp.content
+    assert (
+        b"there is already a draft version for this codelist which could be published"
+        in rsp.content
+    )
+
+    # If you can create a new version (the owner or in the org), and there is
+    # not already a draft version, then you are invited to "create a new version"
+    bnf_draft_version = bnf_version_asthma.codelist.versions.filter(
+        status=Status.DRAFT
+    ).first()
+    save_for_review(draft=bnf_draft_version)
+    publish_version(version=bnf_draft_version)
+    rsp = client.get(bnf_version_asthma.get_absolute_url())
+    assert rsp.status_code == 200
+    assert b"create your own" not in rsp.content
+    assert b"create a new version" in rsp.content
+    assert (
+        b"there is already a draft version for this codelist which could be published"
+        not in rsp.content
+    )

--- a/templates/codelists/_medication_warning_banner.html
+++ b/templates/codelists/_medication_warning_banner.html
@@ -1,0 +1,39 @@
+
+<div role="alert" class="fade alert alert-warning show">
+  Medication codelists can quickly become outdated and may not be
+  suitable for reuse. The
+  <a
+    href="https://www.bennett.ox.ac.uk/blog/2019/08/what-is-the-dm-d-the-nhs-dictionary-of-medicines-and-devices/"
+    target="_blank"
+    rel="noopener noreferrer"
+    aria-label="Read more about the dictionary of medicines and devices (opens in new tab)"
+  >
+    dictionary of medicines and devices
+  </a> is updated weekly and
+  <a
+    href="https://www.bennett.ox.ac.uk/blog/2017/04/prescribing-data-bnf-codes/"
+    target="_blank"
+    rel="noopener noreferrer"
+    aria-label="Read more about BNF codes (opens in new tab)"
+  >
+    BNF codes
+  </a> are updated monthly. Please check carefully for any new medicines
+  and codes before reusing this
+  {% if user_can_edit %}
+  codelist.
+    {% if can_create_new_version %}
+      If it needs updating, you can create a new version with the button above.
+    {% else %}
+      If it needs updating, there is already a draft version for this codelist which could be published.
+    {% endif %}
+  {% else %}
+    codelist, or
+    {% if request.user.username %}
+    <a href="{% url 'user-create-codelist' request.user %}">
+      create your own
+    </a>.
+    {% else %}
+      create your own.
+    {% endif %}
+  {% endif %}
+</div>

--- a/templates/codelists/version.html
+++ b/templates/codelists/version.html
@@ -290,6 +290,11 @@
     </div>
 
     <div class="col-md-9">
+      {% if clv.is_published %}
+        {% if clv.coding_system_id == "dmd" or clv.coding_system_id == "bnf" %}
+          {% include "./_medication_warning_banner.html" %}
+        {% endif %}
+      {% endif %}
       <ul id="tab-list" class="nav nav-tabs" role="tablist">
         {% include "./_tab_nav.html" with label="About" tabname="about" active=True %}
 


### PR DESCRIPTION
Fixes #2394 

Looks like:

![image](https://github.com/user-attachments/assets/389971df-bb65-46a7-89db-6746e48910e9)


- only displays for codelists that are
  - published, and
  - either dmd or bnf
- appears on ALL codelists. I considered just on old ones, but I think the way the message is worded it's sufficiently generic. Also, if it's the first med codelist you've created, it's still useful to know that you can't necessarily rely on it if you only get round to using it in a few months.
-  message is tailored so that
   - if you're logged in, the "or create a codelist" is hyperlinked to the create page
   - if it's a codelist that you can create a new version of, then it tells you that instead of saying you can create a new codelist