### PR TITLE
Add ordered list to allowed Markdown tags

### DIFF
--- a/opencodelists/settings.py
+++ b/opencodelists/settings.py
@@ -343,6 +343,7 @@ MARKDOWN_FILTER_ALLOWLIST_TAGS = {
     "h6",
     "a",
     "p",
+    "ol",
     "ul",
     "li",
     "code",


### PR DESCRIPTION
Fixes #2683.

Thomas spotted this was missing.

https://github.com/opensafely-core/opencodelists/issues/2683#issuecomment-3027422425