### PR TITLE
Use non-default Vite `port` to avoid clashes

### DIFF
--- a/templates/builder/draft.html
+++ b/templates/builder/draft.html
@@ -30,7 +30,7 @@
 
   {% if debug %}
     <script type="module" nonce="{{ request.csp_nonce }}">
-      import RefreshRuntime from 'http://localhost:5173/static/@react-refresh'
+      import RefreshRuntime from 'http://localhost:7001/static/@react-refresh'
       RefreshRuntime.injectIntoGlobalHook(window)
       window.$RefreshReg$ = () => {}
       window.$RefreshSig$ = () => (type) => type

--- a/templates/codelists/version.html
+++ b/templates/codelists/version.html
@@ -359,7 +359,7 @@
 
   {% if debug %}
     <script type="module" nonce="{{ request.csp_nonce }}">
-      import RefreshRuntime from 'http://localhost:5173/static/@react-refresh'
+      import RefreshRuntime from 'http://localhost:7001/static/@react-refresh'
       RefreshRuntime.injectIntoGlobalHook(window)
       window.$RefreshReg$ = () => {}
       window.$RefreshSig$ = () => (type) => type

--- a/vite.config.mjs
+++ b/vite.config.mjs
@@ -23,7 +23,9 @@ export default defineConfig(({ mode }) => ({
     emptyOutDir: true,
   },
   server: {
-    origin: "http://localhost:5173",
+    origin: "http://localhost:7001",
+    port: 7001,
+    strictPort: true,
   },
   clearScreen: false,
   plugins: [


### PR DESCRIPTION
Before this change, if you ran `run-assets` while another Vite server was
running somewhere on your local development system on also on the default port,
the new Vite server would automatically pick another free port, which would
then not match the origin configured and assets wouldn't load.

This would happen if trying to run `job-server` alongside `opencodelists`, for example.

Using port `7001` as this one more than `7000` used by the `just run`
webserver, so it's in the same "namespace".

Some templates have the port hardcoded in dev mode. Change those and
therefore use `strictPort` as it's required for those templates to work fully.