### PR TITLE
Use `request.user` in base templates

### DIFF
--- a/templates/_includes/header.html
+++ b/templates/_includes/header.html
@@ -13,7 +13,7 @@
           {% url 'user' request.user.username as codelist_url %}
           {% nav_link title="My codelists" href=codelist_url %}
 
-          {% if user.memberships.exists %}
+          {% if request.user.memberships.exists %}
             {% url 'organisations' as organisations_url %}
             {% nav_link title="My organisations" href=organisations_url %}
           {% endif %}

--- a/templates/base-tw.html
+++ b/templates/base-tw.html
@@ -13,8 +13,8 @@
     <script
       defer
       data-domain="opencodelists.org"
-      event-is_logged_in="{% if user.is_authenticated %}true{% else %}false{% endif %}"
-      event-is_admin="{% if user.is_admin %}true{% else %}false{% endif %}"
+      event-is_logged_in="{% if request.user.is_authenticated %}true{% else %}false{% endif %}"
+      event-is_admin="{% if request.user.is_admin %}true{% else %}false{% endif %}"
       src="https://plausible.io/js/script.pageview-props.tagged-events.js"
     ></script>
     <script nonce="{{ request.csp_nonce }}">

--- a/templates/base.html
+++ b/templates/base.html
@@ -14,8 +14,8 @@
     <script
       defer
       data-domain="opencodelists.org"
-      event-is_logged_in="{% if user.is_authenticated %}true{% else %}false{% endif %}"
-      event-is_admin="{% if user.is_admin %}true{% else %}false{% endif %}"
+      event-is_logged_in="{% if request.user.is_authenticated %}true{% else %}false{% endif %}"
+      event-is_admin="{% if request.user.is_admin %}true{% else %}false{% endif %}"
       src="https://plausible.io/js/script.pageview-props.tagged-events.js"
     ></script>
     <script nonce="{{ request.csp_nonce }}">
@@ -69,7 +69,7 @@
               <li class="navbar-nav nav-item">
                 <a class="nav-link text-white" href="{% url 'user' request.user.username %}">My codelists</a>
               </li>
-              {% if user.memberships.exists %}
+              {% if request.user.memberships.exists %}
                 <li class="navbar-nav nav-item">
                   <a class="nav-link text-white" href="{% url 'organisations' %}">My organisations</a>
                 </li>


### PR DESCRIPTION
As `user` can be polluted when browsing users pages. This means the header can incorrectly display that a user has access to a "My Organisations" page, and sends the "is_admin" event incorrectly to Plausible.