### PR TITLE
Add a script to update the NHS PCD refsets automatically

### DIFF
--- a/codelists/actions.py
+++ b/codelists/actions.py
@@ -67,6 +67,7 @@ def create_or_update_codelist(
     codes,
     coding_system_database_alias,
     slug=None,
+    new_slug=None,
     tag=None,
     description=None,
     methodology=None,
@@ -77,6 +78,8 @@ def create_or_update_codelist(
     should_publish=False,
 ):
     slug = slug or slugify(name)
+    new_slug = new_slug or slug
+
     references = references or []
     signoffs = signoffs or []
 
@@ -86,7 +89,7 @@ def create_or_update_codelist(
         update_codelist(
             owner=owner,
             name=name,
-            slug=slug,
+            slug=new_slug,
             codelist=codelist,
             description=description,
             methodology=methodology,
@@ -112,7 +115,7 @@ def create_or_update_codelist(
             coding_system_id=coding_system_id,
             coding_system_database_alias=coding_system_database_alias,
             codes=codes,
-            slug=slug,
+            slug=new_slug,
             tag=tag,
             description=description,
             methodology=methodology,

--- a/codelists/actions.py
+++ b/codelists/actions.py
@@ -401,6 +401,9 @@ def _create_version_with_codes(
             # and want to (a) ignore codes that aren't in the dictionary, (b) add them
             # to the description so it's transparent
             unfound_codes = codes - found_codes
+
+            if not codelist.description:
+                codelist.description = ""
             codelist.description += (
                 "\n\nThis codelist was imported automatically. The following codes "
                 f"were not found in the {codelist.coding_system_cls.name} dictionary "

--- a/codelists/actions.py
+++ b/codelists/actions.py
@@ -77,19 +77,19 @@ def create_or_update_codelist(
     ignore_unfound_codes=False,
     should_publish=False,
 ):
-    slug = slug or slugify(name)
-    new_slug = new_slug or slug
+    current_slug = slug or slugify(name)
+    slug = new_slug or current_slug
 
     references = references or []
     signoffs = signoffs or []
 
     try:
-        codelist = owner.handles.get(slug=slug).codelist
+        codelist = owner.handles.get(slug=current_slug).codelist
 
         update_codelist(
             owner=owner,
             name=name,
-            slug=new_slug,
+            slug=slug,
             codelist=codelist,
             description=description,
             methodology=methodology,
@@ -115,7 +115,7 @@ def create_or_update_codelist(
             coding_system_id=coding_system_id,
             coding_system_database_alias=coding_system_database_alias,
             codes=codes,
-            slug=new_slug,
+            slug=slug,
             tag=tag,
             description=description,
             methodology=methodology,

--- a/codelists/actions.py
+++ b/codelists/actions.py
@@ -414,7 +414,7 @@ def _create_version_with_codes(
             codes = found_codes
         else:
             raise ValueError(
-                f"Attempting to import codes that aren't in this coding system: {', '.join(sorted(codes - found_codes))}"
+                f"Attempting to import codes that aren't in the {codelist.coding_system_cls.name}/{coding_system_release.database_alias} coding system: {', '.join(sorted(codes - found_codes))}"
             )
 
     clv = codelist.versions.create(

--- a/codelists/actions.py
+++ b/codelists/actions.py
@@ -74,6 +74,7 @@ def create_or_update_codelist(
     signoffs=None,
     always_create_new_version=False,
     ignore_unfound_codes=False,
+    should_publish=False,
 ):
     slug = slug or slugify(name)
     references = references or []
@@ -99,6 +100,7 @@ def create_or_update_codelist(
             coding_system_database_alias=coding_system_database_alias,
             always_create_new_version=always_create_new_version,
             ignore_unfound_codes=ignore_unfound_codes,
+            status=Status.PUBLISHED if should_publish else Status.UNDER_REVIEW,
         )
 
         return codelist

--- a/codelists/actions.py
+++ b/codelists/actions.py
@@ -73,6 +73,7 @@ def create_or_update_codelist(
     references=None,
     signoffs=None,
     always_create_new_version=False,
+    ignore_unfound_codes=False,
 ):
     slug = slug or slugify(name)
     references = references or []
@@ -97,6 +98,7 @@ def create_or_update_codelist(
             tag=tag,
             coding_system_database_alias=coding_system_database_alias,
             always_create_new_version=always_create_new_version,
+            ignore_unfound_codes=ignore_unfound_codes,
         )
 
         return codelist
@@ -115,6 +117,7 @@ def create_or_update_codelist(
             references=references,
             signoffs=signoffs,
             status=Status.PUBLISHED,
+            ignore_unfound_codes=ignore_unfound_codes,
         )
 
 
@@ -134,6 +137,7 @@ def create_codelist_with_codes(
     signoffs=None,
     author=None,
     status=Status.DRAFT,
+    ignore_unfound_codes=False,
 ):
     """Create a new Codelist with a new-style version with given codes."""
 
@@ -157,6 +161,7 @@ def create_codelist_with_codes(
         coding_system_release=coding_system.release,
         tag=tag,
         author=author,
+        ignore_unfound_codes=ignore_unfound_codes,
     )
     return codelist
 
@@ -271,6 +276,7 @@ def create_version_with_codes(
     codeset=None,
     author=None,
     always_create_new_version=False,
+    ignore_unfound_codes=False,
 ):
     """Create a new version of a codelist with given codes.
     Returns the new version, or None if no version is created because the codes are the
@@ -294,6 +300,7 @@ def create_version_with_codes(
             hierarchy=hierarchy,
             codeset=codeset,
             author=author,
+            ignore_unfound_codes=ignore_unfound_codes,
         )
     return None
 
@@ -375,12 +382,35 @@ def _create_version_with_codes(
     hierarchy=None,
     codeset=None,
     author=None,
+    ignore_unfound_codes=False,
 ):
     codes = set(codes)
     coding_system = codelist.coding_system_cls.get_by_release(
         coding_system_release.database_alias
     )
-    assert codes == set(coding_system.lookup_names(codes))
+    found_codes = set(coding_system.lookup_names(codes))
+
+    if codes != found_codes:
+        if ignore_unfound_codes:
+            # This means we're importing (almost certainly bulk importing from the API)
+            # and want to (a) ignore codes that aren't in the dictionary, (b) add them
+            # to the description so it's transparent
+            unfound_codes = codes - found_codes
+            codelist.description += (
+                "\n\nThis codelist was imported automatically. The following codes "
+                f"were not found in the {codelist.coding_system_cls.name} dictionary "
+                "and so excluded from this codelist: "
+                f"{', '.join(unfound_codes)}."
+                "\n\nThis may be because this codelist contains both clinical terms and "
+                "medications. In which case you may need to create another codelist "
+                "for the missing clinical/medication codes."
+            )
+            codelist.save()
+            codes = found_codes
+        else:
+            raise ValueError(
+                f"Attempting to import codes that aren't in this coding system: {', '.join(sorted(codes - found_codes))}"
+            )
 
     clv = codelist.versions.create(
         tag=tag,

--- a/codelists/api.py
+++ b/codelists/api.py
@@ -32,7 +32,7 @@ from .actions import (
     update_codelist,
 )
 from .api_decorators import require_authentication, require_permission
-from .models import Codelist, CodelistVersion, Handle
+from .models import Codelist, CodelistVersion, Handle, Status
 from .views.decorators import load_codelist, load_owner
 
 
@@ -240,6 +240,7 @@ def codelists_post(request, owner):
         "signoffs",
         "always_create_new_version",
         "ignore_unfound_codes",
+        "should_publish",
     ]
 
     if len(set(data) & set(code_keys)) != 1:
@@ -280,6 +281,7 @@ def versions(request, codelist):
         * ignore_unfound_codes (optional, for "codes" / new-style only.)
         * name (optional, if passed overwrite the current name)
         * description (optional, if passed overwrite the current description)
+        * should_publish (optional, if passed forces the new version to be published)
 
 
     Known clients (see caveats in module docstring):
@@ -317,6 +319,9 @@ def versions(request, codelist):
             clv = create_version_with_codes(
                 codelist=codelist,
                 codes=set(data["codes"]),
+                status=Status.PUBLISHED
+                if data.get("should_publish", False)
+                else Status.UNDER_REVIEW,
                 tag=data.get("tag"),
                 coding_system_database_alias=data["coding_system_database_alias"],
                 always_create_new_version=data.get("always_create_new_version", False),

--- a/codelists/api.py
+++ b/codelists/api.py
@@ -240,6 +240,7 @@ def codelists_post(request, owner):
         "signoffs",
         "always_create_new_version",
         "ignore_unfound_codes",
+        "new_slug",
         "should_publish",
     ]
 
@@ -296,11 +297,11 @@ def versions(request, codelist):
     if len(set(data) & {"codes", "csv_data", "ecl"}) != 1:
         return error("Provide exactly one of `codes`, `csv_data` or `ecl`")
 
-    if "description" in data or "name" in data:
+    if "description" in data or "name" in data or "new_slug" in data:
         update_codelist(
             owner=codelist.owner,
             name=data.get("name", codelist.name),
-            slug=codelist.slug,
+            slug=data.get("new_slug", codelist.slug),
             codelist=codelist,
             description=data.get("description", codelist.description),
             methodology=codelist.methodology,

--- a/codelists/api.py
+++ b/codelists/api.py
@@ -213,6 +213,7 @@ def codelists_post(request, owner):
         * references (optional)
         * signoffs (optional)
         * always_create_new_version (optional)
+        # ignore_unfound_codes (optional)
 
     Known clients (see caveats in module docstring):
         2024-Nov: Scripts such as those in /codelists/scripts/ may use this
@@ -238,6 +239,7 @@ def codelists_post(request, owner):
         "references",
         "signoffs",
         "always_create_new_version",
+        "ignore_unfound_codes",
     ]
 
     if len(set(data) & set(code_keys)) != 1:
@@ -275,6 +277,7 @@ def versions(request, codelist):
         * tag
         * coding_system_database_alias
         * always_create_new_version (optional, for "codes" / new-style only.)
+        * ignore_unfound_codes (optional, for "codes" / new-style only.)
         * name (optional, if passed overwrite the current name)
         * description (optional, if passed overwrite the current description)
 
@@ -317,6 +320,7 @@ def versions(request, codelist):
                 tag=data.get("tag"),
                 coding_system_database_alias=data["coding_system_database_alias"],
                 always_create_new_version=data.get("always_create_new_version", False),
+                ignore_unfound_codes=data.get("ignore_unfound_codes", False),
             )
         elif "csv_data" in data:
             clv = create_old_style_version(

--- a/codelists/scripts/bulk_import_codelists.py
+++ b/codelists/scripts/bulk_import_codelists.py
@@ -48,6 +48,7 @@ def main(
     force_new_version=False,
     force_description=False,
     force_name=False,
+    force_slug=False,
     force_publish=False,
     ignore_unfound_codes=False,
     dry_run=True,
@@ -119,6 +120,7 @@ def main(
                 force_description,
                 force_name,
                 force_publish,
+                force_slug,
                 ignore_unfound_codes,
             )
 
@@ -240,6 +242,7 @@ def get_post_data(
     force_description,
     force_name,
     force_publish,
+    force_slug,
     ignore_unfound_codes,
 ):
     """
@@ -284,6 +287,8 @@ def get_post_data(
         post_data["name"] = codelist_name
     if force_publish:
         post_data["should_publish"] = True
+    if force_slug:
+        post_data["new_slug"] = first_row["codelist_new_slug"].lower()
     if ignore_unfound_codes:
         post_data["ignore_unfound_codes"] = True
 
@@ -324,6 +329,11 @@ def parse_args():
         help="For new versions, this causes them to auto-publish rather than defaulting to under review.",
     )
     parser.add_argument(
+        "--force-slug",
+        action="store_true",
+        help="For new codelists, user the provided slug rather than generating one.",
+    )
+    parser.add_argument(
         "--ignore-unfound-codes",
         action="store_true",
         help=(
@@ -359,6 +369,7 @@ def parse_args():
         arguments.force_description,
         arguments.force_name,
         arguments.force_publish,
+        arguments.force_slug,
         arguments.ignore_unfound_codes,
         not arguments.live_run,
     )

--- a/codelists/scripts/bulk_import_codelists.py
+++ b/codelists/scripts/bulk_import_codelists.py
@@ -48,6 +48,7 @@ def main(
     force_new_version=False,
     force_description=False,
     force_name=False,
+    force_publish=False,
     ignore_unfound_codes=False,
     dry_run=True,
 ):
@@ -117,6 +118,7 @@ def main(
                 force_new_version,
                 force_description,
                 force_name,
+                force_publish,
                 ignore_unfound_codes,
             )
 
@@ -237,6 +239,7 @@ def get_post_data(
     force_new_version,
     force_description,
     force_name,
+    force_publish,
     ignore_unfound_codes,
 ):
     """
@@ -279,6 +282,8 @@ def get_post_data(
         post_data["description"] = description
     if force_name:
         post_data["name"] = codelist_name
+    if force_publish:
+        post_data["should_publish"] = True
     if ignore_unfound_codes:
         post_data["ignore_unfound_codes"] = True
 
@@ -312,6 +317,11 @@ def parse_args():
         "--force-name",
         action="store_true",
         help="Always update the name, even if it already exists.",
+    )
+    parser.add_argument(
+        "--force-publish",
+        action="store_true",
+        help="For new versions, this causes them to auto-publish rather than defaulting to under review.",
     )
     parser.add_argument(
         "--ignore-unfound-codes",
@@ -348,6 +358,7 @@ def parse_args():
         arguments.force_new_version,
         arguments.force_description,
         arguments.force_name,
+        arguments.force_publish,
         arguments.ignore_unfound_codes,
         not arguments.live_run,
     )

--- a/codelists/scripts/bulk_import_codelists.py
+++ b/codelists/scripts/bulk_import_codelists.py
@@ -48,6 +48,7 @@ def main(
     force_new_version=False,
     force_description=False,
     force_name=False,
+    ignore_unfound_codes=False,
     dry_run=True,
 ):
     if dry_run:
@@ -116,6 +117,7 @@ def main(
                 force_new_version,
                 force_description,
                 force_name,
+                ignore_unfound_codes,
             )
 
             message_part = f"new {'version for ' if action == 'update' else ''}{coding_system_id} codelist '{codelist_name}'"
@@ -235,6 +237,7 @@ def get_post_data(
     force_new_version,
     force_description,
     force_name,
+    ignore_unfound_codes,
 ):
     """
     Return the relevant data to post to the api endpoint to create a new
@@ -276,6 +279,8 @@ def get_post_data(
         post_data["description"] = description
     if force_name:
         post_data["name"] = codelist_name
+    if ignore_unfound_codes:
+        post_data["ignore_unfound_codes"] = True
 
     return codelist_name, coding_system_id, post_data
 
@@ -309,6 +314,17 @@ def parse_args():
         help="Always update the name, even if it already exists.",
     )
     parser.add_argument(
+        "--ignore-unfound-codes",
+        action="store_true",
+        help=(
+            "If set, will force the creation of codelists even if the codes "
+            "aren't found in the coding system. This is useful if e.g. you "
+            "are importing the PCD refsets which occasionally contain codes "
+            "from the clinical AND medication SNOMED dictionaries. This causes "
+            "unfound codes to be ignored, but appends the ignored codes to the description."
+        ),
+    )
+    parser.add_argument(
         "--live-run",
         action="store_true",
         help=(
@@ -332,6 +348,7 @@ def parse_args():
         arguments.force_new_version,
         arguments.force_description,
         arguments.force_name,
+        arguments.ignore_unfound_codes,
         not arguments.live_run,
     )
 

--- a/codelists/scripts/bulk_import_codelists.py
+++ b/codelists/scripts/bulk_import_codelists.py
@@ -46,6 +46,8 @@ def main(
     config,
     host,
     force_new_version=False,
+    force_description=False,
+    force_name=False,
     dry_run=True,
 ):
     if dry_run:
@@ -108,7 +110,12 @@ def main(
             assert len(set(df["coding_system"])) == 1
 
             codelist_name, coding_system_id, post_data = get_post_data(
-                config, df, action == "create", force_new_version
+                config,
+                df,
+                action == "create",
+                force_new_version,
+                force_description,
+                force_name,
             )
 
             message_part = f"new {'version for ' if action == 'update' else ''}{coding_system_id} codelist '{codelist_name}'"
@@ -221,7 +228,14 @@ def process_file_to_dataframe(filepath, config):
     return codelist_df
 
 
-def get_post_data(config, codelist_df, create_new_codelist, force_new_version):
+def get_post_data(
+    config,
+    codelist_df,
+    create_new_codelist,
+    force_new_version,
+    force_description,
+    force_name,
+):
     """
     Return the relevant data to post to the api endpoint to create a new
     codelist or codelist version
@@ -258,6 +272,11 @@ def get_post_data(config, codelist_df, create_new_codelist, force_new_version):
             }
         )
 
+    if force_description:
+        post_data["description"] = description
+    if force_name:
+        post_data["name"] = codelist_name
+
     return codelist_name, coding_system_id, post_data
 
 
@@ -278,6 +297,16 @@ def parse_args():
         "-f",
         action="store_true",
         help="Always create a new version, even if a version with identical codes already exists.",
+    )
+    parser.add_argument(
+        "--force-description",
+        action="store_true",
+        help="Always update the description, even if it already exists.",
+    )
+    parser.add_argument(
+        "--force-name",
+        action="store_true",
+        help="Always update the name, even if it already exists.",
     )
     parser.add_argument(
         "--live-run",
@@ -301,6 +330,8 @@ def parse_args():
         config,
         arguments.host,
         arguments.force_new_version,
+        arguments.force_description,
+        arguments.force_name,
         not arguments.live_run,
     )
 

--- a/codelists/scripts/nhsd_primary_care_refsets.json
+++ b/codelists/scripts/nhsd_primary_care_refsets.json
@@ -9,11 +9,11 @@
     },
     "tag": "20241205",
     "column_aliases": {
-        "codelist_name": "Cluster_description",
-        "code": "SNOMED_code",
-        "term": "SNOMED_code_description",
-        "codelist_description":"Cluster_ID"
+        "codelist_name": "Cluster_Desc",
+        "code": "ConceptId",
+        "term": "ConceptId_Description",
+        "codelist_description": "Cluster_ID",
+        "codelist_new_slug": "Cluster_Slug"
     },
-    "description_template":"Taken from the `%s` refset published by NHSD.",
-    "delimiter":"\t"
+    "description_template": "Taken from the `%s` refset published by NHSD. Contains public sector information licensed under the UK Open Government Licence v3.0 (https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/)."
 }

--- a/codelists/scripts/update_pcd_refsets.py
+++ b/codelists/scripts/update_pcd_refsets.py
@@ -1,0 +1,432 @@
+#!/usr/bin/env python
+
+"""
+Script to automatically update NHS Primary Care Domain Refsets
+
+These are released whenever they are updated i.e. not on a particular release cycle. There
+are roughly 4 a year. This script allows them to be loaded into opencodelists, as either new
+versions of existing codelists, or new codelists if they don't yet exist.
+
+This script:
+1. Fetches available releases from TRUD API
+2. Identifies releases the same or newer than the current one
+3. Downloads and extracts a particular release
+4. Optionally filters to specific Cluster_IDs (refset IDs) if provided
+5. Updates the configuration JSON with the new release date (if --live-run is set)
+6. Runs the bulk import process with the new files
+
+The bulk import process will tell you how many success/failures there were. It is worth
+trying to rerun the script for any failed imports (assuming there aren't that many). See
+below for how to run just for a few cluster ids.
+
+Usage:
+    TRUD_API_KEY=your_api_key python codelists/scripts/update_pcd_refsets.py [--live-run] [REFSET_ID [REFSET_ID ...]]
+
+Flags:
+    --live-run      Actually update the config and run the bulk import for real (not a dry run).
+                    If not set, the script will perform a dry run and not update the config.
+    --host          Base URL for the API (default: http://localhost:7000) but likely
+                    https://www.opencodelists.org/ for the live run
+
+Arguments:
+    REFSET_ID       Optional space-separated list of Cluster_IDs (refset IDs) to include in the output CSV.
+                    If omitted, all clusters are included.
+
+Examples:
+    # Dry run, process only specific clusters
+    TRUD_API_KEY=your_api_key python codelists/scripts/update_pcd_refsets.py ANTIPSYONLYDRUG_COD C19ACTIVITY_COD
+
+    # Live run, process all clusters
+    TRUD_API_KEY=your_api_key python codelists/scripts/update_pcd_refsets.py --live-run --host https://www.opencodelists.org/
+
+
+"""
+
+import csv
+import json
+import os
+import re
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+from zipfile import ZipFile
+
+import requests
+
+
+CONFIG_FILE = Path(__file__).parent / "nhsd_primary_care_refsets.json"
+TRUD_API_ENDPOINT = "https://isd.digital.nhs.uk/trud/api/v1/keys/{}/items/659/releases"
+CLUSTER_REFSET_PATTERN = r"GPData_Cluster_Refset_1000230_\d+\.csv"
+
+
+def get_tag_and_coding_system(config_file):
+    """Return the 'tag' and the first key from 'coding_systems' in the config file."""
+    print(f"\nReading config file ({config_file}):")
+    with open(config_file) as f:
+        config = json.load(f)
+    tag = config.get("tag")
+    coding_systems = config.get("coding_systems", {})
+    first_coding_system = next(iter(coding_systems), None)
+    print(f" - Current tag: {tag}")
+    print(f" - Coding system: {first_coding_system}")
+    return tag, first_coding_system
+
+
+def fetch_pcd_releases(api_key, current_tag):
+    """
+    Fetch available releases from TRUD API, filter to those the same or newer
+    than the current tag, and return the tag, id, date, and url.
+    The "releases" array from TRUD looks like:
+    {
+      "id": "'uk_sct2pc_56.0.0_20250627000000Z.zip',
+      "releaseDate": "2025-06-30",
+      "archiveFileUrl": "https://isd.digital.nhs.uk/.../uk_sct2pc_56.0.0_20250627000000Z.zip"
+      ...
+    }
+    """
+    msg = "\nFetching available releases..."
+    if current_tag:
+        msg += f" (the same or newer than the current tag: {current_tag})"
+    print(msg)
+    response = requests.get(TRUD_API_ENDPOINT.format(api_key))
+    response.raise_for_status()
+    raw_releases = response.json().get("releases", [])
+    releases = []
+    for release in raw_releases:
+        release_date = release.get("releaseDate", "")
+        release_id = release.get("id", "")
+        match = re.search(r"uk_sct2pc_\d+\.\d+\.\d+_(\d{8})", release_id)
+        release_tag = match.group(1) if match else release_date.replace("-", "")
+        if current_tag and release_tag >= current_tag:
+            releases.append(
+                {
+                    "id": release_id,
+                    "tag": release_tag,
+                    "date": release_date,
+                    "url": release.get("archiveFileUrl", ""),
+                }
+            )
+    releases.sort(key=lambda r: r["tag"], reverse=True)
+    print(f" - Found {len(releases)} releases")
+    return releases
+
+
+def download_and_extract(url, output_dir):
+    """Download and extract the archive from the given URL."""
+    print("\nDownload and extracting zip from TRUD:")
+    with tempfile.NamedTemporaryFile(suffix=".zip", delete=False) as temp_file:
+        print(f" - Downloading from {url}...")
+        response = requests.get(url, stream=True)
+        response.raise_for_status()
+        for chunk in response.iter_content(chunk_size=8192):
+            temp_file.write(chunk)
+
+    try:
+        with ZipFile(temp_file.name) as zip_file:
+            print(" - Extracting archive...")
+            zip_file.extractall(output_dir)
+
+            # Find the cluster refset CSV file
+            cluster_files = []
+            for root, _, files in os.walk(output_dir):
+                for file in files:
+                    if re.match(CLUSTER_REFSET_PATTERN, file):
+                        cluster_files.append(os.path.join(root, file))
+
+            # if not cluster_files:
+            #     # Look for files in SupportingProducts directory
+            #     supporting_dir = os.path.join(output_dir, "SupportingProducts")
+            #     if os.path.exists(supporting_dir):
+            #         for root, _, files in os.walk(supporting_dir):
+            #             for file in files:
+            #                 if file.endswith(".csv") and "Cluster_Refset" in file:
+            #                     cluster_files.append(os.path.join(root, file))
+
+            if not cluster_files:
+                raise FileNotFoundError(
+                    "No cluster refset CSV file found in the archive"
+                )
+
+            assert len(cluster_files) == 1, (
+                "Multiple cluster refset CSV files found - which is unexpected"
+            )
+            print(f" - Extracted cluster file: {cluster_files[0]}")
+            return cluster_files[0]
+    finally:
+        os.unlink(temp_file.name)
+
+
+def get_latest_db_release_from_api(base_url, coding_system_id):
+    """
+    Fetch the latest available database release for the coding system from the API.
+    Returns the database_alias string (e.g., 'snomedct_4000_20250416') or None.
+    """
+    url = f"{base_url}/coding-systems/latest-releases?type=json"
+    try:
+        resp = requests.get(url)
+        resp.raise_for_status()
+        data = resp.json()
+        if coding_system_id in data and "database_alias" in data[coding_system_id]:
+            return data[coding_system_id]["database_alias"]
+        else:
+            print(f"No database_alias found for {coding_system_id} in API response.")
+            return None
+    except Exception as e:
+        print(f"Error fetching latest DB release from API: {e}")
+        return None
+
+
+def update_config_file(config_file, base_url, new_tag, coding_system_id):
+    """Update the config file with the new tag and database release."""
+    with open(config_file) as f:
+        config = json.load(f)
+
+    config["tag"] = new_tag
+
+    db_release = get_latest_db_release_from_api(base_url, coding_system_id)
+
+    # Update the coding system release
+    if (
+        db_release
+        and "coding_systems" in config
+        and coding_system_id in config["coding_systems"]
+    ):
+        config["coding_systems"][coding_system_id]["release"] = db_release
+
+    with open(config_file, "w") as f:
+        json.dump(config, f, indent=4)
+        f.write("\n")
+
+    print(f"\nUpdated config file with new tag: {new_tag}\n")
+
+
+def parse_args():
+    import argparse
+
+    parser = argparse.ArgumentParser(
+        description="Update NHS Primary Care Domain Refsets"
+    )
+    parser.add_argument(
+        "--live-run",
+        action="store_true",
+        help="If set, update config and run bulk import for real (not a dry run)",
+    )
+    parser.add_argument(
+        "--host",
+        default="http://localhost:7000",
+        help="Base URL for the API (default: http://localhost:7000)",
+    )
+    parser.add_argument(
+        "names",
+        nargs="*",
+        help="Optional list of Cluster_IDs to include in the output CSV. If omitted, all are included.",
+    )
+    return parser.parse_args()
+
+
+def run_bulk_import(cluster_file, config_file, host, release, live_run, names=None):
+    """Run the bulk import script with the extracted file."""
+    bulk_import_script = Path(__file__).parent / "bulk_import_codelists.py"
+
+    if not os.environ.get("API_TOKEN"):
+        print(
+            "Warning: API_TOKEN environment variable not set. Import will be a dry run. "
+            "Rerun the command prefixed with:\n"
+            "         API_TOKEN=xxx <existing command>\n"
+            "         to pass the API_TOKEN.\n"
+            "NB the API_TOKEN is for connecting to the opencodelists API (either locally "
+            "or in production. The TRUD_API_KEY is different, and is what is needed to get "
+            "the PCD refset files from TRUD."
+        )
+        live_run = False
+
+    cmd = [
+        "python3",
+        str(bulk_import_script),
+        str(cluster_file),
+        str(config_file),
+        "--host",
+        host,
+    ]
+    if live_run:
+        cmd.append("--live-run")
+        cmd.append("--force-new-version")
+        cmd.append("--force-description")
+        cmd.append("--force-name")
+        cmd.append("--force-slug")
+        cmd.append("--force-publish")
+        cmd.append("--ignore-unfound-codes")
+
+    # Prompt user for confirmation
+    print("\nAbout to process the following release:")
+    print(f"  Release ID: {release['id']}")
+    print(f"  Tag: {release['tag']}")
+    if names:
+        print(f"  Filtering to Cluster_IDs: {', '.join(names)}")
+    else:
+        print("  Including ALL Cluster_IDs.")
+    print(f"  This will be a {f'LIVE RUN against {host}' if live_run else 'DRY RUN'}")
+    proceed = input("Proceed? [Y/n]: ").strip().lower()
+    if proceed not in ("", "y", "yes"):
+        print("Aborted.")
+        return
+
+    print(f"Running bulk import: {' '.join(cmd)}")
+    subprocess.run(cmd, check=True)
+
+
+def process_cluster_file(input_file, output_file, names=None):
+    """
+    Process the cluster file to extract only the needed columns and handle encoding issues.
+    Optionally filter to only rows where Cluster_ID is in names (case-insensitive).
+    Returns the number of rows written.
+    """
+    print(f"\nProcessing {input_file} to extract required columns...")
+
+    names_lower = set(n.lower() for n in names) if names else None
+
+    # The csv files are typically encoded with "Windows 1252" format, but adding fallbacks
+    # here in case it changes
+    encodings = ["cp1252", "utf-8", "latin-1", "iso-8859-1"]
+    for encoding in encodings:
+        try:
+            with (
+                open(input_file, encoding=encoding, newline="") as infile,
+                open(output_file, "w", encoding="utf-8", newline="") as outfile,
+            ):
+                reader = csv.DictReader(infile)
+                fieldnames = [
+                    "Cluster_Desc",
+                    "ConceptId",
+                    "ConceptId_Description",
+                    "Cluster_ID",
+                    "Cluster_Slug",
+                ]
+                writer = csv.DictWriter(outfile, fieldnames=fieldnames, delimiter=",")
+                writer.writeheader()
+                row_count = 0
+                for row in reader:
+                    cluster_id = row.get("Cluster_ID", "")
+                    # Active_in_Refset is used to "retire" codes from a refset. These codes were
+                    # incorrectly included in the past so we should ignore them. NB this is
+                    # separate to "inactive" SNOMED codes. Refsets can contain "inactive" codes
+                    # (which is in the unused Active_Code_Status field in this csv) and we want to
+                    # include those because analyses may well involve a time when these codes were active.
+                    # The possible "Type_of_Inclusion" values are "PC refset" for the primary care (clinical)
+                    # ones, and "Refset" for the drug refsets. We currently only import the clinical ones.
+                    if (
+                        row.get("Active_in_Refset") == "1"
+                        and row.get("Type_of_Inclusion") == "PC refset"
+                        and (not names_lower or cluster_id.lower() in names_lower)
+                    ):
+                        new_row = {
+                            "Cluster_Desc": row.get("Cluster_Desc", ""),
+                            "ConceptId": row.get("ConceptId", ""),
+                            "ConceptId_Description": row.get(
+                                "ConceptId_Description", ""
+                            ),
+                            "Cluster_ID": cluster_id,
+                            "Cluster_Slug": cluster_id,
+                        }
+                        writer.writerow(new_row)
+                        row_count += 1
+                print(
+                    f" - Successfully processed file using {encoding} encoding. {row_count} rows written to {output_file}"
+                )
+                return output_file, row_count
+        except UnicodeDecodeError:
+            print(f"Failed to decode with {encoding}, trying next encoding...")
+    raise ValueError(
+        f"Could not process file {input_file} with any of the tried encodings"
+    )
+
+
+def get_user_choice_for_release(releases, current_tag):
+    print("\nPlease select which release you want to import:")
+    for i, release in enumerate(releases):
+        msg = f"  [{i + 1}] {release['id']} (Release date: {release['date']}, Tag: {release['tag']})"
+        if release["tag"] == current_tag:
+            msg += "   <-- CURRENT TAG"
+        print(msg)
+
+    while True:
+        try:
+            choice = input(
+                f"Select a release to use {f'[1-{len(releases)}] ' if len(releases) > 1 else ''}(default: 1): "
+            )
+            if not choice:
+                choice = 1
+            else:
+                choice = int(choice)
+
+            if 1 <= choice <= len(releases):
+                release_to_use = releases[choice - 1]
+                break
+            else:
+                print(f"Please enter a number between 1 and {len(releases)}")
+        except ValueError:
+            print("Please enter a valid number")
+
+    print(f"Processing release: {release_to_use['id']} (tag: {release_to_use['tag']})")
+    return release_to_use
+
+
+def main():
+    args = parse_args()
+    # Check for API key
+    api_key = os.environ.get("TRUD_API_KEY")
+    if not api_key:
+        print("Error: TRUD_API_KEY environment variable must be set")
+        sys.exit(1)
+
+    # Get current tag from config
+    current_tag, coding_system_id = get_tag_and_coding_system(CONFIG_FILE)
+
+    # Fetch possible new releases
+    releases = fetch_pcd_releases(api_key, current_tag)
+
+    if not releases:
+        print(
+            f"No releases found. The current version ({current_tag}) is newer "
+            "than all releases available from the TRUD api. Something's gone "
+            "wrong because you should always at least match the latest tag."
+        )
+        exit(0)
+
+    release_to_use = get_user_choice_for_release(releases, current_tag)
+
+    # Create temporary directory for extraction
+    with tempfile.TemporaryDirectory() as temp_dir:
+        # Download and extract
+        cluster_file = download_and_extract(release_to_use["url"], temp_dir)
+
+        # Process the file to extract only the columns we need
+        processed_filename = f"processed_{os.path.basename(cluster_file)}"
+        target_file = Path(temp_dir) / processed_filename
+        processed_file, row_count = process_cluster_file(
+            cluster_file, target_file, names=args.names
+        )
+        if row_count == 0:
+            print("\nNo rows matched the filter. Skipping bulk import.")
+            return
+        # Only update config and pass --live-run if requested
+        if args.live_run:
+            update_config_file(
+                CONFIG_FILE, args.host, release_to_use["tag"], coding_system_id
+            )
+        else:
+            print("\nDry run: not updating config file and not running live import.\n")
+
+        run_bulk_import(
+            processed_file,
+            CONFIG_FILE,
+            args.host,
+            release_to_use,
+            live_run=args.live_run,
+            names=args.names,
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/coding_systems/versioning/views.py
+++ b/coding_systems/versioning/views.py
@@ -17,6 +17,20 @@ def latest_releases(request):
             if cs.has_database
         ]
     }
+
+    if request.GET.get("type") == "json":
+        data = {
+            lr.id: {
+                "name": lr.name,
+                "release_name": lr.release_name,
+                "valid_from": lr.release.valid_from,
+                "import_timestamp": lr.release.import_timestamp,
+                "database_alias": lr.database_alias,
+            }
+            for lr in ctx["latest_releases"]
+        }
+        return JsonResponse(data)
+
     return render(request, "versioning/latest_releases.html", ctx)
 
 


### PR DESCRIPTION
Fixes #2668 

Running the script provides an interactive CLI to update the NHS PCD refsets. Previously this was [a manual process](https://github.com/opensafely-core/opencodelists/issues/2163).

This addresses the automation part of #2671 but not the scheduling part.

The commit messages provide more detail as to the exact behaviour of the script. But the key things are:
- we now overwrite the name and description of the codelists as we want them to always match the latest (and sometimes the names change)
- the description now includes the OGLv3 message to comply (we think) with the licence
- any unfound codes (e.g. medication codes in a clinical refset) are automatically omitted and explicitly listed in the description

### Steps when running
The first time this runs we will need to take some extra steps. These will not be necessary for future runs. They also act as a way for a reviewer to test the script. To test properly you would need a version of the database that contains the PCD refsets. You also need a `TRUD_API_KEY` associated with an account that has access to the PCD refsets (https://isd.digital.nhs.uk/trud/users/authenticated/filters/0/categories/8/items/659/releases). It is free to sign up, but takes a day or two to be authorised to access a dataset.

1. Set all PCD refsest to have " (obsolete)" appended to their names:
```bash
just manage shell
```
```python
from codelists.models import Handle
from opencodelists.models import Organisation

org = Organisation.objects.get(name="NHSD Primary Care Domain Refsets")
handles = Handle.objects.filter(organisation=org, is_current=True).exclude(slug__contains="_")
print(f"Found {handles.count()} current handles")

# Update each handle by appending " (obsolete)" to the name
for handle in handles:
    original_name = handle.name
    if not original_name.endswith(" (obsolete)"):
        handle.name = f"{original_name} (obsolete)"
        handle.save()
        print(f"Updated: {original_name} → {handle.name}")
    else:
        print(f"Skipped: {original_name} (already marked as obsolete)")
```
2. Back up your database so we can restore later if it goes wrong
```bash
cp db.sqlite3 db.sqlite3.bak
```
3. Run the update script. This requires both an `API_TOKEN` (for using the opencodelists API), and a `TRUD_API_KEY` to be set.
```bash
API_TOKEN=xxx codelists/scripts/update_pcd_refsets.py --live-run
```
(this will run against localhost by default - live-run is just so it actually makes changes rather than tell you what changes it would make)

4. If any fail, you can rerun but append the cluster ids e.g. to run for just `AST_COD` and `FLU_COD`:
```bash
codelists/scripts/update_pcd_refsets.py --live-run ast_cod flu_cod
```

Here are the four different scenarios and what to expect:

#### Existing refset with the correct slug
http://localhost:7000/codelist/nhsd-primary-care-domain-refsets/ast_cod/
- happy path
- After update all versions, including the latest one, shown correctly.
- The (obsolete) tag will have been removed by the update because names are overwritten

#### New refset that didn't previously exist
http://localhost:7000/codelist/nhsd-primary-care-domain-refsets/mmrvvac1_cod/
- It will have been successfully imported

#### Existing refset that only exists with the wrong slug
http://localhost:7000/codelist/nhsd-primary-care-domain-refsets/acquired-immune-deficiency-syndrome-aids-codes/20241205
- After update the above url will still work, but so will urls with the correct slug of `aids_cod`. If you enter the slug in the url but not the date tag, then the old slug will redirect to the new slug.
- The (obsolete) tag will have been removed by the update because names are overwritten

#### Existing refset that exists with the correct AND the wrong slug
http://localhost:7000/codelist/nhsd-primary-care-domain-refsets/adult-and-child-psoriasis-codes/
http://localhost:7000/codelist/nhsd-primary-care-domain-refsets/psoriasis_cod/

- The latest version will appear under "psoriasis_cod"
- The obsolete label will have been removed by the update because names are overwritten
- The wrong slug will still exist, but now display an (obsolete) message

*NB for future runs we will just need to run the script. The `obsolete` dance was just to fix errors introduced by the previous manual process.*