### PR TITLE
Remove `dmd_previous_codes_mapping`

### DIFF
--- a/codelists/api.py
+++ b/codelists/api.py
@@ -21,7 +21,6 @@ from django.http import JsonResponse
 from django.views.decorators.csrf import csrf_exempt
 from django.views.decorators.http import require_http_methods
 
-from mappings.dmdvmpprevmap.mappers import vmp_ids_to_previous
 from opencodelists.models import Organisation, User
 
 from .actions import (
@@ -326,28 +325,6 @@ def versions(request, codelist):
 
 def error(msg):
     return JsonResponse({"error": msg}, status=400)
-
-
-@require_http_methods(["GET"])
-def dmd_previous_codes_mapping(request):
-    """
-    Return a mapping of dm+d VMP ID to previous VMP IDs
-
-    dm+d VPM IDs can change.  When they do, the data we obtain in the coding system release
-    contains a record of the previous VMP ID.  Any system using a dm+d codelist with a
-    VMP ID needs to also look up any previous or subsequent IDs in order to avoid missing
-    medications.
-
-    This endpoint is intended to be used by backends to determine any additional related codes
-    to include with set of dm+d codes.
-
-
-    Known clients (see caveats in module docstring):
-        2025-Jun: Previously used by cohort-extractor update_vmp_mapping.py, but
-        cohort-extractor is no longer in service.
-    """
-    vmp_to_previous_tuples = vmp_ids_to_previous()
-    return JsonResponse(vmp_to_previous_tuples, safe=False)
 
 
 @require_http_methods("POST")

--- a/codelists/api_urls.py
+++ b/codelists/api_urls.py
@@ -8,11 +8,6 @@ app_name = "codelists_api"
 
 urlpatterns = [
     path("codelist/", api.all_codelists, name="all_codelists"),
-    path(
-        "dmd-mapping/",
-        api.dmd_previous_codes_mapping,
-        name="dmd_previous_codes_mapping",
-    ),
     path("check/", api.codelists_check, name="check_codelists"),
 ]
 

--- a/codelists/tests/test_api.py
+++ b/codelists/tests/test_api.py
@@ -515,27 +515,6 @@ def post(client, url, data, user):
     return client.post(url, data, content_type="application/json", **headers)
 
 
-def test_dmd_mapping_no_data(client, organisation, dmd_data):
-    rsp = client.get("/api/v1/dmd-mapping/")
-    data = json.loads(rsp.content)
-    assert rsp.status_code == 200
-    assert data == []
-
-
-def test_dmd_mapping_with_data(client, organisation):
-    VmpPrevMapping.objects.create(id="11", vpidprev="01")
-    VmpPrevMapping.objects.create(id="22", vpidprev="11")
-
-    rsp = client.get("/api/v1/dmd-mapping/")
-    data = json.loads(rsp.content)
-    assert rsp.status_code == 200
-    assert sorted(data) == [
-        ["11", "01"],
-        ["22", "01"],
-        ["22", "11"],
-    ]
-
-
 @pytest.mark.parametrize(
     "codelists,manifest,error",
     [


### PR DESCRIPTION
Fixes #2676.

This is no longer needed following the end-of-life of cohort-extractor.