### PR TITLE
Replace metdata description component in codelist builder

### DIFF
--- a/assets/src/scripts/__tests__/builder/codelistbuilder.test.jsx
+++ b/assets/src/scripts/__tests__/builder/codelistbuilder.test.jsx
@@ -250,57 +250,6 @@ describe("Metadata Editing", () => {
     return { data };
   };
 
-  it("handles description field", async () => {
-    const { data } = setupMetadataTest();
-
-    renderCodelistBuilder(data);
-
-    // Switch to metadata tab
-    const metadataTab = document.querySelector(
-      '[role="tab"][data-rb-event-key="metadata"]',
-    );
-    await userEvent.click(metadataTab);
-
-    // Click edit button
-    const editButton = document.querySelector(
-      'button[title="Edit description"]',
-    );
-    await userEvent.click(editButton);
-
-    // Find textarea
-    const textarea = document.querySelector("textarea#description");
-    expect(textarea).toBeInTheDocument();
-    expect(textarea).toHaveValue("Initial description");
-
-    // Type new content
-    await userEvent.clear(textarea);
-    await userEvent.type(textarea, "Updated description");
-
-    // Save
-    const saveButton = document.querySelector(
-      'button[title="Save description"]',
-    );
-    await userEvent.click(saveButton);
-
-    // Wait for API call and state update
-    await vi.waitFor(() => {
-      expect(fetch).toHaveBeenCalledWith(
-        data.update_url,
-        expect.objectContaining({
-          method: "POST",
-          body: expect.stringContaining('"description":"Updated description"'),
-        }),
-      );
-    });
-
-    // Verify textarea is no longer visible and content is updated
-    expect(textarea).not.toBeInTheDocument();
-    const displayedContent = document.querySelector(
-      ".description .builder__markdown",
-    );
-    expect(displayedContent).toHaveTextContent("Updated description");
-  });
-
   it("handles methodology field", async () => {
     const { data, visiblePaths, hierarchy } = setupMetadataTest();
 

--- a/assets/src/scripts/__tests__/components/Metadata/MetadataForm.spec.tsx
+++ b/assets/src/scripts/__tests__/components/Metadata/MetadataForm.spec.tsx
@@ -1,0 +1,275 @@
+import "@testing-library/jest-dom";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import nock from "nock";
+import React, { type ReactNode } from "react";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import MetadataForm from "../../../components/Metadata/MetadataForm";
+import type { IS_EDITABLE, METADATA, UPDATE_URL } from "../../../types";
+
+const queryClient = new QueryClient({
+  defaultOptions: { queries: { retry: false } },
+});
+const wrapper = ({ children }: { children: ReactNode }) => (
+  <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+);
+
+// biome-ignore lint/suspicious/noExplicitAny: we can pass in any data in this test
+function setScript(id: string, value: any) {
+  const el = document.createElement("script");
+  el.id = id;
+  el.type = "application/json";
+  el.textContent = JSON.stringify(value);
+  document.body.appendChild(el);
+}
+
+function scriptTagSetup({
+  metadata,
+  isEditable = true,
+  updateUrl = "https://mock-url.localhost/update",
+}: {
+  metadata?: {
+    description?: METADATA["description"];
+    methodology?: METADATA["methodology"];
+  };
+  isEditable?: IS_EDITABLE;
+  updateUrl?: UPDATE_URL;
+} = {}) {
+  setScript("metadata", metadata);
+  setScript("is-editable", isEditable);
+  setScript("update-url", updateUrl);
+}
+
+function cleanupScriptTags() {
+  ["metadata", "update-url", "is-editable"].forEach((id) =>
+    document.getElementById(id)?.remove(),
+  );
+}
+
+function mockPostRequest(metadata: {
+  description: { html: string; text: string };
+}) {
+  return nock("https://mock-url.localhost")
+    .post("/update")
+    .reply(200, { metadata });
+}
+
+describe("Does not load", () => {
+  beforeEach(() => scriptTagSetup());
+  afterEach(() => cleanupScriptTags());
+
+  it("does not show if no data is provided", () => {
+    render(<MetadataForm id="description" name="Description" />, { wrapper });
+    expect(
+      screen.queryByRole("heading", { name: "Description" }),
+    ).not.toBeInTheDocument();
+  });
+});
+
+describe("Anonymous users", () => {
+  beforeEach(() =>
+    scriptTagSetup({
+      isEditable: false,
+      metadata: {
+        description: {
+          text: "This is a test",
+          html: "<p>This is a test</p>",
+        },
+      },
+    }),
+  );
+  afterEach(() => cleanupScriptTags());
+
+  it("does not show buttons to anonymous users", () => {
+    render(<MetadataForm id="description" name="Description" />, { wrapper });
+    expect(
+      screen.queryByRole("heading", { name: "Description" }),
+    ).toBeVisible();
+    expect(
+      screen.queryByRole("button", { name: "Edit Description" }),
+    ).not.toBeInTheDocument();
+  });
+});
+
+describe("Interacting with Metadata forms", () => {
+  beforeEach(() =>
+    scriptTagSetup({
+      isEditable: true,
+      metadata: {
+        description: {
+          text: "This is a test",
+          html: "<p>This is a test</p>",
+        },
+        methodology: {
+          text: "This is a test",
+          html: "<p>This is a test</p>",
+        },
+      },
+    }),
+  );
+
+  afterEach(() => cleanupScriptTags());
+
+  it("loads the HTML text from the metadata", async () => {
+    render(<MetadataForm id="description" name="Description" />, { wrapper });
+    expect(screen.getByText("This is a test")).toBeVisible();
+  });
+
+  it("loads the buttons for users who can edit", async () => {
+    render(<MetadataForm id="methodology" name="Methodology" />, { wrapper });
+    expect(
+      screen.getByRole("button", { name: "Edit Methodology" }),
+    ).toBeVisible();
+  });
+
+  it("opens and closes the editing view, discarding changes", async () => {
+    const user = userEvent.setup();
+    render(<MetadataForm id="description" name="Description" />, { wrapper });
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole("button", { name: "Edit Description" }),
+      ).toBeVisible();
+    });
+
+    await user.click(screen.getByRole("button", { name: "Edit Description" }));
+    expect(screen.getByRole("textbox", { name: "Description" })).toBeVisible();
+    expect(screen.getByRole("textbox", { name: "Description" })).toHaveValue(
+      "This is a test",
+    );
+    await user.click(screen.getByRole("button", { name: "Cancel" }));
+    expect(
+      screen.queryByRole("textbox", { name: "Description" }),
+    ).not.toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "Edit Description" }));
+    await user.clear(screen.getByRole("textbox", { name: "Description" }));
+    await user.type(
+      screen.getByRole("textbox", { name: "Description" }),
+      "This is some text which is going to be discarded",
+    );
+    await user.click(screen.getByRole("button", { name: "Cancel" }));
+    expect(
+      screen.queryByRole("textbox", { name: "Description" }),
+    ).not.toBeInTheDocument();
+    expect(screen.getByText("This is a test")).toBeVisible();
+  });
+
+  it("allows editing of content", async () => {
+    const user = userEvent.setup();
+    mockPostRequest({
+      description: {
+        html: "<p>This is some text which is going to be saved</p>",
+        text: "This is some text which is going to be saved",
+      },
+    });
+    render(<MetadataForm id="description" name="Description" />, { wrapper });
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole("button", { name: "Edit Description" }),
+      ).toBeVisible();
+    });
+
+    await user.click(screen.getByRole("button", { name: "Edit Description" }));
+    expect(screen.getByRole("textbox", { name: "Description" })).toBeVisible();
+    expect(screen.getByRole("textbox", { name: "Description" })).toHaveValue(
+      "This is a test",
+    );
+    await user.click(screen.getByRole("button", { name: "Cancel" }));
+    expect(
+      screen.queryByRole("textbox", { name: "Description" }),
+    ).not.toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "Edit Description" }));
+    await user.clear(screen.getByRole("textbox", { name: "Description" }));
+    await user.type(
+      screen.getByRole("textbox", { name: "Description" }),
+      "This is some text which is going to be saved",
+    );
+    await user.click(screen.getByRole("button", { name: "Save" }));
+
+    await waitFor(() =>
+      expect(
+        screen.getByText("This is some text which is going to be saved"),
+      ).toBeVisible(),
+    );
+  });
+
+  it("accepts keyboard shortcuts to cancel", async () => {
+    const user = userEvent.setup();
+    mockPostRequest({
+      description: {
+        html: "<p>This is some text which is going to be saved</p>",
+        text: "This is some text which is going to be saved",
+      },
+    });
+    render(<MetadataForm id="description" name="Description" />, { wrapper });
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole("button", { name: "Edit Description" }),
+      ).toBeVisible();
+    });
+
+    await user.click(screen.getByRole("button", { name: "Edit Description" }));
+    expect(screen.getByRole("textbox", { name: "Description" })).toBeVisible();
+    expect(screen.getByRole("textbox", { name: "Description" })).toHaveValue(
+      "This is a test",
+    );
+    await user.clear(screen.getByRole("textbox", { name: "Description" }));
+    await user.type(
+      screen.getByRole("textbox", { name: "Description" }),
+      "This is some text which is going to be discarded",
+    );
+    await user.keyboard("[Escape]");
+    await waitFor(() => {
+      expect(
+        screen.queryByRole("textbox", { name: "Description" }),
+      ).not.toBeInTheDocument();
+      expect(screen.getByText("This is a test")).toBeVisible();
+    });
+  });
+
+  it("allows keyboard shortcuts to save", async () => {
+    const user = userEvent.setup();
+    mockPostRequest({
+      description: {
+        html: "<p>This is some text which is going to be saved</p>",
+        text: "This is some text which is going to be saved",
+      },
+    });
+    render(<MetadataForm id="description" name="Description" />, { wrapper });
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole("button", { name: "Edit Description" }),
+      ).toBeVisible();
+    });
+
+    await user.click(screen.getByRole("button", { name: "Edit Description" }));
+    expect(screen.getByRole("textbox", { name: "Description" })).toBeVisible();
+    expect(screen.getByRole("textbox", { name: "Description" })).toHaveValue(
+      "This is a test",
+    );
+    await user.click(screen.getByRole("button", { name: "Cancel" }));
+    expect(
+      screen.queryByRole("textbox", { name: "Description" }),
+    ).not.toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "Edit Description" }));
+    await user.clear(screen.getByRole("textbox", { name: "Description" }));
+    await user.type(
+      screen.getByRole("textbox", { name: "Description" }),
+      "This is some text which is going to be saved",
+    );
+    await user.keyboard("{Meta>}[Enter]");
+
+    await waitFor(() =>
+      expect(
+        screen.getByText("This is some text which is going to be saved"),
+      ).toBeVisible(),
+    );
+  });
+});

--- a/assets/src/scripts/_utils.ts
+++ b/assets/src/scripts/_utils.ts
@@ -21,3 +21,33 @@ export function readValueFromPage(id: string) {
     return JSON.parse(scriptId.textContent);
   }
 }
+
+export async function postFetchWithOptions({
+  body,
+  url,
+}: {
+  body: Record<string, unknown>;
+  url: string;
+}) {
+  const requestHeaders = new Headers();
+  requestHeaders.append("Accept", "application/json");
+  requestHeaders.append("Content-Type", "application/json");
+
+  const csrfCookie = getCookie("csrftoken");
+  if (csrfCookie) {
+    requestHeaders.append("X-CSRFToken", csrfCookie);
+  }
+
+  const response = await fetch(url, {
+    method: "POST",
+    credentials: "include" as RequestCredentials,
+    mode: "same-origin" as RequestMode,
+    headers: requestHeaders,
+    body: JSON.stringify(body),
+  });
+
+  if (!response.ok) {
+    throw new Error("Something went wrong.");
+  }
+  return await response.json();
+}

--- a/assets/src/scripts/components/Layout/MetadataTab.tsx
+++ b/assets/src/scripts/components/Layout/MetadataTab.tsx
@@ -1,7 +1,10 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { ReactQueryDevtools } from "@tanstack/react-query-devtools";
 import React from "react";
 import { Form } from "react-bootstrap";
 import type { PageData, Reference } from "../../types";
 import type { MetadataFieldName } from "../CodelistBuilder";
+import MetadataForm from "../Metadata/MetadataForm";
 import ReferenceList from "../Metadata/ReferenceList";
 
 interface MetadataTabProps {
@@ -17,15 +20,19 @@ export default function MetadataTab({
   references,
   renderMetadataField,
 }: MetadataTabProps) {
+  const client = new QueryClient();
+
   return (
-    <>
+    <QueryClientProvider client={client}>
       <p className="font-italic">
         Users have found it helpful to record their decision strategy as they
         build their codelist. Text added here will be ready for you to edit
         before you publish the codelist.
       </p>
-      <Form noValidate>
-        {renderMetadataField("description")}
+      <div className="builder__metadata-forms">
+        <MetadataForm id="description" name="Description" />
+      </div>
+      <Form className="mt-2" noValidate>
         {renderMetadataField("methodology")}
         <ReferenceList
           isEditable={isEditable}
@@ -33,6 +40,8 @@ export default function MetadataTab({
           onSave={handleSaveReferences}
         />
       </Form>
-    </>
+
+      <ReactQueryDevtools />
+    </QueryClientProvider>
   );
 }

--- a/assets/src/scripts/components/Layout/MetadataTab.tsx
+++ b/assets/src/scripts/components/Layout/MetadataTab.tsx
@@ -20,7 +20,16 @@ export default function MetadataTab({
   references,
   renderMetadataField,
 }: MetadataTabProps) {
-  const client = new QueryClient();
+  const client = new QueryClient({
+    defaultOptions: {
+      queries: {
+        refetchOnMount: false,
+        refetchOnReconnect: false,
+        refetchOnWindowFocus: false,
+        staleTime: "static",
+      },
+    },
+  });
 
   return (
     <QueryClientProvider client={client}>

--- a/assets/src/scripts/components/Metadata/MetadataForm.tsx
+++ b/assets/src/scripts/components/Metadata/MetadataForm.tsx
@@ -1,0 +1,127 @@
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import React, { useState } from "react";
+import { postFetchWithOptions, readValueFromPage } from "../../_utils";
+import type { IS_EDITABLE, METADATA, UPDATE_URL } from "../../types";
+
+export default function MetadataForm({
+  id,
+  name,
+}: {
+  id: string;
+  name: string;
+}) {
+  const isEditable: IS_EDITABLE = readValueFromPage("is-editable");
+  const metadata: METADATA = readValueFromPage("metadata");
+  const updateURL: UPDATE_URL = readValueFromPage("update-url");
+  const fieldMetadata = metadata?.[id as keyof METADATA];
+
+  const [isEditing, setIsEditing] = useState(false);
+
+  const queryClient = useQueryClient();
+  const { data } = useQuery({
+    queryKey: ["metadata", id],
+    initialData: fieldMetadata,
+    queryFn: () => fieldMetadata,
+  });
+
+  const updateMetadata = useMutation({
+    mutationFn: async (body: Record<string, unknown>) => {
+      return postFetchWithOptions({
+        body,
+        url: updateURL,
+      });
+    },
+    onSuccess: (data) => {
+      queryClient.setQueryData(["metadata", id], data.metadata[id]);
+      setIsEditing(false);
+    },
+  });
+
+  if (!fieldMetadata) return null;
+
+  function handleSubmit(event: React.FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    const formData = new FormData(event.currentTarget);
+    const formFieldData = Object.fromEntries(formData);
+    updateMetadata.mutate(formFieldData);
+  }
+
+  function handleKeyDown(e: React.KeyboardEvent<HTMLTextAreaElement>) {
+    // Handle Ctrl+Enter for Save
+    if (e.key === "Enter" && (e.ctrlKey || e.metaKey)) {
+      e.preventDefault();
+      (e.currentTarget.form as HTMLFormElement)?.requestSubmit();
+    }
+
+    // Handle Escape for Cancel
+    if (e.key === "Escape") {
+      e.preventDefault();
+      setIsEditing(false);
+    }
+  }
+
+  return (
+    <form
+      className="card"
+      onReset={() => setIsEditing(false)}
+      onSubmit={handleSubmit}
+    >
+      <div className="card-header d-flex flex-row align-items-center">
+        <h3 className="h5 mb-0 mr-auto">{name}</h3>
+        {isEditable ? (
+          isEditing ? (
+            <>
+              <button className="btn btn-primary btn-sm" type="submit">
+                Save
+              </button>
+              <button className="btn btn-secondary btn-sm ml-1" type="reset">
+                Cancel
+              </button>
+            </>
+          ) : (
+            <button
+              className="btn btn-primary btn-sm"
+              onClick={() => setIsEditing(true)}
+              type="button"
+            >
+              Edit <span className="sr-only">{name}</span>
+            </button>
+          )
+        ) : null}
+      </div>
+
+      <div className="card-body">
+        {isEditing ? (
+          <div className="form-group">
+            <label className="form-label sr-only" htmlFor={`metadata-${id}`}>
+              {name}
+            </label>
+            <textarea
+              className="form-control"
+              // @ts-ignore
+              defaultValue={data.text}
+              id={`metadata-${id}`}
+              name={id}
+              onKeyDown={handleKeyDown}
+              rows={5}
+            ></textarea>
+            <small className="form-text text-muted">
+              If you make changes, please remember to click Save (shortcut:
+              CTRL-ENTER) to keep them or Cancel (shortcut: ESC) to discard.
+            </small>
+          </div>
+          // @ts-ignore
+        ) : data?.html ? (
+          <div
+            className="builder__markdown"
+            // @ts-ignore
+            // biome-ignore lint/security/noDangerouslySetInnerHtml: backend is validating the markdown content
+            dangerouslySetInnerHTML={{ __html: data.html }}
+          />
+        ) : (
+          <p className="mb-0 text-muted font-italic">{name} not provided</p>
+        )}
+      </div>
+    </form>
+  );
+}

--- a/assets/src/scripts/components/Metadata/MetadataForm.tsx
+++ b/assets/src/scripts/components/Metadata/MetadataForm.tsx
@@ -80,7 +80,7 @@ export default function MetadataForm({
             </>
           ) : (
             <button
-              className="btn btn-primary btn-sm"
+              className={`btn btn-primary btn-sm plausible-event-name=Edit+metadata+${id}`}
               onClick={() => setIsEditing(true)}
               type="button"
             >

--- a/assets/src/scripts/components/Metadata/MetadataForm.tsx
+++ b/assets/src/scripts/components/Metadata/MetadataForm.tsx
@@ -98,7 +98,8 @@ export default function MetadataForm({
             </label>
             <textarea
               className="form-control"
-              // @ts-ignore
+              // @ts-ignore: we're not currently using react-query to return
+              // the expected values of the typescript compiler
               defaultValue={data.text}
               id={`metadata-${id}`}
               name={id}
@@ -114,7 +115,8 @@ export default function MetadataForm({
         ) : data?.html ? (
           <div
             className="builder__markdown"
-            // @ts-ignore
+            // @ts-ignore: we're not currently using react-query to return
+            // the expected values of the typescript compiler
             // biome-ignore lint/security/noDangerouslySetInnerHtml: backend is validating the markdown content
             dangerouslySetInnerHTML={{ __html: data.html }}
           />

--- a/assets/src/scripts/types.ts
+++ b/assets/src/scripts/types.ts
@@ -47,3 +47,39 @@ export interface Reference {
   text: string;
   url: string;
 }
+
+/**
+ * Set up types for data passed from Django
+ */
+
+// {{ is_editable|json_script:"is-editable" }}
+export type IS_EDITABLE = boolean;
+
+// {{ metadata|json_script:"metadata" }}
+export type METADATA = {
+  description: {
+    text: string;
+    html: string;
+  };
+  methodology: {
+    text: string;
+    html: string;
+  };
+  references: {
+    text: string;
+    url: string;
+  }[];
+  coding_system_id: string;
+  coding_system_name: string;
+  coding_system_release: {
+    release_name: string;
+    valid_from: string;
+  };
+  organisation_name: string;
+  codelist_full_slug: string;
+  hash: string;
+  codelist_name: string;
+};
+
+// {{ search_url|json_script:"update-url" }}
+export type UPDATE_URL = string;

--- a/assets/src/styles/_builder.css
+++ b/assets/src/styles/_builder.css
@@ -40,3 +40,10 @@
 .builder__markdown p:last-child {
   margin-bottom: 0;
 }
+
+.builder__metadata-forms {
+  display: flex;
+  flex-direction: column;
+  margin-block-end: 1rem;
+  row-gap: 1rem;
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,8 @@
         "@tailwindcss/forms": "^0.5.10",
         "@tailwindcss/typography": "^0.5.16",
         "@tailwindcss/vite": "^4.1.11",
+        "@tanstack/react-query": "^5.83.0",
+        "@tanstack/react-query-devtools": "^5.83.0",
         "@zachleat/details-utils": "^2.0.2",
         "bootstrap": "4.6.2",
         "datatables.net-bs4": "1.13.11",
@@ -1835,6 +1837,59 @@
       },
       "peerDependencies": {
         "vite": "^5.2.0 || ^6 || ^7"
+      }
+    },
+    "node_modules/@tanstack/query-core": {
+      "version": "5.83.0",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.83.0.tgz",
+      "integrity": "sha512-0M8dA+amXUkyz5cVUm/B+zSk3xkQAcuXuz5/Q/LveT4ots2rBpPTZOzd7yJa2Utsf8D2Upl5KyjhHRY+9lB/XA==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@tanstack/query-devtools": {
+      "version": "5.81.2",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-devtools/-/query-devtools-5.81.2.tgz",
+      "integrity": "sha512-jCeJcDCwKfoyyBXjXe9+Lo8aTkavygHHsUHAlxQKKaDeyT0qyQNLKl7+UyqYH2dDF6UN/14873IPBHchcsU+Zg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@tanstack/react-query": {
+      "version": "5.83.0",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.83.0.tgz",
+      "integrity": "sha512-/XGYhZ3foc5H0VM2jLSD/NyBRIOK4q9kfeml4+0x2DlL6xVuAcVEW+hTlTapAmejObg0i3eNqhkr2dT+eciwoQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/query-core": "5.83.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": "^18 || ^19"
+      }
+    },
+    "node_modules/@tanstack/react-query-devtools": {
+      "version": "5.83.0",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query-devtools/-/react-query-devtools-5.83.0.tgz",
+      "integrity": "sha512-yfp8Uqd3I1jgx8gl0lxbSSESu5y4MO2ThOPBnGNTYs0P+ZFu+E9g5IdOngyUGuo6Uz6Qa7p9TLdZEX3ntik2fQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/query-devtools": "5.81.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "@tanstack/react-query": "^5.83.0",
+        "react": "^18 || ^19"
       }
     },
     "node_modules/@testing-library/dom": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -34,6 +34,7 @@
         "@vitejs/plugin-react-swc": "^3.11.0",
         "@vitest/coverage-v8": "^3.2.4",
         "jsdom": "^26.1.0",
+        "nock": "^14.0.7",
         "typescript": "^5.8.3",
         "vite": "^7.0.0",
         "vite-plugin-live-reload": "^3.0.5",
@@ -929,6 +930,49 @@
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
+    },
+    "node_modules/@mswjs/interceptors": {
+      "version": "0.39.5",
+      "resolved": "https://registry.npmjs.org/@mswjs/interceptors/-/interceptors-0.39.5.tgz",
+      "integrity": "sha512-B9nHSJYtsv79uo7QdkZ/b/WoKm20IkVSmTc/WCKarmDtFwM0dRx2ouEniqwNkzCSLn3fydzKmnMzjtfdOWt3VQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@open-draft/deferred-promise": "^2.2.0",
+        "@open-draft/logger": "^0.3.0",
+        "@open-draft/until": "^2.0.0",
+        "is-node-process": "^1.2.0",
+        "outvariant": "^1.4.3",
+        "strict-event-emitter": "^0.5.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@open-draft/deferred-promise": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@open-draft/deferred-promise/-/deferred-promise-2.2.0.tgz",
+      "integrity": "sha512-CecwLWx3rhxVQF6V4bAgPS5t+So2sTbPgAzafKkVizyi7tlwpcFpdFqq+wqF2OwNBmqFuu6tOyouTuxgpMfzmA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@open-draft/logger": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@open-draft/logger/-/logger-0.3.0.tgz",
+      "integrity": "sha512-X2g45fzhxH238HKO4xbSr7+wBS8Fvw6ixhTDuvLd5mqh6bJJCFAPwU9mPDxbcrRtfxv4u5IHCEH77BmxvXmmxQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-node-process": "^1.2.0",
+        "outvariant": "^1.4.0"
+      }
+    },
+    "node_modules/@open-draft/until": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@open-draft/until/-/until-2.1.0.tgz",
+      "integrity": "sha512-U69T3ItWHvLwGg5eJ0n3I62nWuE6ilHlmz7zM0npLBRvPRd7e6NYmg54vvRtP5mZG7kZqZCFVdsTWo7BPtBujg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@pkgjs/parseargs": {
       "version": "0.11.0",
@@ -3021,6 +3065,13 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/is-node-process": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/is-node-process/-/is-node-process-1.2.0.tgz",
+      "integrity": "sha512-Vg4o6/fqPxIjtxgUH5QLJhwZ7gW5diGCVlXpuUfELC62CuxM1iHcRe51f2W1FDy04Ai4KJkagKjx3XaqyfRKXw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/is-number": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
@@ -3175,6 +3226,13 @@
           "optional": true
         }
       }
+    },
+    "node_modules/json-stringify-safe": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+      "integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/lightningcss": {
       "version": "1.30.1",
@@ -3605,6 +3663,21 @@
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
     },
+    "node_modules/nock": {
+      "version": "14.0.7",
+      "resolved": "https://registry.npmjs.org/nock/-/nock-14.0.7.tgz",
+      "integrity": "sha512-ubwvvhSzNPqc7Nm3a/iYolwqb7lo1zfllDKO1ODsYu3KnarmQEya5yV70ZUwhVxYIl1ePuX3W+lHw2un+pUfpQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@mswjs/interceptors": "^0.39.3",
+        "json-stringify-safe": "^5.0.1",
+        "propagate": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18.20.0 <20 || >=20.12.1"
+      }
+    },
     "node_modules/normalize-path": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
@@ -3630,6 +3703,13 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/outvariant": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/outvariant/-/outvariant-1.4.3.tgz",
+      "integrity": "sha512-+Sl2UErvtsoajRDKCE5/dBz4DIvHXQQnAxtQTF04OJxY0+DyZXSo5P5Bb7XYWOh81syohlYL24hbDwxedPUJCA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/package-json-from-dist": {
       "version": "1.0.1",
@@ -3831,6 +3911,16 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
       "license": "MIT"
+    },
+    "node_modules/propagate": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/propagate/-/propagate-2.0.1.tgz",
+      "integrity": "sha512-vGrhOavPSTz4QVNuBNdcNXePNdNMaO1xj9yBeH1ScQPjk/rhg9sSlCXPhMkFuaNNW/syTvYqsnbIJxMBfRbbag==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
     },
     "node_modules/punycode": {
       "version": "2.3.1",
@@ -4137,6 +4227,13 @@
       "version": "3.9.0",
       "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.9.0.tgz",
       "integrity": "sha512-UGvjygr6F6tpH7o2qyqR6QYpwraIjKSdtzyBdyytFOHmPZY917kwdwLG0RbOjWOnKmnm3PeHjaoLLMie7kPLQw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/strict-event-emitter": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/strict-event-emitter/-/strict-event-emitter-0.5.1.tgz",
+      "integrity": "sha512-vMgjE/GGEPEFnhFub6pa4FmJBRBVOLpIII2hvCZ8Kzb7K0hlHo7mQv6xYrBvCL2LtAIBwFUK8wvuJgTVSQ5MFQ==",
       "dev": true,
       "license": "MIT"
     },

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "@vitejs/plugin-react-swc": "^3.11.0",
     "@vitest/coverage-v8": "^3.2.4",
     "jsdom": "^26.1.0",
+    "nock": "^14.0.7",
     "typescript": "^5.8.3",
     "vite": "^7.0.0",
     "vite-plugin-live-reload": "^3.0.5",

--- a/package.json
+++ b/package.json
@@ -34,6 +34,8 @@
     "@tailwindcss/forms": "^0.5.10",
     "@tailwindcss/typography": "^0.5.16",
     "@tailwindcss/vite": "^4.1.11",
+    "@tanstack/react-query": "^5.83.0",
+    "@tanstack/react-query-devtools": "^5.83.0",
     "@zachleat/details-utils": "^2.0.2",
     "bootstrap": "4.6.2",
     "datatables.net-bs4": "1.13.11",


### PR DESCRIPTION
The current implementation of the metadata tab requires that all data updates are handled in the CodelistBuilder (class) component. We should simplify this so that the individual components can handle their own state, and POST changes to the server. This PR is the first of a number of PRs to simplify the component architecture.

In this PR I have:
- Created a new MetadataForm component
    - Used that component for the description field
    - Styled it using Bootstrap card classes (as opposed to react-bootstrap, which contains many context providers)
- Used react-query to hold the state of the metadata, and update it upon the POST request to the server
- Added tests which use react-query for testing, and nock for mocking API requests
- Removed any tests for the existing description functionality
- Prepared the MetadataForm component to be used for the Methodology field
- Added types as capitalised constants for data passed directly from the Django app to the React app (where the data is not changed in any way)

## Screenshot

<img width="820" alt="Screenshot showing the metadata tab" src="https://github.com/user-attachments/assets/e0edc3ba-6fa3-4b0e-a860-657532738854" />

## Video

https://github.com/user-attachments/assets/65e2a179-1800-4acc-86d6-2ec1fd891377