### PR TITLE
Simplify logic for displaying buttons on template

### DIFF
--- a/assets/src/styles/base.css
+++ b/assets/src/styles/base.css
@@ -115,7 +115,8 @@ a:focus {
   row-gap: 1rem;
 }
 
-.version__sidebar {
+.version__sidebar,
+.versions__sidebar-buttons {
   display: flex;
   flex-direction: column;
   row-gap: 2rem;

--- a/opencodelists/tests/functional/test_build_codelist.py
+++ b/opencodelists/tests/functional/test_build_codelist.py
@@ -299,7 +299,7 @@ def verify_codelist_csv(navigator, search_actions, initial_page_navigation=True)
         navigator.go_to_codelist()
 
     with navigator.page.expect_download() as download_info:
-        navigator.page.get_by_role("button", name="Download CSV").click()
+        navigator.page.get_by_role("link", name="Download CSV").click()
 
     codelist_table_from_csv = {}
 

--- a/opencodelists/tests/functional/test_docs_screenshots.py
+++ b/opencodelists/tests/functional/test_docs_screenshots.py
@@ -112,7 +112,7 @@ These 3 lists were mapped into CTV3 by TPP to create one list. This list was exa
     # The download buttons
     screenshot_element_with_padding(
         page,
-        page.locator(".version__sidebar .btn-group-vertical"),
+        page.get_by_test_id("not-dmd-buttons"),
         "download-buttons.png",
         full_page=True,
     )

--- a/opencodelists/tests/functional/test_docs_screenshots.py
+++ b/opencodelists/tests/functional/test_docs_screenshots.py
@@ -173,7 +173,7 @@ def test_generate_non_org_user_screen_shots(
 
     screenshot_element_with_padding(
         page,
-        page.get_by_role("button", name="Convert to dm+d").locator(".."),
+        page.get_by_role("button", name="Convert to dm+d"),
         "download-convert-buttons-bnf.png",
     )
 

--- a/opencodelists/tests/functional/test_docs_screenshots.py
+++ b/opencodelists/tests/functional/test_docs_screenshots.py
@@ -112,7 +112,7 @@ These 3 lists were mapped into CTV3 by TPP to create one list. This list was exa
     # The download buttons
     screenshot_element_with_padding(
         page,
-        page.locator("div.version__sidebar form"),
+        page.locator(".version__sidebar .btn-group-vertical"),
         "download-buttons.png",
         full_page=True,
     )

--- a/templates/codelists/version.html
+++ b/templates/codelists/version.html
@@ -213,7 +213,7 @@
             </a>
           {% endif %}
 
-          {% if clv.user %}
+          {% if clv.is_published or user_can_edit %}
             <a class="btn btn-outline-primary" href="{{ clv.codelist.get_clone_url }}">
               Clone this codelist
             </a>
@@ -254,7 +254,7 @@
               </a>
             {% endif %}
 
-            {% if clv.user %}
+            {% if clv.is_published or user_can_edit %}
               <a class="btn btn-outline-primary" href="{{ clv.codelist.get_clone_url }}">
                 Clone this codelist
               </a>

--- a/templates/codelists/version.html
+++ b/templates/codelists/version.html
@@ -228,7 +228,6 @@
               <a
                 class="btn btn-outline-primary"
                 href="{{ clv.get_download_url }}"
-                role="button"
               >
                 Download CSV
               </a>
@@ -267,7 +266,6 @@
         <div class="btn-group-vertical">
           <a
             href="{{ clv.get_dmd_download_url }}"
-            role="button"
             class="btn btn-outline-primary btn-block"
           >
             Download dm+d

--- a/templates/codelists/version.html
+++ b/templates/codelists/version.html
@@ -190,100 +190,107 @@
 
   <div class="row">
     <div class="col-md-3 version__sidebar">
-      <form action="{{ clv.get_dmd_convert_url }}" method="POST">
-        {% csrf_token %}
-        <div class="btn-group-vertical btn-block" role="group">
-          {% if clv.coding_system_id == "dmd" %}
-            {% if clv.downloadable %}
-              <a
-                href="{{ clv.get_download_url }}"
-                role="button"
-                class="btn btn-outline-primary btn-block"
-              >
-                Download CSV <small class="d-block">with mapped VMPs*</small>
-              </a>
-            {% else %}
-              <div class="btn btn-outline-primary btn-block disabled">
-                Download CSV <small class="d-block">with mapped VMPs*</small>
-              </div>
-            {% endif %}
-          {% else %}
-            {% if clv.downloadable %}
-              <a
-                href="{{ clv.get_download_url }}"
-                role="button"
-                class="btn btn-outline-primary btn-block"
-              >
-                Download CSV
-              </a>
-            {% elif user_can_edit %}
-              <div class="btn btn-outline-primary btn-block disabled"
-                   data-toggle="tooltip"
-                   data-placement="right"
-                   title="This codelist cannot be downloaded, most likely because it's header does not contain a 'code' column. You can upload a new version if you want to fix this."
-              >
-                Download CSV
-              </div>
-            {% endif %}
-          {% endif %}
-          {% if clv.coding_system_id == "dmd" %}
-            <a
-              href="{{ clv.get_download_url }}?omit-mapped-vmps"
-              role="button"
-              class="btn btn-outline-primary btn-block"
-            >
-              Download CSV <small class="d-block">original</small>
+
+      {% if clv.coding_system_id == "dmd" %}
+        <div class="btn-group-vertical">
+          {% if clv.downloadable %}
+            <a class="btn btn-outline-primary" href="{{ clv.get_download_url }}">
+              Download CSV <small class="d-block">with mapped VMPs*</small>
             </a>
+          {% else %}
+            <button class="btn btn-outline-primary btn-block" disabled type="button">
+              Download CSV <small class="d-block">with mapped VMPs*</small>
+            </button>
           {% endif %}
+
+          <a class="btn btn-outline-primary" href="{{ clv.get_download_url }}?omit-mapped-vmps">
+            Download CSV <small class="d-block">original</small>
+          </a>
+
           {% if clv.codeset %}
-            <a
-              href="{{ clv.get_download_definition_url }}"
-              role="button"
-              class="btn btn-outline-primary btn-block"
-            >
+            <a class="btn btn-outline-primary" href="{{ clv.get_download_definition_url }}">
               Download definition
             </a>
           {% endif %}
-          {% if clv.is_published or user_can_edit %}
-            <a
-              href="{{ clv.codelist.get_clone_url }}"
-              role="button"
-              class="btn btn-outline-primary btn-block"
-            >
+
+          {% if clv.user %}
+            <a class="btn btn-outline-primary" href="{{ clv.codelist.get_clone_url }}">
               Clone this codelist
             </a>
           {% endif %}
-          {% if clv.coding_system_id == "bnf" %}
+        </div>
+      {% endif %}
+
+      {% if clv.coding_system_id != "dmd" %}
+        {% if user_can_edit or clv.codeset or clv.downloadable %}
+          <div class="btn-group-vertical">
+            {% if clv.downloadable %}
+              <a
+                class="btn btn-outline-primary"
+                href="{{ clv.get_download_url }}"
+                role="button"
+              >
+                Download CSV
+              </a>
+            {% endif %}
+
+            {% if not clv.downloadable and user_can_edit %}
+              <span
+                class="w-100"
+                data-placement="right"
+                data-toggle="tooltip"
+                tabindex="0"
+                title="This codelist cannot be downloaded, most likely because it's header does not contain a 'code' column. You can upload a new version if you want to fix this."
+              >
+                <button class="btn btn-outline-primary" disabled>
+                  Download CSV
+                </button>
+              </span>
+            {% endif %}
+
+            {% if clv.codeset %}
+              <a class="btn btn-outline-primary" href="{{ clv.get_download_definition_url }}">
+                Download definition
+              </a>
+            {% endif %}
+
+            {% if clv.user %}
+              <a class="btn btn-outline-primary" href="{{ clv.codelist.get_clone_url }}">
+                Clone this codelist
+              </a>
+            {% endif %}
+          </div>
+        {% endif %}
+      {% endif %}
+
+      {% if clv.coding_system_id == "bnf" %}
+        <form action="{{ clv.get_dmd_convert_url }}" method="POST">
+          {% csrf_token %}
+          <div class="btn-group-vertical d-block">
             <a
               href="{{ clv.get_dmd_download_url }}"
               role="button"
-              class="btn btn-outline-primary btn-block"
+              class="btn btn-outline-primary"
             >
               Download dm+d
             </a>
             {% if user_can_edit %}
               <button
-                type="submit"
-                role="button"
-                class="btn btn-outline-primary btn-block"
+                class="btn btn-outline-primary"
                 data-toggle="tooltip"
-                title="Convert this version to a new dm+d codelist">
+                title="Convert this version to a new dm+d codelist"
+                type="submit">
                 Convert to dm+d
               </button>
             {% endif %}
-          {% endif %}
-        </div>
-      </form>
-
+          </div>
+        </form>
+      {% endif %}
 
       {% if user_can_edit %}
-        <div class="btn-group-vertical btn-block" role="group">
-          <a
-            class="btn btn-outline-primary btn-block"
-            href="{{ codelist.get_update_url }}">
-            Edit metadata
-          </a>
-        </div>
+        <a class="btn btn-outline-primary" href="{{ codelist.get_update_url }}">
+          Edit metadata
+        </a>
       {% endif %}
 
       {% if versions %}

--- a/templates/codelists/version.html
+++ b/templates/codelists/version.html
@@ -191,61 +191,23 @@
   <div class="row">
     <div class="col-md-3 version__sidebar">
 
-      {% if clv.coding_system_id == "dmd" %}
-        <div class="btn-group-vertical">
-          {% if clv.downloadable %}
-            <a class="btn btn-outline-primary" href="{{ clv.get_download_url }}">
-              Download CSV <small class="d-block">with mapped VMPs*</small>
-            </a>
-          {% else %}
-            <button class="btn btn-outline-primary btn-block" disabled type="button">
-              Download CSV <small class="d-block">with mapped VMPs*</small>
-            </button>
-          {% endif %}
-
-          <a class="btn btn-outline-primary" href="{{ clv.get_download_url }}?omit-mapped-vmps">
-            Download CSV <small class="d-block">original</small>
-          </a>
-
-          {% if clv.codeset %}
-            <a class="btn btn-outline-primary" href="{{ clv.get_download_definition_url }}">
-              Download definition
-            </a>
-          {% endif %}
-
-          {% if clv.is_published or user_can_edit %}
-            <a class="btn btn-outline-primary" href="{{ clv.codelist.get_clone_url }}">
-              Clone this codelist
-            </a>
-          {% endif %}
-        </div>
-      {% endif %}
-
-      {% if clv.coding_system_id != "dmd" %}
-        {% if user_can_edit or clv.codeset or clv.downloadable %}
+      <section aria-labelledby="actions-heading" class="versions__sidebar-buttons">
+        <h2 class="sr-only" id="actions-heading">Actions</h2>
+        {% if clv.coding_system_id == "dmd" %}
           <div class="btn-group-vertical">
             {% if clv.downloadable %}
-              <a
-                class="btn btn-outline-primary"
-                href="{{ clv.get_download_url }}"
-              >
-                Download CSV
+              <a class="btn btn-outline-primary" href="{{ clv.get_download_url }}">
+                Download CSV <small class="d-block">with mapped VMPs*</small>
               </a>
+            {% else %}
+              <button class="btn btn-outline-primary btn-block" disabled type="button">
+                Download CSV <small class="d-block">with mapped VMPs*</small>
+              </button>
             {% endif %}
 
-            {% if not clv.downloadable and user_can_edit %}
-              <span
-                class="w-100"
-                data-placement="right"
-                data-toggle="tooltip"
-                tabindex="0"
-                title="This codelist cannot be downloaded, most likely because it's header does not contain a 'code' column. You can upload a new version if you want to fix this."
-              >
-                <button class="btn btn-outline-primary" disabled>
-                  Download CSV
-                </button>
-              </span>
-            {% endif %}
+            <a class="btn btn-outline-primary" href="{{ clv.get_download_url }}?omit-mapped-vmps">
+              Download CSV <small class="d-block">original</small>
+            </a>
 
             {% if clv.codeset %}
               <a class="btn btn-outline-primary" href="{{ clv.get_download_definition_url }}">
@@ -260,35 +222,76 @@
             {% endif %}
           </div>
         {% endif %}
-      {% endif %}
 
-      {% if clv.coding_system_id == "bnf" %}
-        <div class="btn-group-vertical">
-          <a
-            href="{{ clv.get_dmd_download_url }}"
-            class="btn btn-outline-primary btn-block"
-          >
-            Download dm+d
-          </a>
-          {% if user_can_edit %}
-            <form action="{{ clv.get_dmd_convert_url }}" class="btn-group" method="POST">
-              <button
-                class="btn btn-outline-primary rounded-bottom"
-                title="Convert this version to a new dm+d codelist"
-                type="submit">
-                Convert to dm+d
-              </button>
-              {% csrf_token %}
-            </form>
+        {% if clv.coding_system_id != "dmd" %}
+          {% if user_can_edit or clv.codeset or clv.downloadable %}
+            <div class="btn-group-vertical">
+              {% if clv.downloadable %}
+                <a
+                  class="btn btn-outline-primary"
+                  href="{{ clv.get_download_url }}"
+                >
+                  Download CSV
+                </a>
+              {% endif %}
+
+              {% if not clv.downloadable and user_can_edit %}
+                <span
+                  class="w-100"
+                  data-placement="right"
+                  data-toggle="tooltip"
+                  tabindex="0"
+                  title="This codelist cannot be downloaded, most likely because it's header does not contain a 'code' column. You can upload a new version if you want to fix this."
+                >
+                  <button class="btn btn-outline-primary" disabled>
+                    Download CSV
+                  </button>
+                </span>
+              {% endif %}
+
+              {% if clv.codeset %}
+                <a class="btn btn-outline-primary" href="{{ clv.get_download_definition_url }}">
+                  Download definition
+                </a>
+              {% endif %}
+
+              {% if clv.is_published or user_can_edit %}
+                <a class="btn btn-outline-primary" href="{{ clv.codelist.get_clone_url }}">
+                  Clone this codelist
+                </a>
+              {% endif %}
+            </div>
           {% endif %}
-        </div>
-      {% endif %}
+        {% endif %}
 
-      {% if user_can_edit %}
-        <a class="btn btn-outline-primary" href="{{ codelist.get_update_url }}">
-          Edit metadata
-        </a>
-      {% endif %}
+        {% if clv.coding_system_id == "bnf" %}
+          <div class="btn-group-vertical">
+            <a
+              href="{{ clv.get_dmd_download_url }}"
+              class="btn btn-outline-primary btn-block"
+            >
+              Download dm+d
+            </a>
+            {% if user_can_edit %}
+              <form action="{{ clv.get_dmd_convert_url }}" class="btn-group" method="POST">
+                <button
+                  class="btn btn-outline-primary rounded-bottom"
+                  title="Convert this version to a new dm+d codelist"
+                  type="submit">
+                  Convert to dm+d
+                </button>
+                {% csrf_token %}
+              </form>
+            {% endif %}
+          </div>
+        {% endif %}
+
+        {% if user_can_edit %}
+          <a class="btn btn-outline-primary" href="{{ codelist.get_update_url }}">
+            Edit metadata
+          </a>
+        {% endif %}
+      </section>
 
       {% if versions %}
         <div class="card">

--- a/templates/codelists/version.html
+++ b/templates/codelists/version.html
@@ -264,27 +264,26 @@
       {% endif %}
 
       {% if clv.coding_system_id == "bnf" %}
-        <form action="{{ clv.get_dmd_convert_url }}" method="POST">
-          {% csrf_token %}
-          <div class="btn-group-vertical d-block">
-            <a
-              href="{{ clv.get_dmd_download_url }}"
-              role="button"
-              class="btn btn-outline-primary"
-            >
-              Download dm+d
-            </a>
-            {% if user_can_edit %}
+        <div class="btn-group-vertical">
+          <a
+            href="{{ clv.get_dmd_download_url }}"
+            role="button"
+            class="btn btn-outline-primary btn-block"
+          >
+            Download dm+d
+          </a>
+          {% if user_can_edit %}
+            <form action="{{ clv.get_dmd_convert_url }}" class="btn-group" method="POST">
               <button
-                class="btn btn-outline-primary"
-                data-toggle="tooltip"
+                class="btn btn-outline-primary rounded-bottom"
                 title="Convert this version to a new dm+d codelist"
                 type="submit">
                 Convert to dm+d
               </button>
-            {% endif %}
-          </div>
-        </form>
+              {% csrf_token %}
+            </form>
+          {% endif %}
+        </div>
       {% endif %}
 
       {% if user_can_edit %}

--- a/templates/codelists/version.html
+++ b/templates/codelists/version.html
@@ -225,7 +225,7 @@
 
         {% if clv.coding_system_id != "dmd" %}
           {% if user_can_edit or clv.codeset or clv.downloadable %}
-            <div class="btn-group-vertical">
+            <div class="btn-group-vertical" data-testid="not-dmd-buttons">
               {% if clv.downloadable %}
                 <a
                   class="btn btn-outline-primary"

--- a/templates/codelists/version.html
+++ b/templates/codelists/version.html
@@ -101,8 +101,8 @@
       {% endif %}
     </div>
 
-    <section>
-      <h2 class="sr-only">Codelist metadata</h2>
+    <section aria-labelledby="metadata-heading">
+      <h2 class="sr-only" id="metadata-heading">Metadata</h2>
       <dl class="list-group list-group-horizontal small">
         <div class="list-group-item py-1 px-2">
           <dt>
@@ -294,8 +294,8 @@
       </section>
 
       {% if versions %}
-        <div class="card">
-          <h2 class="card-header h6 font-weight-bold">Versions</h2>
+        <section class="card" aria-labelledby="versions-card-header">
+          <h2 class="card-header h6 font-weight-bold" id="versions-card-header">Versions</h2>
           <ol class="list-group list-group-flush sidebar-versions">
             {% for version in versions %}
               <li class="list-group-item{% if version == clv %} list-group-item-secondary{% endif %}">
@@ -332,7 +332,7 @@
               </li>
             {% endfor %}
           </ol>
-        </div>
+        </section>
       {% endif %}
     </div>
 


### PR DESCRIPTION
There are many options for which buttons should display in the sidebar of the versions template page. We should choose to be explicit, and make sure that anchor elements are outside of the form, and container elements are not shown if none of their children are visible.