### PR TITLE
Only show download btn if downloadable

### DIFF
--- a/templates/codelists/version.html
+++ b/templates/codelists/version.html
@@ -208,13 +208,23 @@
               </div>
             {% endif %}
           {% else %}
-            <a
-              href="{{ clv.get_download_url }}"
-              role="button"
-              class="btn btn-outline-primary btn-block"
-            >
-              Download CSV
-            </a>
+            {% if clv.downloadable %}
+              <a
+                href="{{ clv.get_download_url }}"
+                role="button"
+                class="btn btn-outline-primary btn-block"
+              >
+                Download CSV
+              </a>
+            {% elif user_can_edit %}
+              <div class="btn btn-outline-primary btn-block disabled"
+                   data-toggle="tooltip"
+                   data-placement="right"
+                   title="This codelist cannot be downloaded, most likely because it's header does not contain a 'code' column. You can upload a new version if you want to fix this."
+              >
+                Download CSV
+              </div>
+            {% endif %}
           {% endif %}
           {% if clv.coding_system_id == "dmd" %}
             <a


### PR DESCRIPTION
Fixes #2784 

- If the CSV is downloadable, we show the "Download CSV" button
- If not downloadable, but the viewer can edit the codelist, then we display the button, but disabled, with a useful tooltip about what they can do about it
- If not downloadable, and the viewer cannot edit the codelist, then we display nothing