### PR TITLE
Handle duplicate username error

### DIFF
--- a/opencodelists/tests/views/test_register.py
+++ b/opencodelists/tests/views/test_register.py
@@ -1,3 +1,7 @@
+from unittest.mock import patch
+
+from django.forms import ValidationError
+
 from ...models import User
 from ..assertions import assert_difference, assert_no_difference
 
@@ -78,3 +82,29 @@ def test_post_failure_duplicate_email(client, user):
         rsp = client.post("/accounts/register/", data)
 
     assert b"A user with this email address already exists." in rsp.content
+
+
+def test_post_failure_duplicate_username_unhandled(client, user):
+    # We had an odd sentry error whereby a duplicate username caused a
+    # ValidationError to be raised. This shouldn't happend because the form
+    # should catch this in the call to is_valid() and return an error to the user
+    # instead of raising an unhandled exception.
+    # This test is to ensure that if this happens again, we handle it gracefully.
+    data = {
+        "username": "new-one",
+        "name": "Prof User",
+        "email": "user@example.com",
+        "password1": "hCSeKtZg",
+        "password2": "hCSeKtZg",
+    }
+
+    with (
+        patch(
+            "opencodelists.models.User.save",
+            side_effect=ValidationError("A user with this username already exists."),
+        ),
+    ):
+        with assert_no_difference(User.objects.count):
+            rsp = client.post("/accounts/register/", data)
+
+    assert b"A user with this username already exists." in rsp.content

--- a/opencodelists/views/register.py
+++ b/opencodelists/views/register.py
@@ -1,5 +1,6 @@
 from django.contrib import messages
 from django.contrib.auth import authenticate, login
+from django.core.exceptions import ValidationError
 from django.shortcuts import redirect, render
 
 from ..forms import RegisterForm
@@ -13,13 +14,28 @@ def register(request):
     if request.method == "POST":
         form = RegisterForm(request.POST)
         if form.is_valid():
-            user = form.save()
-            user = authenticate(
-                username=user.username, password=form.cleaned_data["password1"]
-            )
-            login(request, user)
+            try:
+                user = form.save()
+                user = authenticate(
+                    username=user.username, password=form.cleaned_data["password1"]
+                )
+                login(request, user)
 
-            return redirect("/")
+                return redirect("/")
+            except ValidationError as e:
+                # In theory this shouldn't happen because a duplicate username
+                # causes form.is_valid() to return False. But we've seen this
+                # error happen once in production - possibly due to some race
+                # condition. So we handle it here.
+                if (
+                    hasattr(e, "messages")
+                    and "A user with this username already exists." in e.messages
+                ):
+                    form.add_error(
+                        "username", "A user with this username already exists."
+                    )
+                else:
+                    raise
 
     else:
         form = RegisterForm()


### PR DESCRIPTION
Fixes #2734 

Sentry caught an unhandled ValidationError when a duplicate username was attempted. The relevant code was:
https://github.com/opensafely-core/opencodelists/blob/52eb10585c757b982a464d689153ff9bea3a4148/opencodelists/views/register.py#L15-L16

The username was ok when `form.is_valid()` was called (because it returned True), but then was a duplicate when the following line (`user=form.save()`) was called. I'm not sure why this happened (db issues, race condition?), and I'm tempted to not do anything, but at least now if it happens again the user will get the duplicate username warning and the error won't go to Sentry.