### PR TITLE
Capture event data in Plausible for how users interact with OpenCodelists

### DIFF
--- a/assets/src/scripts/components/Codelist/MoreInfoModal.tsx
+++ b/assets/src/scripts/components/Codelist/MoreInfoModal.tsx
@@ -148,7 +148,7 @@ function MoreInfoModal({
   return (
     <>
       <Button
-        className="builder__more-info-btn"
+        className="builder__more-info-btn plausible-event-name=More+info+click"
         onClick={handleShow}
         variant="outline-dark"
       >

--- a/templates/opencodelists/user_create_codelist.html
+++ b/templates/opencodelists/user_create_codelist.html
@@ -88,8 +88,22 @@
       <p>The next step will allow you to prepare your codelist for use.</p>
     </div>
 
-    <button type="submit" class="flex w-fit mx-auto justify-center cursor-pointer rounded-md bg-green-700 px-3 py-1.5 text-sm/6 font-semibold text-white shadow-xs transition-colors hover:bg-green-600 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-green-700">
+    <button type="submit" class="flex w-fit mx-auto justify-center cursor-pointer rounded-md bg-green-700 px-3 py-1.5 text-sm/6 font-semibold text-white shadow-xs transition-colors hover:bg-green-600 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-green-700" id="formSubmit">
       Create a draft codelist
     </button>
   </form>
+{% endblock %}
+
+{% block extra_js %}
+  <script>
+    const selectInput = document.getElementById(
+      "{{ form.coding_system_id.id_for_label }}",
+    );
+    const submitButton = document.getElementById("formSubmit");
+    const submitButtonClassList = submitButton.classList.toString();
+    selectInput.addEventListener("change", (e) => {
+      const codingSystemId = e.target.value;
+      submitButton.classList = `${submitButtonClassList} plausible-event-name=New+codelist+${codingSystemId}`;
+    });
+  </script>
 {% endblock %}

--- a/templates/opencodelists/user_create_codelist.html
+++ b/templates/opencodelists/user_create_codelist.html
@@ -102,7 +102,7 @@
     const submitButton = document.getElementById("formSubmit");
     const submitButtonClassList = submitButton.classList.toString();
     selectInput.addEventListener("change", (e) => {
-      const codingSystemId = e.target.value;
+      const codingSystemId = e.target.value.toLowerCase().replace(/\W/g, "");
       submitButton.classList = `${submitButtonClassList} plausible-event-name=New+codelist+${codingSystemId}`;
     });
   </script>


### PR DESCRIPTION
Partially address #2648

Specifically implements:

- Number of Clicks on ‘More info’- 
- Percentage of new codelists created using dm+d vs BNF

Plausible will start capturing these events once they're in production. The Plausible dashboard will then need to be updated to display these events.