### PR TITLE
Unify publishing behaviour for new/updated codelists via API

### DIFF
--- a/codelists/actions.py
+++ b/codelists/actions.py
@@ -124,7 +124,7 @@ def create_or_update_codelist(
             methodology=methodology,
             references=references,
             signoffs=signoffs,
-            status=Status.PUBLISHED,
+            status=Status.PUBLISHED if should_publish else Status.UNDER_REVIEW,
             ignore_unfound_codes=ignore_unfound_codes,
         )
 


### PR DESCRIPTION
4d08d68 added a url param for forcing publishing of codelists updated via the API (defaulting to UNDER_REVIEW), but didn't add this logic to the codelist creation path.

This commit makes both these paths behave the same.