### PR TITLE
Remove unused included_codes and excluded_codes

### DIFF
--- a/assets/src/scripts/__tests__/fixtures/version_from_scratch.json
+++ b/assets/src/scripts/__tests__/fixtures/version_from_scratch.json
@@ -2,26 +2,26 @@
   "searches": [
     {
       "term_or_code": "code: 439656005",
-      "url": "/builder/3ce9e642/search/code:439656005/",
-      "delete_url": "/builder/3ce9e642/search/code:439656005/delete/",
+      "url": "/builder/71bb8ca2/search/13/code:439656005/",
+      "delete_url": "/builder/71bb8ca2/search/13/code:439656005/delete/",
       "active": false
     },
     {
       "term_or_code": "arthritis",
-      "url": "/builder/3ce9e642/search/arthritis/",
-      "delete_url": "/builder/3ce9e642/search/arthritis/delete/",
+      "url": "/builder/71bb8ca2/search/10/arthritis/",
+      "delete_url": "/builder/71bb8ca2/search/10/arthritis/delete/",
       "active": false
     },
     {
       "term_or_code": "elbow",
-      "url": "/builder/3ce9e642/search/elbow/",
-      "delete_url": "/builder/3ce9e642/search/elbow/delete/",
+      "url": "/builder/71bb8ca2/search/12/elbow/",
+      "delete_url": "/builder/71bb8ca2/search/12/elbow/delete/",
       "active": false
     },
     {
       "term_or_code": "tennis",
-      "url": "/builder/3ce9e642/search/tennis/",
-      "delete_url": "/builder/3ce9e642/search/tennis/delete/",
+      "url": "/builder/71bb8ca2/search/11/tennis/",
+      "delete_url": "/builder/71bb8ca2/search/11/tennis/delete/",
       "active": false
     }
   ],
@@ -60,16 +60,6 @@
     "429554009",
     "439656005",
     "73583000"
-  ],
-  "included_codes": [
-    "128133004",
-    "156659008",
-    "439656005"
-  ],
-  "excluded_codes": [
-    "116309007",
-    "238484001",
-    "3723001"
   ],
   "parent_map": {
     "103001000119108": [
@@ -864,63 +854,80 @@
     "73583000": "(+)"
   },
   "is_editable": true,
-  "update_url": "/builder/3ce9e642/update/",
-  "search_url": "/builder/3ce9e642/search/",
+  "update_url": "/builder/71bb8ca2/update/",
+  "search_url": "/builder/71bb8ca2/search/",
   "versions": [
     {
-      "tag_or_hash": "3ce9e642",
-      "url": "/codelist/test-university/new-style-codelist/3ce9e642/",
+      "tag_or_hash": "71bb8ca2",
+      "url": "/codelist/test-university/new-style-codelist/71bb8ca2/",
       "status": "draft",
-      "current": true
+      "current": true,
+      "created_at": "2025-07-18 10:27:11.079350+00:00"
     },
     {
-      "tag_or_hash": "55f95977",
-      "url": "/codelist/test-university/new-style-codelist/55f95977/",
+      "tag_or_hash": "0acaffd8",
+      "url": "/codelist/test-university/new-style-codelist/0acaffd8/",
       "status": "draft",
-      "current": false
+      "current": false,
+      "created_at": "2025-07-18 10:27:11.002476+00:00"
     },
     {
-      "tag_or_hash": "6f08ccac",
-      "url": "/codelist/test-university/new-style-codelist/6f08ccac/",
+      "tag_or_hash": "23da730d",
+      "url": "/codelist/test-university/new-style-codelist/23da730d/",
       "status": "draft",
-      "current": false
+      "current": false,
+      "created_at": "2025-07-18 10:27:10.817077+00:00"
+    },
+    {
+      "tag_or_hash": "6c560cb6",
+      "url": "/codelist/test-university/new-style-codelist/6c560cb6/",
+      "status": "under review",
+      "current": false,
+      "created_at": "2025-07-18 10:27:10.766556+00:00"
     },
     {
       "tag_or_hash": "05657fec",
       "url": "/codelist/test-university/new-style-codelist/05657fec/",
       "status": "under review",
-      "current": false
+      "current": false,
+      "created_at": "2025-07-18 10:27:10.754647+00:00"
     },
     {
       "tag_or_hash": "1e74f321",
       "url": "/codelist/test-university/new-style-codelist/1e74f321/",
-      "status": "under review",
-      "current": false
-    },
-    {
-      "tag_or_hash": "37846656",
-      "url": "/codelist/test-university/new-style-codelist/37846656/",
       "status": "published",
-      "current": false
+      "current": false,
+      "created_at": "2025-07-18 10:27:10.750497+00:00"
     }
   ],
   "metadata": {
-    "coding_system_name": "SNOMED CT",
+    "coding_system_id": "snomedct",
+    "coding_system_name": "SNOMED CT (UK Clinical Edition)",
     "coding_system_release": {
       "release_name": "test",
       "valid_from": "2020-01-01"
     },
     "organisation_name": "Test University",
     "codelist_full_slug": "test-university/new-style-codelist",
-    "hash": "3ce9e642",
-    "description":{
-      "text": "",
+    "hash": "71bb8ca2",
+    "codelist_name": "New-style Codelist",
+    "description": {
+      "text": null,
       "html": ""
     },
-    "methodology":{
-      "text": "",
+    "methodology": {
+      "text": null,
       "html": ""
     },
-    "references": []
+    "references": [
+      {
+        "text": "Reference 1",
+        "url": "https://example.com/reference1"
+      },
+      {
+        "text": "Reference 2",
+        "url": "https://example.com/reference2"
+      }
+    ]
   }
 }

--- a/assets/src/scripts/__tests__/fixtures/version_with_complete_searches.json
+++ b/assets/src/scripts/__tests__/fixtures/version_with_complete_searches.json
@@ -2,26 +2,26 @@
   "searches": [
     {
       "term_or_code": "code: 439656005",
-      "url": "/builder/3ce9e642/search/code:439656005/",
-      "delete_url": "/builder/3ce9e642/search/code:439656005/delete/",
+      "url": "/builder/71bb8ca2/search/13/code:439656005/",
+      "delete_url": "/builder/71bb8ca2/search/13/code:439656005/delete/",
       "active": false
     },
     {
       "term_or_code": "arthritis",
-      "url": "/builder/3ce9e642/search/arthritis/",
-      "delete_url": "/builder/3ce9e642/search/arthritis/delete/",
+      "url": "/builder/71bb8ca2/search/10/arthritis/",
+      "delete_url": "/builder/71bb8ca2/search/10/arthritis/delete/",
       "active": false
     },
     {
       "term_or_code": "elbow",
-      "url": "/builder/3ce9e642/search/elbow/",
-      "delete_url": "/builder/3ce9e642/search/elbow/delete/",
+      "url": "/builder/71bb8ca2/search/12/elbow/",
+      "delete_url": "/builder/71bb8ca2/search/12/elbow/delete/",
       "active": false
     },
     {
       "term_or_code": "tennis",
-      "url": "/builder/3ce9e642/search/tennis/",
-      "delete_url": "/builder/3ce9e642/search/tennis/delete/",
+      "url": "/builder/71bb8ca2/search/11/tennis/",
+      "delete_url": "/builder/71bb8ca2/search/11/tennis/delete/",
       "active": false
     }
   ],
@@ -60,16 +60,6 @@
     "429554009",
     "439656005",
     "73583000"
-  ],
-  "included_codes": [
-    "128133004",
-    "156659008",
-    "439656005"
-  ],
-  "excluded_codes": [
-    "116309007",
-    "238484001",
-    "3723001"
   ],
   "parent_map": {
     "103001000119108": [
@@ -864,63 +854,80 @@
     "73583000": "(+)"
   },
   "is_editable": true,
-  "update_url": "/builder/3ce9e642/update/",
-  "search_url": "/builder/3ce9e642/search/",
+  "update_url": "/builder/71bb8ca2/update/",
+  "search_url": "/builder/71bb8ca2/search/",
   "versions": [
     {
-      "tag_or_hash": "3ce9e642",
-      "url": "/codelist/test-university/new-style-codelist/3ce9e642/",
+      "tag_or_hash": "71bb8ca2",
+      "url": "/codelist/test-university/new-style-codelist/71bb8ca2/",
       "status": "draft",
-      "current": true
+      "current": true,
+      "created_at": "2025-07-18 10:27:11.079350+00:00"
     },
     {
-      "tag_or_hash": "55f95977",
-      "url": "/codelist/test-university/new-style-codelist/55f95977/",
+      "tag_or_hash": "0acaffd8",
+      "url": "/codelist/test-university/new-style-codelist/0acaffd8/",
       "status": "draft",
-      "current": false
+      "current": false,
+      "created_at": "2025-07-18 10:27:11.002476+00:00"
     },
     {
-      "tag_or_hash": "6f08ccac",
-      "url": "/codelist/test-university/new-style-codelist/6f08ccac/",
+      "tag_or_hash": "23da730d",
+      "url": "/codelist/test-university/new-style-codelist/23da730d/",
       "status": "draft",
-      "current": false
+      "current": false,
+      "created_at": "2025-07-18 10:27:10.817077+00:00"
+    },
+    {
+      "tag_or_hash": "6c560cb6",
+      "url": "/codelist/test-university/new-style-codelist/6c560cb6/",
+      "status": "under review",
+      "current": false,
+      "created_at": "2025-07-18 10:27:10.766556+00:00"
     },
     {
       "tag_or_hash": "05657fec",
       "url": "/codelist/test-university/new-style-codelist/05657fec/",
       "status": "under review",
-      "current": false
+      "current": false,
+      "created_at": "2025-07-18 10:27:10.754647+00:00"
     },
     {
       "tag_or_hash": "1e74f321",
       "url": "/codelist/test-university/new-style-codelist/1e74f321/",
-      "status": "under review",
-      "current": false
-    },
-    {
-      "tag_or_hash": "37846656",
-      "url": "/codelist/test-university/new-style-codelist/37846656/",
       "status": "published",
-      "current": false
+      "current": false,
+      "created_at": "2025-07-18 10:27:10.750497+00:00"
     }
   ],
   "metadata": {
-    "coding_system_name": "SNOMED CT",
+    "coding_system_id": "snomedct",
+    "coding_system_name": "SNOMED CT (UK Clinical Edition)",
     "coding_system_release": {
       "release_name": "test",
       "valid_from": "2020-01-01"
     },
     "organisation_name": "Test University",
     "codelist_full_slug": "test-university/new-style-codelist",
-    "hash": "3ce9e642",
-    "description":{
-      "text": "",
+    "hash": "71bb8ca2",
+    "codelist_name": "New-style Codelist",
+    "description": {
+      "text": null,
       "html": ""
     },
-    "methodology":{
-      "text": "",
+    "methodology": {
+      "text": null,
       "html": ""
     },
-    "references": []
+    "references": [
+      {
+        "text": "Reference 1",
+        "url": "https://example.com/reference1"
+      },
+      {
+        "text": "Reference 2",
+        "url": "https://example.com/reference2"
+      }
+    ]
   }
 }

--- a/assets/src/scripts/__tests__/fixtures/version_with_no_searches.json
+++ b/assets/src/scripts/__tests__/fixtures/version_with_no_searches.json
@@ -1,5 +1,11 @@
 {
-  "searches": [],
+  "searches": [
+    {
+      "term_or_code": "[no search term]",
+      "url": "/builder/23da730d/no-search-term/",
+      "active": false
+    }
+  ],
   "tree_tables": [
     [
       "Disorder",
@@ -23,13 +29,6 @@
     "429554009",
     "439656005",
     "73583000"
-  ],
-  "included_codes": [
-    "128133004",
-    "156659008"
-  ],
-  "excluded_codes": [
-    "439656005"
   ],
   "parent_map": {
     "105969002": [
@@ -462,51 +461,66 @@
     "73583000": "(+)"
   },
   "is_editable": true,
-  "update_url": "/builder/6f08ccac/update/",
-  "search_url": "/builder/6f08ccac/search/",
+  "update_url": "/builder/23da730d/update/",
+  "search_url": "/builder/23da730d/search/",
   "versions": [
     {
-      "tag_or_hash": "6f08ccac",
-      "url": "/codelist/test-university/new-style-codelist/6f08ccac/",
+      "tag_or_hash": "23da730d",
+      "url": "/codelist/test-university/new-style-codelist/23da730d/",
       "status": "draft",
-      "current": true
+      "current": true,
+      "created_at": "2025-07-18 10:27:10.817077+00:00"
+    },
+    {
+      "tag_or_hash": "6c560cb6",
+      "url": "/codelist/test-university/new-style-codelist/6c560cb6/",
+      "status": "under review",
+      "current": false,
+      "created_at": "2025-07-18 10:27:10.766556+00:00"
     },
     {
       "tag_or_hash": "05657fec",
       "url": "/codelist/test-university/new-style-codelist/05657fec/",
       "status": "under review",
-      "current": false
+      "current": false,
+      "created_at": "2025-07-18 10:27:10.754647+00:00"
     },
     {
       "tag_or_hash": "1e74f321",
       "url": "/codelist/test-university/new-style-codelist/1e74f321/",
-      "status": "under review",
-      "current": false
-    },
-    {
-      "tag_or_hash": "37846656",
-      "url": "/codelist/test-university/new-style-codelist/37846656/",
       "status": "published",
-      "current": false
+      "current": false,
+      "created_at": "2025-07-18 10:27:10.750497+00:00"
     }
   ],
   "metadata": {
-    "coding_system_name": "SNOMED CT",
+    "coding_system_id": "snomedct",
+    "coding_system_name": "SNOMED CT (UK Clinical Edition)",
     "coding_system_release": {
       "release_name": "test",
       "valid_from": "2020-01-01"
     },
     "organisation_name": "Test University",
     "codelist_full_slug": "test-university/new-style-codelist",
-    "hash": "6f08ccac",
-    "description":{
-      "text": "",
+    "hash": "23da730d",
+    "codelist_name": "New-style Codelist",
+    "description": {
+      "text": null,
       "html": ""
     },
-    "methodology":{
-      "text": "",
+    "methodology": {
+      "text": null,
       "html": ""
     },
-    "references": []
+    "references": [
+      {
+        "text": "Reference 1",
+        "url": "https://example.com/reference1"
+      },
+      {
+        "text": "Reference 2",
+        "url": "https://example.com/reference2"
+      }
+    ]
   }
 }

--- a/assets/src/scripts/__tests__/fixtures/version_with_some_searches.json
+++ b/assets/src/scripts/__tests__/fixtures/version_with_some_searches.json
@@ -2,13 +2,13 @@
   "searches": [
     {
       "term_or_code": "arthritis",
-      "url": "/builder/55f95977/search/arthritis/",
-      "delete_url": "/builder/55f95977/search/arthritis/delete/",
+      "url": "/builder/0acaffd8/search/9/arthritis/",
+      "delete_url": "/builder/0acaffd8/search/9/arthritis/delete/",
       "active": false
     },
     {
       "term_or_code": "[no search term]",
-      "url": "/builder/55f95977/no-search-term/",
+      "url": "/builder/0acaffd8/no-search-term/",
       "active": false
     }
   ],
@@ -37,14 +37,6 @@
     "429554009",
     "439656005",
     "73583000"
-  ],
-  "included_codes": [
-    "128133004",
-    "156659008",
-    "439656005"
-  ],
-  "excluded_codes": [
-    "3723001"
   ],
   "parent_map": {
     "105969002": [
@@ -479,57 +471,73 @@
     "73583000": "(+)"
   },
   "is_editable": true,
-  "update_url": "/builder/55f95977/update/",
-  "search_url": "/builder/55f95977/search/",
+  "update_url": "/builder/0acaffd8/update/",
+  "search_url": "/builder/0acaffd8/search/",
   "versions": [
     {
-      "tag_or_hash": "55f95977",
-      "url": "/codelist/test-university/new-style-codelist/55f95977/",
+      "tag_or_hash": "0acaffd8",
+      "url": "/codelist/test-university/new-style-codelist/0acaffd8/",
       "status": "draft",
-      "current": true
+      "current": true,
+      "created_at": "2025-07-18 10:27:11.002476+00:00"
     },
     {
-      "tag_or_hash": "6f08ccac",
-      "url": "/codelist/test-university/new-style-codelist/6f08ccac/",
+      "tag_or_hash": "23da730d",
+      "url": "/codelist/test-university/new-style-codelist/23da730d/",
       "status": "draft",
-      "current": false
+      "current": false,
+      "created_at": "2025-07-18 10:27:10.817077+00:00"
+    },
+    {
+      "tag_or_hash": "6c560cb6",
+      "url": "/codelist/test-university/new-style-codelist/6c560cb6/",
+      "status": "under review",
+      "current": false,
+      "created_at": "2025-07-18 10:27:10.766556+00:00"
     },
     {
       "tag_or_hash": "05657fec",
       "url": "/codelist/test-university/new-style-codelist/05657fec/",
       "status": "under review",
-      "current": false
+      "current": false,
+      "created_at": "2025-07-18 10:27:10.754647+00:00"
     },
     {
       "tag_or_hash": "1e74f321",
       "url": "/codelist/test-university/new-style-codelist/1e74f321/",
-      "status": "under review",
-      "current": false
-    },
-    {
-      "tag_or_hash": "37846656",
-      "url": "/codelist/test-university/new-style-codelist/37846656/",
       "status": "published",
-      "current": false
+      "current": false,
+      "created_at": "2025-07-18 10:27:10.750497+00:00"
     }
   ],
   "metadata": {
-    "coding_system_name": "SNOMED CT",
+    "coding_system_id": "snomedct",
+    "coding_system_name": "SNOMED CT (UK Clinical Edition)",
     "coding_system_release": {
       "release_name": "test",
       "valid_from": "2020-01-01"
     },
     "organisation_name": "Test University",
     "codelist_full_slug": "test-university/new-style-codelist",
-    "hash": "55f95977",
-    "description":{
-      "text": "",
+    "hash": "0acaffd8",
+    "codelist_name": "New-style Codelist",
+    "description": {
+      "text": null,
       "html": ""
     },
-    "methodology":{
-      "text": "",
+    "methodology": {
+      "text": null,
       "html": ""
     },
-    "references": []
+    "references": [
+      {
+        "text": "Reference 1",
+        "url": "https://example.com/reference1"
+      },
+      {
+        "text": "Reference 2",
+        "url": "https://example.com/reference2"
+      }
+    ]
   }
 }

--- a/builder/management/commands/generate_builder_fixture.py
+++ b/builder/management/commands/generate_builder_fixture.py
@@ -122,7 +122,7 @@ class Command(BaseCommand):
             data["code_to_status"] = dict(sorted(data["code_to_status"].items()))
 
             js_fixtures_path = Path(
-                settings.BASE_DIR, "static", "test", "js", "fixtures"
+                settings.BASE_DIR, "assets", "src", "scripts", "__tests__", "fixtures"
             )
 
             with open(js_fixtures_path / f"{version_key}.json", "w") as f:

--- a/builder/management/commands/generate_builder_fixture.py
+++ b/builder/management/commands/generate_builder_fixture.py
@@ -95,8 +95,6 @@ class Command(BaseCommand):
                     "searches",
                     "tree_tables",
                     "all_codes",
-                    "included_codes",
-                    "excluded_codes",
                     "parent_map",
                     "child_map",
                     "code_to_term",
@@ -112,8 +110,6 @@ class Command(BaseCommand):
             # Ensure that all fields are sorted, to allow for meaningful diffs should
             # the data change.
             data["all_codes"] = sorted(data["all_codes"])
-            data["included_codes"] = sorted(data["included_codes"])
-            data["excluded_codes"] = sorted(data["excluded_codes"])
             data["parent_map"] = {
                 code: sorted(parents)
                 for code, parents in sorted(data["parent_map"].items())

--- a/builder/management/commands/generate_builder_fixture.py
+++ b/builder/management/commands/generate_builder_fixture.py
@@ -126,7 +126,7 @@ class Command(BaseCommand):
             )
 
             with open(js_fixtures_path / f"{version_key}.json", "w") as f:
-                json.dump(data, f, indent=2)
+                json.dump(data, f, indent=2, default=str)
 
 
 def set_up_db():

--- a/builder/views.py
+++ b/builder/views.py
@@ -217,8 +217,6 @@ def _draft(request, draft, search_id):
         "searches": searches,
         "tree_tables": tree_tables,
         "all_codes": list(codeset.all_codes()),
-        "included_codes": list(codeset.codes("+")),
-        "excluded_codes": list(codeset.codes("-")),
         "parent_map": {p: list(cc) for p, cc in hierarchy.parent_map.items()},
         "child_map": {c: list(pp) for c, pp in hierarchy.child_map.items()},
         "code_to_term": code_to_term,

--- a/templates/builder/draft.html
+++ b/templates/builder/draft.html
@@ -15,8 +15,6 @@
   {{ code_to_term|json_script:"code-to-term" }}
   {{ code_to_status|json_script:"code-to-status" }}
   {{ all_codes|json_script:"all-codes" }}
-  {{ included_codes|json_script:"included-codes" }}
-  {{ excluded_codes|json_script:"excluded-codes" }}
   {{ parent_map|json_script:"parent-map" }}
   {{ child_map|json_script:"child-map" }}
   {{ is_editable|json_script:"is-editable" }}


### PR DESCRIPTION
As they are no longer used in the builder.

This PR also fixes the broken test fixture generation, and updates the fixtures.