### PR TITLE
Handle error when a draft is saved for review with unresolved codes

### DIFF
--- a/builder/actions.py
+++ b/builder/actions.py
@@ -10,6 +10,10 @@ from coding_systems.base.import_data_utils import check_and_update_compatibile_v
 from coding_systems.versioning.models import CodingSystemRelease
 
 
+class DraftNotReadyError(Exception):
+    pass
+
+
 logger = structlog.get_logger()
 
 
@@ -180,7 +184,8 @@ def save(*, draft):
     under review.
     """
 
-    assert not draft.code_objs.filter(status__in=["?", "!"]).exists()
+    if draft.code_objs.filter(status__in=["?", "!"]).exists():
+        raise DraftNotReadyError()
     draft.status = Status.UNDER_REVIEW
     draft.save()
 

--- a/builder/tests/test_actions.py
+++ b/builder/tests/test_actions.py
@@ -509,3 +509,29 @@ def test_create_search_codes_over_limit(version_from_scratch):
     assert "returned 20,001" in result["message"]
     assert "which exceeds the maximum limit of 20,000" in result["message"]
     assert "term-returning-loads" in result["message"]
+
+
+def test_cannot_save_with_unresolved_codes(draft_with_complete_searches):
+    draft = draft_with_complete_searches
+    code_obj = draft.code_objs.first()
+    code_obj.status = "?"
+    code_obj.save()
+
+    with pytest.raises(actions.DraftNotReadyError):
+        actions.save(draft=draft)
+
+    draft.refresh_from_db()
+    assert draft.is_draft
+
+
+def test_cannot_save_with_in_conflict_codes(draft_with_complete_searches):
+    draft = draft_with_complete_searches
+    code_obj = draft.code_objs.first()
+    code_obj.status = "!"
+    code_obj.save()
+
+    with pytest.raises(actions.DraftNotReadyError):
+        actions.save(draft=draft)
+
+    draft.refresh_from_db()
+    assert draft.is_draft

--- a/builder/views.py
+++ b/builder/views.py
@@ -44,7 +44,15 @@ def no_search_term(request, draft):
 def _handle_post(request, draft):
     action = request.POST["action"]
     if action == "save-for-review":
-        actions.save(draft=draft)
+        try:
+            actions.save(draft=draft)
+        except actions.DraftNotReadyError:
+            messages.add_message(
+                request,
+                messages.ERROR,
+                "You cannot save this draft for review because it contains unresolved or in conflict codes.",
+            )
+            return redirect(draft.codelist)
         messages.add_message(
             request, messages.INFO, "A new version has been saved for review"
         )


### PR DESCRIPTION
This is when a user attempts to save a draft for review, but there are still unresolved or in-conflict codes. This shouldn't happen, but can do when the UI and backend get out of sync e.g. when ajax POST requests to update the state fail. As per #2732 preventing the UI getting out of sync is not completely straightforward, so instead we just handle the situation better by returning an error message to the user.

Fixes #2732 