### PR TITLE
Prevent start up warning by moving coding system update to wsgi

### DIFF
--- a/coding_systems/versioning/apps.py
+++ b/coding_systems/versioning/apps.py
@@ -4,8 +4,3 @@ from django.apps import AppConfig
 class VersioningConfig(AppConfig):
     default_auto_field = "django.db.models.BigAutoField"
     name = "coding_systems.versioning"
-
-    def ready(self):
-        from .models import update_coding_system_database_connections
-
-        update_coding_system_database_connections()

--- a/opencodelists/wsgi.py
+++ b/opencodelists/wsgi.py
@@ -15,3 +15,25 @@ from django.core.wsgi import get_wsgi_application
 os.environ.setdefault("DJANGO_SETTINGS_MODULE", "opencodelists.settings")
 
 application = get_wsgi_application()
+
+
+# Ensure that the coding system database connections are updated. This needs to
+# be run once at startup. Previously, it was executed during the AppConfig
+# ready method, but Django warned us against it because you shouldn't access
+# the database in that method: (https://github.com/opensafely-core/opencodelists/issues/2289)
+# We can't import the method at the top of the file because it would create a
+# circular import, so we import it here instead. For reference, the circular
+# import is:
+# - coding_system/versioning/models.py imports from codelists.coding_systems,
+# - which dynamically imports modules like coding_systems.snomedct.coding_system,
+# - which imports from coding_system_base.py,
+# - which imports back from coding_systems.versioning.models.
+def run_startup_tasks():
+    from coding_systems.versioning.models import (
+        update_coding_system_database_connections,
+    )
+
+    update_coding_system_database_connections()
+
+
+run_startup_tasks()


### PR DESCRIPTION
- When the db is accessed in the AppConfig.ready() method, django complains that you shouldn't
- By moving it to the wsgi file it means it gets run on first load of the application
- Migrations will have already run by this point, as they are in the dokku release phase, which completes before the wsgi app is launched as part of the dokku web phase.
- We defer the import of the method into a `run_startup_tasks` method (rather than at the top of the wsgi file) to avoid an existing circular dependency

fixes #2289 