### PR TITLE
Limit number of codes returned by search

### DIFF
--- a/builder/views.py
+++ b/builder/views.py
@@ -321,6 +321,10 @@ def new_search(request, draft):
 
     search = actions.create_search(draft=draft, term=term, code=code, codes=codes)
 
+    if isinstance(search, dict) and search.get("error"):
+        messages.error(request, search["message"])
+        return redirect(draft.get_builder_draft_url())
+
     return redirect(draft.get_builder_search_url(search.id, search.slug))
 
 


### PR DESCRIPTION
Fixes #2733 

If there are too many codes returned we hit a limit in sqlite and an unhandled exception is thrown. This limit is currently 250,000 codes in an `IN` clause. However, large numbers of codes returned by a search is probably a sign the user has made a mistake or has not been specific enough. They would then need to include/exclude all codes which would take too long. So instead we set a much smaller limit (20,000 codes) and tell the user if their query exceeded that.

I have taken a look at existing searches that exceed this limit and have summarised them here. These searches will still exist in the system, but I'm happy that we don't need to support any of them in future.

### Less than 3 characters - i.e. no longer allowed

|Term|Number of codes returned|
|---|---|
|NA|141569|
|PE|123320|
|x|82434|
|a|67427|
|1|21605|

### Words too common in SNOMED

|Term|Number of codes returned|
|---|---|
|finding|149626|
|disorder|146499|
|region|127027|
|clinical findings|92845|
|Procedure by method|60139|
|substance|56723|
|product|55111|
|neck|47479|
|Procedure by site|39292|
|family|36062|
|vision|35465|
|Procedure on organ|34438|
|other|30243|
|assessment|28990|
|function|28132|
|operation|27853|
|vascular|26217|
|poisoning|25407|
|Surgical procedure|24149|
|investigations|24022|
|mental|23923|
|cardiovascular|23717|
|Clinical history and observations|23560|
|accident|22759|
|bacteria|21862|
|appliances|20273|

### Short wildcard strings that are too frequent

|Term|Number of codes returned|
|---|---|
|dia|41686|
|vasc|26342|
|appl|20418|

### Short strings that would be fine if we had exact word matching

|Term|Number of codes returned|
|---|---|
|ace|87099|
|TOM|82966|
|tic|71860|
|age|62339|
|kin|59337|
|late|50919|
|uti|43721|
|ICU|34260|

### Codes

|Code|Term|Number of codes returned|
|---|---|---|
|404684003|Clinical finding|132883|
|64572001|Disease|88388|
|362958002|Procedure by site|39172|


