### PR TITLE
Handles missing codeset in definition download

### DIFF
--- a/codelists/presenters.py
+++ b/codelists/presenters.py
@@ -29,6 +29,9 @@ def present_definition_for_download(clv):
     """Return rows for CSV download of a definition."""
 
     codeset = clv.codeset
+    if not codeset:
+        raise ValueError("Codelist version does not have a codeset")
+
     code_to_term = clv.coding_system.code_to_term(codeset.all_codes())
     rows = [
         (code, code_to_term[code], status)

--- a/codelists/views/version_download_definition.py
+++ b/codelists/views/version_download_definition.py
@@ -5,10 +5,18 @@ from .decorators import load_version
 
 @load_version
 def version_download_definition(request, clv):
-    response = HttpResponse(content_type="text/csv")
-    content_disposition = (
-        f'attachment; filename="{clv.download_filename()}-definition.csv"'
-    )
-    response["Content-Disposition"] = content_disposition
-    response.write(clv.definition_csv_data_for_download())
-    return response
+    try:
+        response = HttpResponse(content_type="text/csv")
+        content_disposition = (
+            f'attachment; filename="{clv.download_filename()}-definition.csv"'
+        )
+        response["Content-Disposition"] = content_disposition
+        response.write(clv.definition_csv_data_for_download())
+        return response
+    except ValueError as e:
+        if str(e) == "Codelist version does not have a codeset":
+            return HttpResponse(
+                "This codelist version does not have a codeset.",
+                status=400,
+            )
+        raise e


### PR DESCRIPTION
We hide the "Download definition" for codelists without a codeset, but it's still possible to manually create the URL. This then triggers an unhandled exception. This code handles it and returns a 400 to the user with an explanation.

Fixes #2785 