### PR TITLE
Implement limit on the length of a description

### DIFF
--- a/assets/src/scripts/components/Layout/MetadataTab.tsx
+++ b/assets/src/scripts/components/Layout/MetadataTab.tsx
@@ -11,7 +11,7 @@ export default function MetadataTab() {
         before you publish the codelist.
       </p>
       <div className="builder__metadata-forms">
-        <MetadataForm id="description" name="Description" />
+        <MetadataForm id="description" name="Description" rows={6} />
         <MetadataForm id="methodology" name="Methodology" />
         <References />
       </div>

--- a/assets/src/scripts/components/Metadata/MetadataForm.tsx
+++ b/assets/src/scripts/components/Metadata/MetadataForm.tsx
@@ -7,9 +7,11 @@ import type { IS_EDITABLE, METADATA, UPDATE_URL } from "../../types";
 export default function MetadataForm({
   id,
   name,
+  rows = 10,
 }: {
   id: string;
   name: string;
+  rows?: number;
 }) {
   const isEditable: IS_EDITABLE = readValueFromPage("is-editable");
   const metadata: METADATA = readValueFromPage("metadata");
@@ -131,7 +133,7 @@ export default function MetadataForm({
                 name={id}
                 onFocus={handleFocus}
                 onKeyDown={handleKeyDown}
-                rows={5}
+                rows={rows}
               ></textarea>
               <small className="form-text text-muted">
                 <div

--- a/assets/src/scripts/components/Metadata/MetadataForm.tsx
+++ b/assets/src/scripts/components/Metadata/MetadataForm.tsx
@@ -134,7 +134,16 @@ export default function MetadataForm({
                 rows={5}
               ></textarea>
               <small className="form-text text-muted">
-                Keyboard shortcuts: Save (CTRL-ENTER) / Cancel (ESC)
+                <div
+                  // biome-ignore lint/security/noDangerouslySetInnerHtml: help text is set by us and so safe
+                  dangerouslySetInnerHTML={
+                    // @ts-ignore: we're not currently using react-query to return
+                    // the expected values of the typescript compiler
+                    { __html: data?.help_text ?? "" }
+                  }
+                ></div>
+
+                <p>Keyboard shortcuts: Save (CTRL-ENTER) / Cancel (ESC)</p>
               </small>
             </div>
           </Modal.Body>

--- a/assets/src/scripts/components/Metadata/MetadataForm.tsx
+++ b/assets/src/scripts/components/Metadata/MetadataForm.tsx
@@ -125,6 +125,9 @@ export default function MetadataForm({
                 // the expected values of the typescript compiler
                 defaultValue={data?.text ?? ""}
                 id={`metadata-${id}`}
+                // @ts-ignore: we're not currently using react-query to return
+                // the expected values of the typescript compiler
+                maxLength={data?.max_length || undefined}
                 name={id}
                 onFocus={handleFocus}
                 onKeyDown={handleKeyDown}

--- a/assets/src/scripts/types.ts
+++ b/assets/src/scripts/types.ts
@@ -60,6 +60,7 @@ export type METADATA = {
   description: {
     text: string;
     html: string;
+    max_length?: number;
   };
   methodology: {
     text: string;

--- a/assets/src/scripts/types.ts
+++ b/assets/src/scripts/types.ts
@@ -60,6 +60,7 @@ export type METADATA = {
   description: {
     text: string;
     html: string;
+    help_text?: string;
     max_length?: number;
   };
   methodology: {

--- a/builder/views.py
+++ b/builder/views.py
@@ -12,6 +12,7 @@ from django.utils.text import slugify
 from django.views.decorators.http import require_http_methods
 
 from codelists.actions import update_codelist
+from codelists.forms import CodelistUpdateForm
 from codelists.models import Search
 from codelists.search import do_search
 from opencodelists.templatetags.markdown_filter import render_markdown
@@ -60,6 +61,16 @@ def _handle_post(request, draft):
         return redirect(reverse("user", args=(request.user.username,)))
     else:
         return HttpResponse(status=400)
+
+
+def _get_description_max_length(codelist):
+    """Get the max_length for description field from the form"""
+    # Create form instance with current description
+    form_data = {"description": codelist.description}
+    form = CodelistUpdateForm(data=form_data, owner_choices=[])
+
+    # Get the max_length attribute from the description field widget
+    return form.fields["description"].widget.attrs.get("maxlength")
 
 
 def _draft(request, draft, search_id):
@@ -196,6 +207,7 @@ def _draft(request, draft, search_id):
         "description": {
             "text": codelist.description,
             "html": linebreaks(codelist.description),
+            "max_length": _get_description_max_length(codelist),
         },
         "methodology": {
             "text": codelist.methodology,
@@ -279,6 +291,7 @@ def update(request, draft):
             "description": {
                 "text": updated_fields["description"],
                 "html": linebreaks(updated_fields["description"]),
+                "max_length": _get_description_max_length(draft.codelist),
             },
             "methodology": {
                 "text": updated_fields["methodology"],

--- a/builder/views.py
+++ b/builder/views.py
@@ -63,6 +63,15 @@ def _handle_post(request, draft):
         return HttpResponse(status=400)
 
 
+def _get_description_help_text(codelist):
+    """Get the help_text for description field from the form"""
+    # Create form instance
+    form = CodelistUpdateForm(owner_choices=[])
+
+    # Get the help_text attribute from the description field
+    return form.fields["description"].help_text
+
+
 def _get_description_max_length(codelist):
     """Get the max_length for description field from the form"""
     # Create form instance with current description
@@ -207,6 +216,7 @@ def _draft(request, draft, search_id):
         "description": {
             "text": codelist.description,
             "html": linebreaks(codelist.description),
+            "help_text": _get_description_help_text(codelist),
             "max_length": _get_description_max_length(codelist),
         },
         "methodology": {
@@ -291,6 +301,7 @@ def update(request, draft):
             "description": {
                 "text": updated_fields["description"],
                 "html": linebreaks(updated_fields["description"]),
+                "help_text": _get_description_help_text(draft.codelist),
                 "max_length": _get_description_max_length(draft.codelist),
             },
             "methodology": {

--- a/codelists/forms.py
+++ b/codelists/forms.py
@@ -198,7 +198,7 @@ class CodelistUpdateForm(forms.Form):
         initial_desc = self.data.get("description")
         if initial_desc:
             normalized_desc = initial_desc.replace("\r\n", "\n").replace("\r", "\n")
-            if len(normalized_desc) > 500:
+            if len(normalized_desc) > description_max_length:
                 desc_field.widget.attrs.pop("maxlength", None)
 
     def clean_owner(self):

--- a/codelists/forms.py
+++ b/codelists/forms.py
@@ -145,6 +145,14 @@ class CSVValidationMixin:
 
 
 description_max_length = 500
+description_help_text = (
+    f"This is the short summary (max {description_max_length} characters) that "
+    "will be shown with search results. E.g."
+    "<ul>"
+    '<li>This codelist contains all codes referred to in the "has_dementia" field of the QCovid assessment tool.</li>'
+    "<li>This codelist aims to identify SSRIs that are more likely to be prescribed in obsessive compulsive disorder</li>"
+    "</ul>"
+)
 
 
 class CodelistCreateForm(forms.Form, CSVValidationMixin):
@@ -153,6 +161,7 @@ class CodelistCreateForm(forms.Form, CSVValidationMixin):
     description = form_field_from_model(
         Codelist,
         "description",
+        help_text=description_help_text,
         widget=forms.Textarea(attrs={"maxlength": description_max_length}),
     )
     methodology = form_field_from_model(Codelist, "methodology")
@@ -171,6 +180,7 @@ class CodelistUpdateForm(forms.Form):
     description = form_field_from_model(
         Codelist,
         "description",
+        help_text=description_help_text,
         widget=forms.Textarea(attrs={"maxlength": description_max_length}),
     )
     methodology = form_field_from_model(Codelist, "methodology")


### PR DESCRIPTION
As per [this](https://github.com/opensafely-core/opencodelists/issues/2582) we have decided to limit the length of the description field. This sets that limit to new descriptions. However, we have previously allowed descriptions longer than this (there are about ~60 at present), so this deals with that be only having the limit for new descriptions or those already under the limit. If something is already over the limit, then we don't enforce it. This is so that you can still edit too long descriptions.

Also
- added help text in a way that works for the main "edit metadata" django form page, and also in the builder react app
- made the number of rows in the textarea in the `MetadataForm` component configurable so the description can be short and the methodology can be long