### PR TITLE
Correct use of `format_html()`

### DIFF
--- a/codelists/views/version.py
+++ b/codelists/views/version.py
@@ -33,7 +33,8 @@ def version(request, clv):
             messages.warning(
                 request,
                 format_html(
-                    f"WARNING: Codelist contains codes not found in {coding_system.name}"
+                    "WARNING: Codelist contains codes not found in {}",
+                    coding_system.name,
                 ),
             )
         tree_tables = sorted(


### PR DESCRIPTION
As written, this was ineffective.

`format_html()` takes a string to be formatted, and then escapes the other arguments and keyword arguments passed to it. Passing only a single, already formatted string results in no escaping.

Our incorrect use was deprecated in Django 5.0. It will result in a `ValueError` in Django 6.0:

https://adamj.eu/tech/2023/06/15/format-html/