### PR TITLE
Fix for tab data being pushed over footer

### DIFF
--- a/templates/codelists/_about_tab.html
+++ b/templates/codelists/_about_tab.html
@@ -42,7 +42,7 @@
     <p>No metadata has been provided for this codelist.</p>
   {% endif %}
 
-  <div class="small mt-auto pt-4">
+  <div class="small pt-4">
     <hr>
     <p>
       Codelists are developed by a broad community of users for individual study purposes, which


### PR DESCRIPTION
A flexbox margin top issue is causing the About tab lower data to be pushed over the footer. This PR removes the margin top, which fixes the issue.

[Example link](https://www.opencodelists.org/codelist/opensafely/ace-inhibitor-medications/2020-05-19/)

<img width="1241" alt="Screenshot showing overlapping text due to this bug" src="https://github.com/user-attachments/assets/76993aa2-d877-4614-a3b0-ee56526aefa0" />
