### PR TITLE
Add gbd config, remove nonalphanumerics from codes

### DIFF
--- a/codelists/scripts/bulk_import_codelists.py
+++ b/codelists/scripts/bulk_import_codelists.py
@@ -308,6 +308,13 @@ def process_file_to_dataframe(filepath, config):
     for column in relevant_df_columns:
         codelist_df[column] = codelist_df[column].str.strip()
 
+    # Remove non-alphanumeric from code column
+    if config.get("strip_nonalphanumeric_from_codes", False):
+        codelist_df["code"] = codelist_df["code"].str.replace(
+            "[^a-zA-Z0-9]", "", regex=True
+        )
+        codelist_df = codelist_df.dropna(subset=["code"])
+
     return codelist_df
 
 

--- a/codelists/scripts/gbd_icd_bundles.json
+++ b/codelists/scripts/gbd_icd_bundles.json
@@ -1,0 +1,19 @@
+{
+    "comment": "For loading of the IHME Global Burden of Disease ICD 10 bundles",
+    "organisation": "ihme",
+    "coding_systems": {
+        "icd10": {
+            "id": "icd10",
+            "release": "icd10_2019-covid-expanded_20190101"
+        }
+    },
+    "column_aliases": {
+        "codelist_name": "bundle_name",
+        "code": "cause_code",
+        "term": "cause_name",
+        "codelist_description": "bundle_id"
+    },
+    "description_template": "IHME GBD Bundle ID: %s",
+    "strip_nonalphanumeric_from_codes": true,
+    "sheet": "icd_10_mapping"
+}


### PR DESCRIPTION
Support for #2795 

Add json config for bulk upload of GBD ICD 10 codelists from IHME.

These are supplied in dot-separated notation, which the ICD10 coding system on OpenCodelists does not expect so remove dots and remove blank rows which also cause issues.