### PR TITLE
Unpin `pip`

### DIFF
--- a/justfile
+++ b/justfile
@@ -38,7 +38,7 @@ virtualenv:
     fi
 
     # create venv and upgrade pip
-    test -d $VIRTUAL_ENV || { $PYTHON_VERSION -m venv $VIRTUAL_ENV && $PIP install pip==25.0.1; }
+    test -d $VIRTUAL_ENV || { $PYTHON_VERSION -m venv $VIRTUAL_ENV && $PIP install --upgrade pip; }
 
     # ensure we have pip-tools so we can run pip-compile
     test -e $BIN/pip-compile || $PIP install pip-tools

--- a/requirements.dev.in
+++ b/requirements.dev.in
@@ -20,9 +20,6 @@ litecli
 pip-tools
 pre-commit
 ruff
-# Pin pip due to incompatibility of later releases with pip-tools
-# https://github.com/jazzband/pip-tools/issues/2176
-pip==25.0.1
 
 # For scripts/fetch_vmp_prev.py
 paramiko

--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -870,9 +870,9 @@ wheel==0.45.1 \
     # via pip-tools
 
 # The following packages are considered to be unsafe in a requirements file:
-pip==25.0.1 \
-    --hash=sha256:88f96547ea48b940a3a385494e181e29fb8637898f88d88737c5049780f196ea \
-    --hash=sha256:c46efd13b6aa8279f33f2864459c8ce587ea6a1a59ee20de055868d8f7688f7f
+pip==25.2 \
+    --hash=sha256:578283f006390f85bb6282dffb876454593d637f5d1be494b5202ce4877e71f2 \
+    --hash=sha256:6d67a2b4e7f14d8b31b8b52648866fa717f45a1eb70e83002f4331d07e953717
     # via
     #   litecli
     #   pip-tools

--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -874,7 +874,6 @@ pip==25.0.1 \
     --hash=sha256:88f96547ea48b940a3a385494e181e29fb8637898f88d88737c5049780f196ea \
     --hash=sha256:c46efd13b6aa8279f33f2864459c8ce587ea6a1a59ee20de055868d8f7688f7f
     # via
-    #   -r requirements.dev.in
     #   litecli
     #   pip-tools
 setuptools==80.9.0 \


### PR DESCRIPTION
This was required due to an incompatibility of `pip-tools` with newer `pip` versions.

[That issue](https://github.com/jazzband/pip-tools/issues/2176) is now fixed, and we can upgrade again.