### PR TITLE
Add Plausible tracking code to Tools component

### DIFF
--- a/assets/src/scripts/components/Cards/Tools.tsx
+++ b/assets/src/scripts/components/Cards/Tools.tsx
@@ -32,7 +32,7 @@ export default function Tools() {
               href={tool.link}
               target="_blank"
               rel="noopener noreferrer"
-              className=""
+              className={`plausible-event-name=Builder+tool+click plausible-event-tool=${tool.id}`}
             >
               {tool.name}
             </a>


### PR DESCRIPTION
Closes #2554

Attaches a custom event name, and the tool ID to the outbound links.

[Plausible documentation](https://plausible.io/docs/custom-props/for-custom-events#step-2-tag-properties-to-custom-events-you-want-to-track)