### PR TITLE
Move migrations into dokku release phase

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -48,6 +48,7 @@ jobs:
 
       - name: Test image we imported from previous job works
         run: |
+            SKIP_BUILD=1 just docker-migrate prod
             SKIP_BUILD=1 just docker-serve prod -d
             sleep 5
             just docker-smoke-test || { docker logs docker_prod_1; exit 1; }

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -70,6 +70,9 @@ jobs:
 
       - name: Run smoke test on prod
         run: |
+          # ensure migrations are applied now that they are not part of the docker file
+          just docker-migrate prod
+          # start the server and run a smoke test
           just docker-serve prod -d
           sleep 5
           just docker-smoke-test || {

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -72,7 +72,16 @@ jobs:
         run: |
           just docker-serve prod -d
           sleep 5
-          just docker-smoke-test || { docker logs docker_prod_1; exit 1; }
+          just docker-smoke-test || {
+            echo "Smoke test failed. Listing all containers:";
+            docker ps -a;
+            echo "Attempting to show logs for all containers:";
+            for c in $(docker ps -a --format '{{.Names}}'); do
+              echo "Logs for $c:";
+              docker logs "$c" || true;
+            done
+            exit 1
+          }
 
       - name: Save docker image
         run: |

--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,2 @@
+release: python manage.py check --deploy && python manage.py migrate
+web: gunicorn --config /app/deploy/gunicorn/conf.py opencodelists.wsgi

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -171,8 +171,6 @@ COPY . /app
 RUN TRUD_API_KEY=dummy-key SECRET_KEY=dummy-key \
     python /app/manage.py collectstatic --no-input
 
-ENTRYPOINT ["/app/docker/entrypoints/prod.sh"]
-
 # We set command rather than entrypoint, to make it easier to run different
 # things from the cli
 CMD ["gunicorn", "--config", "/app/deploy/gunicorn/conf.py", "opencodelists.wsgi"]

--- a/docker/entrypoints/prod.sh
+++ b/docker/entrypoints/prod.sh
@@ -1,8 +1,0 @@
-#!/bin/bash
-
-set -euo pipefail
-
-./manage.py check --deploy
-./manage.py migrate
-
-exec "$@"

--- a/docker/justfile
+++ b/docker/justfile
@@ -35,6 +35,9 @@ check-py env="dev": build
 check-migrations env="dev" *args="": build
     docker compose run --rm {{ env }} python manage.py makemigrations --check {{ args }}
 
+migrate env="dev": (_create_storage env)
+    docker compose run --rm {{ env }} bash -c 'python manage.py check && python manage.py migrate'
+
 # run Python (non-functional) tests in docker container
 test-py *args="":
     docker compose run --rm test python -m pytest \

--- a/docs/adr/0005-migrations-during-dokku-in-release-phase.md
+++ b/docs/adr/0005-migrations-during-dokku-in-release-phase.md
@@ -1,0 +1,53 @@
+# ADR: Run Django Migrations in Dokku Release Phase
+
+Date: 2025-05
+
+## Status
+
+Draft
+
+## Context
+
+Previously, we had a `prod.sh` script that ran the database migrations and then called `exec "$@"` in order to execute whatever command was passed as arguments to the script. The Dockerfile was
+
+```docker
+ENTRYPOINT ["/app/docker/entrypoints/prod.sh"]
+CMD ["gunicorn", "--config", "/app/deploy/gunicorn/conf.py", "opencodelists.wsgi"]
+```
+
+Meaning that when the docker container was run, without additional arguments, this command would execute:
+
+```bash
+prod.sh gunicorn --config /app/deploy/gunicorn/conf.py opencodelists.wsgi
+```
+Causing the migrations to run, and gunicorn to start. You could also pass a command to `docker run` which would then execute (instead of gunicorn) after the migrations.
+
+With this setup, migrations were run every time the container started, including during the web process startup and health checks. This approach had caused issues, including an outage to job-server where migrations were not fully applied.
+
+[Dokku recommend](https://dokku.com/docs/advanced-usage/deployment-tasks/) running database migrations in the `release` phase, which is executed before the new web process is started. This ensures migrations are applied atomically and safely, and that the web process only starts after the database schema is up to date.
+
+## Decision
+
+- **Move** the migration and check logic to the `release` phase in the `Procfile` and add the `web` command:
+  ```
+  release: ./manage.py check --deploy && ./manage.py migrate
+  web: gunicorn --config /app/deploy/gunicorn/conf.py opencodelists.wsgi
+  ```
+- **Remove** the `ENTRYPOINT` from the production Docker image.
+- **Delete** the now-obsolete `prod.sh` entrypoint script.
+- **Keep** the `CMD` in the Dockerfile so `docker run` will still start Gunicorn by default, but can be overriden
+
+## Consequences
+
+- Migrations are now run in the correct place (Dokku's release phase), before the web process starts.
+- Deploys are safer and more predictable, with no risk of web processes starting before migrations are complete.
+- No scripts or documentation referenced or used the old `prod.sh` entrypoint, so no further changes were needed following its deletion.
+- The dev docker image overwrites the ENTRYPOINT and so is unaffected by its removal
+- The `CMD` in the Dockerfile remains, allowing for easy overriding of the command when running the container.
+
+
+## Changes
+
+- `docker/Dockerfile`: Removed ENTRYPOINT, kept CMD for Gunicorn.
+- `docker/entrypoints/prod.sh`: Deleted.
+- `Procfile`: Added release phase for migrations and checks, and web phase for Gunicorn.

--- a/justfile
+++ b/justfile
@@ -307,6 +307,9 @@ docker-check-js: _env
 docker-check-py: _env
     {{ just_executable() }} docker/check-py {{ docker_env }}
 
+# run migrations in docker container
+docker-migrate env="dev": _env
+    {{ just_executable() }} docker/migrate {{ if env == "dev" { docker_env } else { env } }}
 
 # run python non-functional tests in docker container
 docker-test-py *args="": _env


### PR DESCRIPTION
- moved migrations into the "release" phase of the Procfile
- move the gunicorn command to the "web" phase of the Procfile
- remove the now redundant prod.sh file
- add an ADR explaining the decision