### PR TITLE
Display number of included codes in metadata

### DIFF
--- a/codelists/views/version.py
+++ b/codelists/views/version.py
@@ -77,5 +77,6 @@ def version(request, clv):
         "can_create_new_version": can_create_new_version,
         "tree_data": tree_data,
         "latest_published_version_url": latest_published_version_url,
+        "count_codes_included": len(rows),
     }
     return render(request, "codelists/version.html", ctx)

--- a/opencodelists/settings.py
+++ b/opencodelists/settings.py
@@ -119,6 +119,7 @@ INSTALLED_APPS = [
     "django.contrib.admin",
     "django.contrib.auth",
     "django.contrib.contenttypes",
+    "django.contrib.humanize",
     "django.contrib.sessions",
     "django.contrib.messages",
     "django.contrib.staticfiles",

--- a/templates/codelists/version.html
+++ b/templates/codelists/version.html
@@ -1,6 +1,7 @@
 {% extends 'base.html' %}
 
 {% load django_vite %}
+{% load humanize %}
 
 {% block title_extra %}: {{ codelist.name }}{% endblock %}
 
@@ -180,7 +181,7 @@
             <dt>
               Number of codes included
             </dt>
-            <dd class="mb-0">{{ count_codes_included }}</dd>
+            <dd class="mb-0">{{ count_codes_included|intcomma }}</dd>
           </div>
         {% endif %}
       </dl>

--- a/templates/codelists/version.html
+++ b/templates/codelists/version.html
@@ -174,6 +174,15 @@
           </dt>
           <dd class="mb-0">{{ clv.hash }}</dd>
         </div>
+
+        {% if count_codes_included %}
+          <div class="list-group-item py-1 px-2">
+            <dt>
+              Number of codes included
+            </dt>
+            <dd class="mb-0">{{ count_codes_included }}</dd>
+          </div>
+        {% endif %}
       </dl>
     </section>
   </div>


### PR DESCRIPTION
So that users can quickly identify the number of codes in a codelist

Closes #2697 