### PR TITLE
Replace React Bootstrap with HTML classes

### DIFF
--- a/assets/src/scripts/components/Cards/Searches.tsx
+++ b/assets/src/scripts/components/Cards/Searches.tsx
@@ -1,5 +1,4 @@
 import React, { useState } from "react";
-import { Button, Card, Form, ListGroup } from "react-bootstrap";
 import { getCookie } from "../../_utils";
 import type { PageData } from "../../types";
 
@@ -31,68 +30,55 @@ export default function Searches({
   };
 
   return (
-    <Card>
-      <Card.Header as="h2" className="h6 font-weight-bold">
-        Previous searches
-      </Card.Header>
-      <ListGroup variant="flush">
+    <div className="card">
+      <h2 className="card-header h6 font-weight-bold">Previous searches</h2>
+      <div className="list-group list-group-flush">
         {searches.map((search) => (
-          <React.Fragment key={search.url}>
+          <a
+            className={`
+                list-group-item list-group-item-action
+                d-flex justify-content-between align-items-center
+                ${search.url === activeUrl ? "active" : ""}
+              `}
+            href={search.url}
+            key={search.url}
+            onClick={handleClick(search.url)}
+          >
+            <div className="break-word">{search.term_or_code}</div>
             {search.delete_url && isEditable ? (
-              <ListGroup.Item
-                action
-                active={search.url === activeUrl}
-                href={search.url}
-                onClick={handleClick(search.url)}
-              >
-                <Form
-                  action={search.delete_url}
-                  className="d-flex justify-content-between align-items-center"
-                  method="post"
+              <form action={search.delete_url} className="ml-2" method="post">
+                <input
+                  name="csrfmiddlewaretoken"
+                  type="hidden"
+                  className="form-control"
+                  value={getCookie("csrftoken")}
+                />
+                <button
+                  type="submit"
+                  aria-label="remove search"
+                  className={`
+                    btn btn-sm
+                    ${search.url === activeUrl ? "btn-light" : "btn-outline-danger"}
+                  `}
+                  name="delete-search"
                 >
-                  <Form.Control
-                    name="csrfmiddlewaretoken"
-                    type="hidden"
-                    value={getCookie("csrftoken")}
-                  />
-                  {search.term_or_code}
-                  <Button
-                    aria-label="remove search"
-                    className="ml-2"
-                    name="delete-search"
-                    type="submit"
-                    size="sm"
-                    variant={
-                      search.url === activeUrl ? "light" : "outline-danger"
-                    }
-                  >
-                    Remove
-                  </Button>
-                </Form>
-              </ListGroup.Item>
-            ) : (
-              <ListGroup.Item
-                action
-                active={search.active}
-                href={encodeURI(search.url)}
-              >
-                {search.term_or_code}
-              </ListGroup.Item>
-            )}
-          </React.Fragment>
+                  Remove
+                </button>
+              </form>
+            ) : null}
+          </a>
         ))}
 
         {searches.some((search) => search.active) ? (
-          <ListGroup.Item
-            action
-            className="font-italic"
+          <a
+            className="list-group-item list-group-item-action font-italic"
             href={encodeURI(draftURL)}
             onClick={handleClick(draftURL)}
           >
             show all
-          </ListGroup.Item>
+          </a>
         ) : null}
-      </ListGroup>
-    </Card>
+      </div>
+    </div>
   );
 }

--- a/assets/src/scripts/components/Cards/Summary.tsx
+++ b/assets/src/scripts/components/Cards/Summary.tsx
@@ -1,5 +1,4 @@
 import React from "react";
-import { Card, ListGroup } from "react-bootstrap";
 import type { PageData } from "../../types";
 
 export interface SummaryProps {
@@ -24,61 +23,56 @@ export default function Summary({ counts, draftURL }: SummaryProps) {
     encodeURI(`${draftURL}?filter=${filter}`);
 
   return (
-    <Card>
-      <Card.Header as="h2" className="h6 font-weight-bold">
+    <div className="card">
+      <h2 className="card-header h6 font-weight-bold">
         Concepts found ({counts.total})
-      </Card.Header>
-      <ListGroup variant="flush">
+      </h2>
+      <div className="list-group list-group-flush">
         {counts["+"] > 0 && (
-          <ListGroup.Item
-            action
-            active={currentFilter === "included"}
+          <a
+            className={`list-group-item list-group-item-action ${currentFilter === "included" ? "active" : ""}`}
             href={itemHref("included")}
             id="summary-included"
           >
             {counts["+"] + counts["(+)"]} included concepts
-          </ListGroup.Item>
+          </a>
         )}
         {counts["-"] > 0 && (
-          <ListGroup.Item
-            action
-            active={currentFilter === "excluded"}
+          <a
+            className={`list-group-item list-group-item-action ${currentFilter === "excluded" ? "active" : ""}`}
             href={itemHref("excluded")}
             id="summary-excluded"
           >
             {counts["-"] + counts["(-)"]} excluded concepts
-          </ListGroup.Item>
+          </a>
         )}
         {counts["?"] > 0 && (
-          <ListGroup.Item
-            action
-            active={currentFilter === "unresolved"}
+          <a
+            className={`list-group-item list-group-item-action ${currentFilter === "unresolved" ? "active" : ""}`}
             href={itemHref("unresolved")}
             id="summary-unresolved"
           >
             {counts["?"]} unresolved concepts
-          </ListGroup.Item>
+          </a>
         )}
         {counts["!"] > 0 && (
-          <ListGroup.Item
-            action
-            active={currentFilter === "in-conflict"}
+          <a
+            className={`list-group-item list-group-item-action ${currentFilter === "in-conflict" ? "active" : ""}`}
             href={itemHref("in-conflict")}
             id="summary-in-conflict"
           >
             {counts["!"]} conflicted concepts
-          </ListGroup.Item>
+          </a>
         )}
         {currentFilter ? (
-          <ListGroup.Item
-            action
-            className="font-italic"
+          <a
+            className="list-group-item list-group-item-action font-italic"
             href={encodeURI(draftURL)}
           >
             show all {counts.total} matching concepts
-          </ListGroup.Item>
+          </a>
         ) : null}
-      </ListGroup>
-    </Card>
+      </div>
+    </div>
   );
 }

--- a/assets/src/scripts/components/Cards/Tools.tsx
+++ b/assets/src/scripts/components/Cards/Tools.tsx
@@ -1,5 +1,4 @@
 import React, { useState } from "react";
-import { Card, ListGroup } from "react-bootstrap";
 import { readValueFromPage } from "../../_utils";
 import listOfTools from "../../data/tools.json";
 
@@ -16,16 +15,16 @@ export default function Tools() {
   if (!codingSystemId || !tools.length) return null;
 
   return (
-    <Card>
-      <Card.Header>
+    <div className="card">
+      <div className="card-header">
         <h2 className="h6 font-weight-bold mb-1">Tools</h2>
         <p className="small mb-0">
           Tools to help you to build a better and more accurate codelist.
         </p>
-      </Card.Header>
-      <ListGroup as="ul" variant="flush">
+      </div>
+      <ul className="list-group list-group-flush">
         {tools.map((tool) => (
-          <ListGroup.Item key={tool.id} as="li">
+          <li className="list-group-item" key={tool.id}>
             <a
               href={tool.link}
               target="_blank"
@@ -37,9 +36,9 @@ export default function Tools() {
             {tool?.description && (
               <p className="small mb-0">{tool.description}</p>
             )}
-          </ListGroup.Item>
+          </li>
         ))}
-      </ListGroup>
-    </Card>
+      </ul>
+    </div>
   );
 }

--- a/assets/src/scripts/components/Cards/Versions.tsx
+++ b/assets/src/scripts/components/Cards/Versions.tsx
@@ -1,11 +1,4 @@
 import React from "react";
-import {
-  Badge,
-  Card,
-  ListGroup,
-  OverlayTrigger,
-  Tooltip,
-} from "react-bootstrap";
 import { readValueFromPage } from "../../_utils";
 
 export interface VersionProps {
@@ -36,10 +29,8 @@ function Version({ version }: { version: VersionProps }) {
   });
 
   return (
-    <ListGroup.Item
-      as="li"
-      key={version.tag_or_hash}
-      variant={version.current ? "secondary" : undefined}
+    <li
+      className={`list-group-item ${version.current ? "list-group-item-secondary" : ""}`}
     >
       <div className="d-flex justify-content-between align-items-center">
         <span className="d-block text-monospace font-weight-bold">
@@ -49,30 +40,23 @@ function Version({ version }: { version: VersionProps }) {
             <a href={encodeURI(version.url)}>{version.tag_or_hash}</a>
           )}
         </span>
-        {version.status === "draft" ? (
-          <Badge variant="light">Draft</Badge>
-        ) : null}
-        {version.status === "under review" ? (
-          <Badge variant="info">Under review</Badge>
-        ) : null}
-        {version.status === "published" ? (
-          <Badge variant="success">Published</Badge>
-        ) : null}
+        {version.status === "draft" && (
+          <span className="badge badge-light">Draft</span>
+        )}
+        {version.status === "under review" && (
+          <span className="badge badge-info">Under review</span>
+        )}
+        {version.status === "published" && (
+          <span className="badge badge-success">Published</span>
+        )}
       </div>
-      <span className="created d-block p-0">
-        <OverlayTrigger
-          placement="right"
-          overlay={
-            <Tooltip id={version.tag_or_hash}>
-              When this codelist version was added to OpenCodelists
-            </Tooltip>
-          }
-        >
-          <abbr className="font-weight-bold">Created</abbr>
-        </OverlayTrigger>
-        : {createdDate} at {createdTime}
-      </span>
-    </ListGroup.Item>
+      <div className="created d-block p-0 mt-1">
+        <span className="font-weight-bold">Added to OpenCodelists</span>
+        <span className="d-block">
+          {createdDate} at {createdTime}
+        </span>
+      </div>
+    </li>
   );
 }
 
@@ -82,15 +66,13 @@ export default function Versions() {
   if (!versions?.length) return null;
 
   return (
-    <Card>
-      <Card.Header as="h2" className="h6 font-weight-bold">
-        Versions
-      </Card.Header>
-      <ListGroup variant="flush" className="sidebar-versions" as="ol">
+    <div className="card">
+      <h2 className="card-header h6 font-weight-bold">Versions</h2>
+      <ol className="list-group list-group-flush sidebar-versions">
         {versions.map((version) => (
           <Version key={version.tag_or_hash} version={version} />
         ))}
-      </ListGroup>
-    </Card>
+      </ol>
+    </div>
   );
 }

--- a/assets/src/scripts/components/Codelist/Row.tsx
+++ b/assets/src/scripts/components/Codelist/Row.tsx
@@ -1,5 +1,4 @@
 import React from "react";
-import { ButtonGroup } from "react-bootstrap";
 import type Hierarchy from "../../_hierarchy";
 import type {
   Code,
@@ -74,7 +73,7 @@ export default function Row({
       data-code={code}
       data-path={path}
     >
-      <ButtonGroup>
+      <div className="btn-group">
         <StatusToggle
           code={code}
           status={status}
@@ -87,7 +86,7 @@ export default function Row({
           symbol="-"
           updateStatus={updateStatus}
         />
-      </ButtonGroup>
+      </div>
 
       <div className="pl-2 whitespace-nowrap">
         <Pipes pipes={pipes} />

--- a/assets/src/scripts/components/Codelist/StatusToggle.tsx
+++ b/assets/src/scripts/components/Codelist/StatusToggle.tsx
@@ -1,5 +1,4 @@
 import React from "react";
-import { Button } from "react-bootstrap";
 import type { Code, Status, UpdateStatus } from "../../types";
 
 interface StatusToggleProps {
@@ -15,21 +14,21 @@ export default function StatusToggle({
   symbol,
   updateStatus,
 }: StatusToggleProps) {
+  let buttonStyle = "outline-secondary";
+  if (status === symbol) {
+    buttonStyle = "primary";
+  }
+  if (status === `(${symbol})`) {
+    buttonStyle = "secondary";
+  }
   return (
-    <Button
-      className="py-0 text-monospace"
+    <button
+      className={`py-0 text-monospace btn btn-sm btn-${buttonStyle}`}
       data-symbol={symbol}
       onClick={updateStatus?.bind(null, code, symbol)}
-      size="sm"
-      variant={
-        status === symbol
-          ? "primary"
-          : status === `(${symbol})`
-            ? "secondary"
-            : "outline-secondary"
-      }
+      type="button"
     >
       {symbol === "+" ? "+" : <>&minus;</>}
-    </Button>
+    </button>
   );
 }

--- a/assets/src/scripts/components/CodelistBuilder.tsx
+++ b/assets/src/scripts/components/CodelistBuilder.tsx
@@ -1,7 +1,7 @@
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { ReactQueryDevtools } from "@tanstack/react-query-devtools";
 import React from "react";
-import { Col, Tab, Tabs } from "react-bootstrap";
+import { Tab, Tabs } from "react-bootstrap";
 import type { SelectCallback } from "react-bootstrap/esm/helpers";
 import type Hierarchy from "../_hierarchy";
 import { getCookie } from "../_utils";
@@ -211,11 +211,11 @@ export default class CodelistBuilder extends React.Component<
           />
 
           {isEmptyCodelist ? (
-            <Col md="9">
+            <div className="col-md-9">
               <EmptyState />
-            </Col>
+            </div>
           ) : (
-            <Col md="9">
+            <div className="col-md-9">
               <Tabs
                 activeKey={this.state.activeTab}
                 onSelect={this.handleTabSelect}
@@ -242,7 +242,7 @@ export default class CodelistBuilder extends React.Component<
                   <MetadataTab />
                 </Tab>
               </Tabs>
-            </Col>
+            </div>
           )}
         </div>
         <ReactQueryDevtools />

--- a/assets/src/scripts/components/CodelistBuilder.tsx
+++ b/assets/src/scripts/components/CodelistBuilder.tsx
@@ -1,7 +1,7 @@
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { ReactQueryDevtools } from "@tanstack/react-query-devtools";
 import React from "react";
-import { Col, Row, Tab, Tabs } from "react-bootstrap";
+import { Col, Tab, Tabs } from "react-bootstrap";
 import type { SelectCallback } from "react-bootstrap/esm/helpers";
 import type Hierarchy from "../_hierarchy";
 import { getCookie } from "../_utils";
@@ -201,7 +201,7 @@ export default class CodelistBuilder extends React.Component<
           metadata={metadata}
         />
 
-        <Row>
+        <div className="row">
           <Sidebar
             counts={this.counts()}
             draftURL={draftURL}
@@ -244,7 +244,7 @@ export default class CodelistBuilder extends React.Component<
               </Tabs>
             </Col>
           )}
-        </Row>
+        </div>
         <ReactQueryDevtools />
       </QueryClientProvider>
     );

--- a/assets/src/scripts/components/Layout/Header.tsx
+++ b/assets/src/scripts/components/Layout/Header.tsx
@@ -1,5 +1,4 @@
 import React from "react";
-import { Badge, ListGroup } from "react-bootstrap";
 import type { PageData } from "../../types";
 import type { SummaryProps } from "../Cards/Summary";
 import ManagementForm from "../Header/ManagementForm";
@@ -18,20 +17,20 @@ export default function Header({
       <div className="d-flex flex-row justify-content-between gap-2 mb-2">
         <h1 className="h3">
           {metadata.codelist_name}
-          <Badge className="align-text-bottom ml-1" variant="secondary">
+          <span className="badge badge-secondary align-text-bottom ml-1">
             Draft
-          </Badge>
+          </span>
         </h1>
         {isEditable && <ManagementForm counts={counts} />}
       </div>
 
-      <ListGroup horizontal className="small">
-        <ListGroup.Item className="py-1 px-2">
+      <dl className="small list-group list-group-horizontal small">
+        <div className="list-group-item py-1 px-2">
           <dt>Coding system</dt>
           <dd className="mb-0">{metadata.coding_system_name}</dd>
-        </ListGroup.Item>
+        </div>
 
-        <ListGroup.Item className="py-1 px-2">
+        <div className="list-group-item py-1 px-2">
           <dt>Coding system release</dt>
           <dd className="mb-0">
             {metadata.coding_system_release.release_name}{" "}
@@ -39,25 +38,25 @@ export default function Header({
               <>({metadata.coding_system_release.valid_from})</>
             ) : null}
           </dd>
-        </ListGroup.Item>
+        </div>
 
         {metadata.organisation_name ? (
-          <ListGroup.Item className="py-1 px-2">
+          <div className="list-group-item py-1 px-2">
             <dt>Organisation</dt>
             <dd className="mb-0">{metadata.organisation_name}</dd>
-          </ListGroup.Item>
+          </div>
         ) : null}
 
-        <ListGroup.Item className="py-1 px-2">
+        <div className="list-group-item py-1 px-2">
           <dt>Codelist ID</dt>
           <dd className="mb-0">{metadata.codelist_full_slug}</dd>
-        </ListGroup.Item>
+        </div>
 
-        <ListGroup.Item className="py-1 px-2">
+        <div className="list-group-item py-1 px-2">
           <dt>Version ID</dt>
           <dd className="mb-0">{metadata.hash}</dd>
-        </ListGroup.Item>
-      </ListGroup>
+        </div>
+      </dl>
     </div>
   );
 }

--- a/assets/src/scripts/components/Layout/Header.tsx
+++ b/assets/src/scripts/components/Layout/Header.tsx
@@ -24,7 +24,7 @@ export default function Header({
         {isEditable && <ManagementForm counts={counts} />}
       </div>
 
-      <dl className="small list-group list-group-horizontal small">
+      <dl className="list-group list-group-horizontal small">
         <div className="list-group-item py-1 px-2">
           <dt>Coding system</dt>
           <dd className="mb-0">{metadata.coding_system_name}</dd>

--- a/assets/src/scripts/components/Layout/Sidebar.tsx
+++ b/assets/src/scripts/components/Layout/Sidebar.tsx
@@ -1,5 +1,4 @@
 import React from "react";
-import { Col } from "react-bootstrap";
 import Searches, { type SearchesProps } from "../Cards/Searches";
 import SearchForm from "../Cards/SearchForm";
 import Summary, { type SummaryProps } from "../Cards/Summary";
@@ -20,7 +19,7 @@ export default function Sidebar({
   searches: SearchesProps["searches"];
 }) {
   return (
-    <Col className="builder__sidebar" md="3">
+    <div className="col-md-3 builder__sidebar">
       {!isEmptyCodelist && <Summary counts={counts} draftURL={draftURL} />}
       {searches.length > 0 && (
         <Searches
@@ -32,6 +31,6 @@ export default function Sidebar({
       {isEditable && <SearchForm />}
       {!isEmptyCodelist && <Versions />}
       <Tools />
-    </Col>
+    </div>
   );
 }


### PR DESCRIPTION
Where the only thing being applied is styling. This reduces the amount of components and context providers in the React component tree.

Images below from the React Dev Tools

## Before

<img width="375" alt="" src="https://github.com/user-attachments/assets/50bccfdf-cf15-46ad-9433-750759dccde5" />

## After

<img width="251" alt="" src="https://github.com/user-attachments/assets/18e4945b-022e-4834-b644-ecebb2524938" />
