### PR TITLE
Fix API to return codelists with more than 1 handle

### DIFF
--- a/codelists/api.py
+++ b/codelists/api.py
@@ -17,7 +17,6 @@ requiring a new version.
 import json
 import re
 
-from django.db.models import Count
 from django.http import JsonResponse
 from django.views.decorators.csrf import csrf_exempt
 from django.views.decorators.http import require_http_methods
@@ -144,8 +143,8 @@ def codelists_get(request, owner=None):
 
     for cl in sorted(
         codelists.filter(**filter_kwargs)
-        .annotate(handle_count=Count("handles"))
-        .filter(handle_count=1)
+        .filter(handles__is_current=True)
+        .distinct()
         .prefetch_related("handles", "versions"),
         key=lambda cl: cl.slug,
     ):


### PR DESCRIPTION
Fixes #2829 

A previous fix to avoid errors from codelists with no handles added a filter to the api to ensure only codelists with a single handle were returned. In fact a codelist can have multiple handles. This corrects the filter to limit to codelists with a `current` handle which better reflects the underlying models.