### PR TITLE
Better rendering of the metadata description field

### DIFF
--- a/builder/views.py
+++ b/builder/views.py
@@ -7,6 +7,7 @@ from django.forms import ValidationError
 from django.http import HttpResponse, JsonResponse
 from django.shortcuts import get_object_or_404, redirect, render
 from django.urls import reverse
+from django.utils.html import linebreaks
 from django.utils.text import slugify
 from django.views.decorators.http import require_http_methods
 
@@ -194,7 +195,7 @@ def _draft(request, draft, search_id):
         "codelist_name": codelist.name,
         "description": {
             "text": codelist.description,
-            "html": render_markdown(codelist.description),
+            "html": linebreaks(codelist.description),
         },
         "methodology": {
             "text": codelist.methodology,
@@ -277,7 +278,7 @@ def update(request, draft):
         response["metadata"] = {
             "description": {
                 "text": updated_fields["description"],
-                "html": render_markdown(updated_fields["description"]),
+                "html": linebreaks(updated_fields["description"]),
             },
             "methodology": {
                 "text": updated_fields["methodology"],

--- a/codelists/templatetags/text_filters.py
+++ b/codelists/templatetags/text_filters.py
@@ -1,0 +1,20 @@
+from django import template
+
+
+register = template.Library()
+
+
+@register.filter(name="truncatelines")
+def truncatelines(value, max_lines=4):
+    """
+    Truncate a string to a maximum number of lines (split by newline).
+    Usage: {{ field_to_truncate|truncatelines:4 }}
+    """
+    try:
+        max_lines = int(max_lines)
+    except Exception:
+        max_lines = 4
+
+    lines = str(value).splitlines()
+    limited = "\n".join(lines[:max_lines])
+    return limited

--- a/codelists/tests/test_text_filters.py
+++ b/codelists/tests/test_text_filters.py
@@ -1,0 +1,27 @@
+import pytest
+
+from codelists.templatetags.text_filters import truncatelines
+
+
+@pytest.mark.parametrize(
+    "input_text,max_lines,expected",
+    [
+        ("a\nb\nc\nd\ne", 3, "a\nb\nc"),
+        ("one line only", 4, "one line only"),
+        ("x\ny", 1, "x"),
+        ("", 2, ""),
+        ("line1\nline2\nline3", 10, "line1\nline2\nline3"),
+    ],
+)
+def test_truncatelines_basic(input_text, max_lines, expected):
+    assert truncatelines(input_text, max_lines) == expected
+
+
+def test_truncatelines_default():
+    text = "1\n2\n3\n4\n5"
+    assert truncatelines(text) == "1\n2\n3\n4"
+
+
+def test_truncatelines_invalid_max_lines():
+    text = "1\n2\n3\n4\n5"
+    assert truncatelines(text, "notanumber") == "1\n2\n3\n4"

--- a/templates/codelists/_about_tab.html
+++ b/templates/codelists/_about_tab.html
@@ -4,7 +4,7 @@
   <h2 class="sr-only">About</h2>
   {% if codelist.description %}
     <h3 class="h4">Description</h3>
-    <p>{{ codelist.description|markdown_filter|safe }}</p>
+    <p>{{ codelist.description|linebreaksbr }}</p>
   {% endif %}
 
   {% if codelist.methodology %}

--- a/templates/codelists/index.html
+++ b/templates/codelists/index.html
@@ -2,7 +2,7 @@
 
 {% load django_vite %}
 
-{% load markdown_filter %}
+{% load text_filters %}
 
 {% block content %}
 
@@ -58,7 +58,9 @@
           <dd>
 
             {% if cl.description %}
-              <div>{{ cl.description|markdown_filter|safe }}</div>
+              <div>
+                {{ cl.description|truncatechars:500|truncatelines:4|linebreaksbr }}
+              </div>
             {% endif %}
 
             {% if not organisation %}


### PR DESCRIPTION
We will shortly be limiting the length of the description field, and preventing markdown. This change ensures that existing descriptions (that may still contain markdown, or be too long), are rendered appropriately.

That is:
- Don't render markdown - but maintain the line breaks - wherever displayed (the metadata tab in draft, and the about tab in published)
- Truncate the description in the list view to 500 chars or 4 line breaks (this will also fix #2721 )
