### PR TITLE
Move metadata editing into modals

### DIFF
--- a/assets/src/scripts/components/CodelistBuilder.tsx
+++ b/assets/src/scripts/components/CodelistBuilder.tsx
@@ -233,6 +233,12 @@ export default class CodelistBuilder extends React.Component<
     });
   };
 
+  handleFocus = (e: React.FocusEvent<HTMLTextAreaElement>) => {
+    var temp_value = e.target.value;
+    e.target.value = "";
+    e.target.value = temp_value;
+  };
+
   // Add save handler:
   handleSaveReferences = async (
     newReferences: Array<{ text: string; url: string }>,
@@ -403,6 +409,7 @@ export default class CodelistBuilder extends React.Component<
               value={draftContent}
               onChange={this.handleContentChange}
               autoFocus
+              onFocus={this.handleFocus}
               onKeyDown={(e) => {
                 // Handle Ctrl+Enter for Save
                 if (e.key === "Enter" && (e.ctrlKey || e.metaKey)) {

--- a/assets/src/scripts/components/Layout/MetadataTab.tsx
+++ b/assets/src/scripts/components/Layout/MetadataTab.tsx
@@ -19,11 +19,13 @@ export default function MetadataTab({
 }: MetadataTabProps) {
   return (
     <>
-      <p className="font-italic">
-        Users have found it helpful to record their decision strategy as they
-        build their codelist. Text added here will be ready for you to edit
-        before you publish the codelist.
-      </p>
+      {isEditable && (
+        <p className="font-italic">
+          Users have found it helpful to record their decision strategy as they
+          build their codelist. Text added here will be ready for you to edit
+          before you publish the codelist.
+        </p>
+      )}
       <Form noValidate>
         {renderMetadataField("description")}
         {renderMetadataField("methodology")}

--- a/assets/src/scripts/components/Metadata/ReferenceForm.tsx
+++ b/assets/src/scripts/components/Metadata/ReferenceForm.tsx
@@ -1,11 +1,12 @@
 import React from "react";
-import { Form } from "react-bootstrap";
+import { Form, Modal } from "react-bootstrap";
 import { Reference } from "../../types";
 
 interface ReferenceFormProps {
   reference?: Reference;
   onCancel: () => void;
   onSave: (reference: Reference) => void;
+  show: boolean;
 }
 
 /**
@@ -13,16 +14,18 @@ interface ReferenceFormProps {
  * @param reference - Optional existing reference to edit, or blank if creating a new one
  * @param onCancel - Callback when user cancels editing
  * @param onSave - Callback when user saves changes, receives updated reference object
+ * @param show - Controls visibility of the modal
  */
 export default function ReferenceForm({
   reference = { text: "", url: "" },
   onCancel,
   onSave,
+  show,
 }: ReferenceFormProps) {
   const textInputRef = React.useRef<HTMLInputElement>(null);
   const urlInputRef = React.useRef<HTMLInputElement>(null);
 
-  const handleSave = () => {
+  const handleSubmit = () => {
     onSave({
       text: textInputRef.current?.value || "",
       url: urlInputRef.current?.value || "",
@@ -30,41 +33,55 @@ export default function ReferenceForm({
   };
 
   return (
-    <div className="card p-3">
-      <Form.Group className="mb-2">
-        <Form.Label>Text</Form.Label>
-        <Form.Control
-          ref={textInputRef}
-          type="text"
-          defaultValue={reference.text}
-          placeholder="Text to display"
-        />
-      </Form.Group>
-      <Form.Group className="mb-3">
-        <Form.Label>URL</Form.Label>
-        <Form.Control
-          ref={urlInputRef}
-          type="url"
-          defaultValue={reference.url}
-          placeholder="URL to link to"
-        />
-      </Form.Group>
-      <div className="mt-2 d-flex flex-row justify-content-end">
-        <button
-          type="button"
-          className="btn btn-secondary btn-sm m-1"
-          onClick={onCancel}
-        >
-          Cancel
-        </button>
-        <button
-          type="button"
-          className="btn btn-primary btn-sm m-1"
-          onClick={handleSave}
-        >
-          Save
-        </button>
-      </div>
-    </div>
+    <Modal
+      animation={false}
+      show={show}
+      onHide={onCancel}
+      backdrop="static"
+      aria-labelledby="reference-modal-title"
+      centered
+    >
+      <Form onSubmit={handleSubmit}>
+        <Modal.Header closeButton>
+          <Modal.Title id="reference-modal-title">
+            {reference.text ? "Edit Reference" : "Add Reference"}
+          </Modal.Title>
+        </Modal.Header>
+        <Modal.Body>
+          <Form.Group className="mb-2">
+            <Form.Label>Text</Form.Label>
+            <Form.Control
+              ref={textInputRef}
+              type="text"
+              defaultValue={reference.text}
+              placeholder="Text to display"
+              required
+            />
+          </Form.Group>
+          <Form.Group className="mb-3">
+            <Form.Label>URL</Form.Label>
+            <Form.Control
+              ref={urlInputRef}
+              type="url"
+              defaultValue={reference.url}
+              placeholder="URL to link to"
+              required
+            />
+          </Form.Group>
+        </Modal.Body>
+        <Modal.Footer>
+          <button
+            type="button"
+            className="btn btn-secondary btn-sm m-1"
+            onClick={onCancel}
+          >
+            Cancel
+          </button>
+          <button type="submit" className="btn btn-primary btn-sm m-1">
+            Save
+          </button>
+        </Modal.Footer>
+      </Form>
+    </Modal>
   );
 }

--- a/assets/src/scripts/components/Metadata/ReferenceList.tsx
+++ b/assets/src/scripts/components/Metadata/ReferenceList.tsx
@@ -9,6 +9,7 @@ interface ReferenceListProps {
 }
 
 interface ReferenceListState {
+  showModal: boolean;
   editingIndex: number | null;
 }
 /**
@@ -24,6 +25,7 @@ export default class ReferenceList extends React.Component<
   ReferenceListState
 > {
   state: ReferenceListState = {
+    showModal: false,
     editingIndex: null,
   };
 
@@ -34,11 +36,11 @@ export default class ReferenceList extends React.Component<
   };
 
   handleEdit = (index: number) => {
-    this.setState({ editingIndex: index });
+    this.setState({ showModal: true, editingIndex: index });
   };
 
   handleAdd = () => {
-    this.setState({ editingIndex: -1 });
+    this.setState({ showModal: true, editingIndex: -1 });
   };
 
   handleSaveForm = (reference: Reference) => {
@@ -50,16 +52,22 @@ export default class ReferenceList extends React.Component<
     }
 
     this.props.onSave(newReferences);
-    this.setState({ editingIndex: null });
+    this.setState({ showModal: false, editingIndex: null });
   };
 
   handleCancel = () => {
-    this.setState({ editingIndex: null });
+    this.setState({ showModal: false, editingIndex: null });
   };
 
   render() {
     const { references } = this.props;
-    const { editingIndex } = this.state;
+    const { showModal, editingIndex } = this.state;
+
+    // Determine which reference to edit, or blank for add
+    const editingReference =
+      editingIndex !== null && editingIndex !== -1
+        ? references[editingIndex]
+        : { text: "", url: "" };
 
     return (
       <div className="card">
@@ -76,63 +84,52 @@ export default class ReferenceList extends React.Component<
           <ul>
             {references.map((ref, index) => (
               <li key={index} className="mb-2">
-                {editingIndex === index ? (
-                  <ReferenceForm
-                    reference={ref}
-                    onCancel={this.handleCancel}
-                    onSave={this.handleSaveForm}
-                  />
-                ) : (
-                  <div className="d-flex align-items-center">
-                    <a href={ref.url} target="_blank" rel="noopener noreferrer">
-                      {ref.text}
-                    </a>
-                    {this.props.isEditable && (
-                      <>
-                        <button
-                          type="button"
-                          className="btn btn-sm btn-warning ml-2"
-                          onClick={() => this.handleEdit(index)}
-                          title="Edit reference"
-                        >
-                          Edit
-                        </button>
-                        <button
-                          type="button"
-                          className="btn btn-sm btn-danger ml-2"
-                          onClick={() => this.handleDelete(index)}
-                          title="Delete reference"
-                        >
-                          Delete
-                        </button>
-                      </>
-                    )}
-                  </div>
-                )}
+                <div className="d-flex align-items-center">
+                  <a href={ref.url} target="_blank" rel="noopener noreferrer">
+                    {ref.text}
+                  </a>
+                  {this.props.isEditable && (
+                    <>
+                      <button
+                        type="button"
+                        className="btn btn-sm btn-warning ml-2"
+                        onClick={() => this.handleEdit(index)}
+                        title="Edit reference"
+                      >
+                        Edit
+                      </button>
+                      <button
+                        type="button"
+                        className="btn btn-sm btn-danger ml-2"
+                        onClick={() => this.handleDelete(index)}
+                        title="Delete reference"
+                      >
+                        Delete
+                      </button>
+                    </>
+                  )}
+                </div>
               </li>
             ))}
           </ul>
-          {this.props.isEditable ? (
-            <>
-              {editingIndex === -1 ? (
-                <ReferenceForm
-                  onCancel={this.handleCancel}
-                  onSave={this.handleSaveForm}
-                />
-              ) : (
-                <button
-                  type="button"
-                  className="btn btn-primary btn-sm"
-                  onClick={this.handleAdd}
-                >
-                  {references.length === 0
-                    ? "Add a reference"
-                    : "Add another reference"}
-                </button>
-              )}
-            </>
-          ) : null}
+          {this.props.isEditable && (
+            <button
+              type="button"
+              className="btn btn-primary btn-sm"
+              onClick={this.handleAdd}
+            >
+              {references.length === 0
+                ? "Add a reference"
+                : "Add another reference"}
+            </button>
+          )}
         </div>
+        <ReferenceForm
+          reference={editingReference}
+          onCancel={this.handleCancel}
+          onSave={this.handleSaveForm}
+          show={showModal}
+        />
       </div>
     );
   }

--- a/assets/src/scripts/components/Metadata/ReferenceList.tsx
+++ b/assets/src/scripts/components/Metadata/ReferenceList.tsx
@@ -60,7 +60,7 @@ export default class ReferenceList extends React.Component<
   };
 
   render() {
-    const { references } = this.props;
+    const { isEditable, references } = this.props;
     const { showModal, editingIndex } = this.state;
 
     // Determine which reference to edit, or blank for add
@@ -74,7 +74,7 @@ export default class ReferenceList extends React.Component<
         <div className="card-body">
           <h3 className="h5 card-title">References</h3>
           <hr />
-          {this.props.isEditable && (
+          {isEditable && (
             <p className="font-italic">
               Sometimes it's useful to provide links, for example links to
               algorithms, methodologies or papers that are relevant to this
@@ -88,7 +88,7 @@ export default class ReferenceList extends React.Component<
                   <a href={ref.url} target="_blank" rel="noopener noreferrer">
                     {ref.text}
                   </a>
-                  {this.props.isEditable && (
+                  {isEditable && (
                     <>
                       <button
                         type="button"
@@ -112,7 +112,7 @@ export default class ReferenceList extends React.Component<
               </li>
             ))}
           </ul>
-          {this.props.isEditable && (
+          {isEditable && (
             <button
               type="button"
               className="btn btn-primary btn-sm"

--- a/assets/src/scripts/components/Metadata/ReferenceList.tsx
+++ b/assets/src/scripts/components/Metadata/ReferenceList.tsx
@@ -15,6 +15,7 @@ interface ReferenceListState {
  * Displays and manages a list of reference links in the codelist metadata.
  * Allows adding, editing, and deleting references, with each reference having
  * display text and a URL. Uses ReferenceForm component for editing.
+ * @param isEditable - Whether the user can modify references
  * @param references - Array of current references
  * @param onSave - Callback when references are modified, receives updated array
  */
@@ -65,11 +66,13 @@ export default class ReferenceList extends React.Component<
         <div className="card-body">
           <h3 className="h5 card-title">References</h3>
           <hr />
-          <p className="font-italic">
-            Sometimes it's useful to provide links, for example links to
-            algorithms, methodologies or papers that are relevant to this
-            codelist. They can be added here:
-          </p>
+          {this.props.isEditable && (
+            <p className="font-italic">
+              Sometimes it's useful to provide links, for example links to
+              algorithms, methodologies or papers that are relevant to this
+              codelist. They can be added here:
+            </p>
+          )}
           <ul>
             {references.map((ref, index) => (
               <li key={index} className="mb-2">
@@ -84,22 +87,26 @@ export default class ReferenceList extends React.Component<
                     <a href={ref.url} target="_blank" rel="noopener noreferrer">
                       {ref.text}
                     </a>
-                    <button
-                      type="button"
-                      className="btn btn-sm btn-warning ml-2"
-                      onClick={() => this.handleEdit(index)}
-                      title="Edit reference"
-                    >
-                      Edit
-                    </button>
-                    <button
-                      type="button"
-                      className="btn btn-sm btn-danger ml-2"
-                      onClick={() => this.handleDelete(index)}
-                      title="Delete reference"
-                    >
-                      Delete
-                    </button>
+                    {this.props.isEditable && (
+                      <>
+                        <button
+                          type="button"
+                          className="btn btn-sm btn-warning ml-2"
+                          onClick={() => this.handleEdit(index)}
+                          title="Edit reference"
+                        >
+                          Edit
+                        </button>
+                        <button
+                          type="button"
+                          className="btn btn-sm btn-danger ml-2"
+                          onClick={() => this.handleDelete(index)}
+                          title="Delete reference"
+                        >
+                          Delete
+                        </button>
+                      </>
+                    )}
                   </div>
                 )}
               </li>


### PR DESCRIPTION
Fixes #2748 
This arose from a bug reported by a user where if you tried to edit two metadata fields at the same time, i.e. without clicking save on the first one before moving to the second, then you would lose some changes. This solution is to make all metadata edits go into modals. This means you can only edit one field at a time and so the bug cannot happen. It has the added benefit that you can't tab away from unsaved text - or try to click `Save draft` thinking it would save your metadata changes.