### PR TITLE
Fix bug where metadata can't be edited

### DIFF
--- a/assets/src/scripts/components/CodelistBuilder.tsx
+++ b/assets/src/scripts/components/CodelistBuilder.tsx
@@ -1,3 +1,4 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import React from "react";
 import { Col, Row, Tab, Tabs } from "react-bootstrap";
 import type { SelectCallback } from "react-bootstrap/esm/helpers";
@@ -15,6 +16,17 @@ interface CodelistBuilderProps extends PageData {
   metadata: METADATA;
 }
 type TabKey = "codelist" | "metadata";
+
+const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      refetchOnMount: false,
+      refetchOnReconnect: false,
+      refetchOnWindowFocus: false,
+      staleTime: "static",
+    },
+  },
+});
 
 /**
  * Creates a fetch options object with standard headers including CSRF token
@@ -181,7 +193,7 @@ export default class CodelistBuilder extends React.Component<
     } = this.props;
 
     return (
-      <>
+      <QueryClientProvider client={queryClient}>
         <Header
           counts={this.counts()}
           isEditable={isEditable}
@@ -232,7 +244,7 @@ export default class CodelistBuilder extends React.Component<
             </Col>
           )}
         </Row>
-      </>
+      </QueryClientProvider>
     );
   }
 }

--- a/assets/src/scripts/components/Layout/MetadataTab.tsx
+++ b/assets/src/scripts/components/Layout/MetadataTab.tsx
@@ -1,23 +1,11 @@
-import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { ReactQueryDevtools } from "@tanstack/react-query-devtools";
 import React from "react";
 import MetadataForm from "../Metadata/MetadataForm";
 import References from "../Metadata/References";
 
 export default function MetadataTab() {
-  const client = new QueryClient({
-    defaultOptions: {
-      queries: {
-        refetchOnMount: false,
-        refetchOnReconnect: false,
-        refetchOnWindowFocus: false,
-        staleTime: "static",
-      },
-    },
-  });
-
   return (
-    <QueryClientProvider client={client}>
+    <>
       <p className="font-italic">
         Users have found it helpful to record their decision strategy as they
         build their codelist. Text added here will be ready for you to edit
@@ -29,6 +17,6 @@ export default function MetadataTab() {
         <References />
       </div>
       <ReactQueryDevtools />
-    </QueryClientProvider>
+    </>
   );
 }


### PR DESCRIPTION
Fixes #2782 

Move the QueryClient up to the CodelistBuilder level. In the MetadataTab component it was causing a bug where switching the tab caused the QueryClient to be recreated. This meant that changes to the description/methodology fields were persisted to the backend but not displayed locally.

By having it at this level it also means we can use the same one to keep the include/exclude state in sync with the backend.

Added a playwright test which failed before this change was committed to act as a regression test.