### PR TITLE
Put add/edit references into a modal for metadata in the draft view

### DIFF
--- a/assets/src/scripts/components/Metadata/Reference.tsx
+++ b/assets/src/scripts/components/Metadata/Reference.tsx
@@ -2,7 +2,7 @@ import { useMutation, useQueryClient } from "@tanstack/react-query";
 import React, { useState } from "react";
 import { postFetchWithOptions, readValueFromPage } from "../../_utils";
 import type { IS_EDITABLE, METADATA } from "../../types";
-import ReferenceForm from "./ReferenceForm";
+import ReferenceFormModal from "./ReferenceFormModal";
 
 export default function Reference({
   isEditable,
@@ -84,7 +84,7 @@ export default function Reference({
           </div>
         )}
       </div>
-      <ReferenceForm
+      <ReferenceFormModal
         defaultValue={reference}
         onReset={() => setIsEditing(false)}
         onSubmit={handleSubmit}

--- a/assets/src/scripts/components/Metadata/Reference.tsx
+++ b/assets/src/scripts/components/Metadata/Reference.tsx
@@ -84,13 +84,12 @@ export default function Reference({
           </div>
         )}
       </div>
-      {isEditing && (
-        <ReferenceForm
-          defaultValue={reference}
-          onReset={() => setIsEditing(false)}
-          onSubmit={handleSubmit}
-        />
-      )}
+      <ReferenceForm
+        defaultValue={reference}
+        onReset={() => setIsEditing(false)}
+        onSubmit={handleSubmit}
+        show={isEditing}
+      />
     </li>
   );
 }

--- a/assets/src/scripts/components/Metadata/ReferenceForm.tsx
+++ b/assets/src/scripts/components/Metadata/ReferenceForm.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import { Modal } from "react-bootstrap";
 
 interface ReferenceFormProps {
   defaultValue?: {
@@ -7,54 +8,74 @@ interface ReferenceFormProps {
   };
   onReset: React.FormEventHandler<HTMLFormElement>;
   onSubmit: React.FormEventHandler<HTMLFormElement>;
+  show: boolean;
 }
 
 export default function ReferenceForm({
   defaultValue,
   onReset,
   onSubmit,
+  show,
 }: ReferenceFormProps) {
   return (
-    <form onReset={onReset} onSubmit={onSubmit}>
-      <div className="form-group">
-        <label className="form-label" htmlFor="addReferenceText">
-          Text
-        </label>
-        <input
-          className="form-control"
-          defaultValue={defaultValue?.text}
-          id="addReferenceText"
-          name="text"
-          placeholder="Text to display"
-          required
-          type="text"
-        />
-      </div>
-      <div className="form-group">
-        <label className="form-label" htmlFor="addReferenceUrl">
-          URL
-        </label>
-        <input
-          className="form-control"
-          defaultValue={defaultValue?.url}
-          id="addReferenceUrl"
-          name="url"
-          placeholder="Website to link to"
-          required
-          type="url"
-        />
-      </div>
-      <div className="btn-group-sm">
-        <button
-          type="submit"
-          className="plausible-event-name=Metadata+save+references btn btn-primary"
-        >
-          Save
-        </button>
-        <button type="reset" className="btn btn-secondary ml-1">
-          Cancel
-        </button>
-      </div>
-    </form>
+    <Modal
+      animation={false}
+      backdrop="static"
+      show={show}
+      size="lg"
+      aria-labelledby="reference-edit-modal"
+      centered
+    >
+      <form onReset={onReset} onSubmit={onSubmit}>
+        <Modal.Header>
+          <Modal.Title id="reference-edit-modal">
+            {defaultValue ? "Edit Reference" : "Add Reference"}
+          </Modal.Title>
+        </Modal.Header>
+        <Modal.Body>
+          <div className="form-group">
+            <label className="form-label" htmlFor="addReferenceText">
+              Text
+            </label>
+            <input
+              className="form-control"
+              defaultValue={defaultValue?.text}
+              id="addReferenceText"
+              name="text"
+              placeholder="Text to display"
+              required
+              type="text"
+            />
+          </div>
+          <div className="form-group">
+            <label className="form-label" htmlFor="addReferenceUrl">
+              URL
+            </label>
+            <input
+              className="form-control"
+              defaultValue={defaultValue?.url}
+              id="addReferenceUrl"
+              name="url"
+              placeholder="Website to link to"
+              required
+              type="url"
+            />
+          </div>
+        </Modal.Body>
+        <Modal.Footer>
+          <div className="btn-group-sm">
+            <button
+              type="submit"
+              className="plausible-event-name=Metadata+save+references btn btn-primary"
+            >
+              Save
+            </button>
+            <button type="reset" className="btn btn-secondary ml-1">
+              Cancel
+            </button>
+          </div>
+        </Modal.Footer>
+      </form>
+    </Modal>
   );
 }

--- a/assets/src/scripts/components/Metadata/ReferenceFormModal.tsx
+++ b/assets/src/scripts/components/Metadata/ReferenceFormModal.tsx
@@ -38,6 +38,8 @@ export default function ReferenceFormModal({
               Text
             </label>
             <input
+              // biome-ignore lint/a11y/noAutofocus: It's fine to use this in a modal dialog
+              autoFocus
               className="form-control"
               defaultValue={defaultValue?.text}
               id="addReferenceText"

--- a/assets/src/scripts/components/Metadata/ReferenceFormModal.tsx
+++ b/assets/src/scripts/components/Metadata/ReferenceFormModal.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { Modal } from "react-bootstrap";
 
-interface ReferenceFormProps {
+interface ReferenceFormModalProps {
   defaultValue?: {
     text: string;
     url: string;
@@ -11,12 +11,12 @@ interface ReferenceFormProps {
   show: boolean;
 }
 
-export default function ReferenceForm({
+export default function ReferenceFormModal({
   defaultValue,
   onReset,
   onSubmit,
   show,
-}: ReferenceFormProps) {
+}: ReferenceFormModalProps) {
   return (
     <Modal
       animation={false}

--- a/assets/src/scripts/components/Metadata/ReferenceFormModal.tsx
+++ b/assets/src/scripts/components/Metadata/ReferenceFormModal.tsx
@@ -17,6 +17,14 @@ export default function ReferenceFormModal({
   onSubmit,
   show,
 }: ReferenceFormModalProps) {
+  function handleKeyDown(e: React.KeyboardEvent<HTMLFormElement>) {
+    // Handle Escape for Cancel
+    if (e.key === "Escape") {
+      e.preventDefault();
+      onReset(e);
+    }
+  }
+
   return (
     <Modal
       animation={false}
@@ -26,7 +34,7 @@ export default function ReferenceFormModal({
       aria-labelledby="reference-edit-modal"
       centered
     >
-      <form onReset={onReset} onSubmit={onSubmit}>
+      <form onKeyDown={handleKeyDown} onReset={onReset} onSubmit={onSubmit}>
         <Modal.Header>
           <Modal.Title id="reference-edit-modal">
             {defaultValue ? "Edit Reference" : "Add Reference"}
@@ -63,6 +71,9 @@ export default function ReferenceFormModal({
               type="url"
             />
           </div>
+          <small className="form-text text-muted">
+            Keyboard shortcuts: Save (ENTER) / Cancel (ESC)
+          </small>
         </Modal.Body>
         <Modal.Footer>
           <div className="btn-group-sm">

--- a/assets/src/scripts/components/Metadata/References.tsx
+++ b/assets/src/scripts/components/Metadata/References.tsx
@@ -3,7 +3,7 @@ import React, { useState } from "react";
 import { postFetchWithOptions, readValueFromPage } from "../../_utils";
 import type { IS_EDITABLE, METADATA } from "../../types";
 import Reference from "./Reference";
-import ReferenceForm from "./ReferenceForm";
+import ReferenceFormModal from "./ReferenceFormModal";
 
 export default function References() {
   const isEditable: IS_EDITABLE = readValueFromPage("is-editable");
@@ -82,7 +82,7 @@ export default function References() {
           ))}
         </ul>
       ) : null}
-      <ReferenceForm
+      <ReferenceFormModal
         onReset={() => setShowAddReference(false)}
         onSubmit={handleSubmit}
         show={showAddReference}

--- a/assets/src/scripts/components/Metadata/References.tsx
+++ b/assets/src/scripts/components/Metadata/References.tsx
@@ -71,17 +71,8 @@ export default function References() {
         </p>
       </div>
 
-      {data.length || showAddReference ? (
+      {data.length ? (
         <ul className="list-group list-group-flush">
-          {showAddReference && (
-            <li className="list-group-item">
-              <ReferenceForm
-                onReset={() => setShowAddReference(false)}
-                onSubmit={handleSubmit}
-              />
-            </li>
-          )}
-
           {data.map((reference) => (
             <Reference
               isEditable={isEditable}
@@ -91,6 +82,11 @@ export default function References() {
           ))}
         </ul>
       ) : null}
+      <ReferenceForm
+        onReset={() => setShowAddReference(false)}
+        onSubmit={handleSubmit}
+        show={showAddReference}
+      />
     </div>
   );
 }


### PR DESCRIPTION
Brings the references in the metadata (in draft view) in line with the description and methodology, by having edits take place in a modal. #2775 was the PR for doing this for description and methodology. The reasons are the same, repeating them here for completeness:

- users can't forget to click save which was possible before this change as you could tab away with no warning
- also reduces confusion as you don't have the choice of "Save" for the field and "Save draft". Users might think "Save draft" would also save their metadata edits.

Within this change I've also added:
- autofocus the first field in the modal
- add a key handler so escape closes the modal - similar to the other metadata fields

