### PR TITLE
Improve the codelist search feature

### DIFF
--- a/codelists/views/index.py
+++ b/codelists/views/index.py
@@ -13,9 +13,13 @@ def index(request, organisation_slug=None, status=Status.PUBLISHED):
 
     q = request.GET.get("q")
     if q:
-        handles = handles.filter(
-            Q(name__contains=q) | Q(codelist__description__contains=q)
-        )
+        search_words = q.split()
+        combined_query = Q()
+        for word in search_words:
+            combined_query &= Q(name__icontains=word) | Q(
+                codelist__description__icontains=word
+            )
+        handles = handles.filter(combined_query)
 
     if organisation_slug:
         organisation = get_object_or_404(Organisation, slug=organisation_slug)

--- a/codelists/views/index.py
+++ b/codelists/views/index.py
@@ -25,42 +25,6 @@ def _parse_search_query(query):
 def index(request, organisation_slug=None, status=Status.PUBLISHED):
     handles = Handle.objects.filter(is_current=True, codelist__is_private=False)
 
-    q = request.GET.get("q")
-    if q:
-        # We search for codelists whose name/description contain all the words
-        # in the query string, or the whole phrase if it is quoted. We then
-        # rank the results as follows:
-        # 1. Exact phrase match in name (rank 1)
-        # 2. All words in name (rank 2)
-        # 3. Any word in name (rank 3)
-        # 4. Any word in description (rank 4)
-
-        search_words = q.split()
-
-        whole_phrase_in_name = Q(name__icontains=q)
-        all_words_in_name = Q()
-        any_word_in_name = Q()
-        any_word_in_desc = Q()
-        combined_search_query = Q()
-        for word in search_words:
-            word_in_name = Q(name__icontains=word)
-            word_in_desc = Q(codelist__description__icontains=word)
-            all_words_in_name &= word_in_name
-            any_word_in_name |= word_in_name
-            any_word_in_desc |= word_in_desc
-            combined_search_query &= word_in_name | word_in_desc
-
-        handles = handles.annotate(
-            rank=Case(
-                When(whole_phrase_in_name, then=Value(1)),
-                When(all_words_in_name, then=Value(2)),
-                When(any_word_in_name, then=Value(3)),
-                When(any_word_in_desc, then=Value(4)),
-                default=Value(5),
-                output_field=IntegerField(),
-            )
-        ).filter(combined_search_query)
-
     if organisation_slug:
         organisation = get_object_or_404(Organisation, slug=organisation_slug)
         handles = handles.filter(organisation=organisation)
@@ -69,8 +33,53 @@ def index(request, organisation_slug=None, status=Status.PUBLISHED):
         # For now, we only want to show codelists that come from organisations.
         handles = handles.filter(organisation_id__isnull=False)
 
+    q = request.GET.get("q")
     if q:
-        handles = handles.order_by("rank", "name")
+        # Parse the search query to handle quoted phrases
+        quoted_phrases, individual_words = _parse_search_query(q.strip())
+        all_search_terms = quoted_phrases + individual_words
+
+        print(f"Search terms: {all_search_terms}")
+
+        if not all_search_terms:
+            # If no valid search terms, skip search and just order by name
+            handles = handles.order_by("name")
+        else:
+            # We search for codelists whose name/description contain all the words
+            # in the query string, or the whole phrase if it is quoted. We then
+            # rank the results as follows:
+            # 1. Exact phrase match in name (rank 1)
+            # 2. All words in name (rank 2)
+            # 3. Any word in name (rank 3)
+            # 4. Any word in description (rank 4)
+
+            whole_phrase_in_name = Q(name__icontains=q.strip().strip('"'))
+            all_terms_in_name = Q()
+            any_term_in_name = Q()
+            any_term_in_desc = Q()
+            combined_search_query = Q()
+            for term in all_search_terms:
+                term_in_name = Q(name__icontains=term)
+                term_in_desc = Q(codelist__description__icontains=term)
+                all_terms_in_name &= term_in_name
+                any_term_in_name |= term_in_name
+                any_term_in_desc |= term_in_desc
+                combined_search_query &= term_in_name | term_in_desc
+
+            handles = (
+                handles.annotate(
+                    rank=Case(
+                        When(whole_phrase_in_name, then=Value(1)),
+                        When(all_terms_in_name, then=Value(2)),
+                        When(any_term_in_name, then=Value(3)),
+                        When(any_term_in_desc, then=Value(4)),
+                        default=Value(5),
+                        output_field=IntegerField(),
+                    )
+                )
+                .filter(combined_search_query)
+                .order_by("rank", "name")
+            )
     else:
         handles = handles.order_by("name")
 

--- a/codelists/views/index.py
+++ b/codelists/views/index.py
@@ -1,3 +1,5 @@
+import re
+
 from django.core.paginator import Paginator
 from django.db.models import Case, IntegerField, Q, Value, When
 from django.shortcuts import get_object_or_404, render
@@ -6,6 +8,18 @@ from opencodelists.list_utils import flatten
 from opencodelists.models import Organisation
 
 from ..models import Handle, Status
+
+
+def _parse_search_query(query):
+    """Parse search query to extract quoted phrases and individual words."""
+    # Find all quoted phrases
+    quoted_phrases = re.findall(r'"([^"]*)"', query)
+
+    # Remove quoted phrases from query to get remaining words
+    remaining_query = re.sub(r'"[^"]*"', "", query)
+    individual_words = remaining_query.split()
+
+    return quoted_phrases, individual_words
 
 
 def index(request, organisation_slug=None, status=Status.PUBLISHED):


### PR DESCRIPTION
Fixes #2777 

Implements
- splits multi-word searches and finds codelists whose name or description contain all of the words
- add a sort order so e.g. matches in the name rank higher than matches in the description
- add quoted searches so e.g. "type 2 diabetes" matches the exact string rather than searching for the individual words