### PR TITLE
Add privacy notice link and re-style footer

### DIFF
--- a/templates/_includes/footer.html
+++ b/templates/_includes/footer.html
@@ -1,6 +1,6 @@
 <footer class="bg-slate-900 mt-auto">
   <div class="container py-20">
-    <nav class="flex flex-wrap justify-center gap-x-12 gap-y-3 text-base/snug" aria-label="Footer">
+    <nav class="flex flex-col gap-y-4 md:flex-row md:flex-wrap md:gap-x-8 text-base/snug" aria-label="Footer">
       <a href="{% url 'contact' %}" class="text-slate-200 underline decoration-slate-600 underline-offset-4 font-semibold transition-colors hover:text-white hover:decoration-white">
         Contact
       </a>
@@ -20,7 +20,7 @@
         University of Oxford
       </a>
     </nav>
-    <div class="mt-10 text-sm/6 text-center text-slate-300 space-y-6 mx-auto max-w-[80ch]">
+    <div class="mt-10 text-sm/6 text-slate-300 space-y-6 max-w-[80ch]">
       <p>© University of Oxford for the Bennett Institute for Applied Data Science {% now "Y" %}. This work may be copied freely for non-commercial research and study. If you wish to do any of the other acts restricted by the copyright you should apply in writing to <a class="text-slate-200 underline decoration-slate-600 underline-offset-4 font-semibold transition-colors hover:text-white hover:decoration-white" href="mailto:team@opensafely.org">team@opensafely.org</a>.</p>
       <p>SNOMED Clinical Terms® content © International Health Terminology Standards Development Organisation.</p>
       <p>ICD-10 codes, terms and text © World Health Organization, Third Edition. 2007.</p>

--- a/templates/base.html
+++ b/templates/base.html
@@ -130,19 +130,20 @@
 
       <footer id="footer" class="border-top bg-light mt-auto py-5">
         <div class="container">
-          <ul class="list-inline text-center d-flex flex-column flex-md-row justify-content-center mb-0 mb-md-3">
-            <li class="list-inline-item mb-3 mb-md-0 mr-0 mr-md-5">
+          <ul class="list-inline">
+            <li class="list-inline-item">
               <a href="{% url 'contact' %}">
                 Contact
               </a>
             </li>
-            <li class="list-inline-item mb-3 mb-md-0 mr-0 mr-md-5">
+
+            <li class="list-inline-item ml-4">
               <a href="{% url 'docs:index' %}">
                 Documentation
               </a>
             </li>
 
-            <li class="list-inline-item mb-3 mb-md-0 mr-0">
+            <li class="list-inline-item ml-4">
               <a href="https://www.opensafely.org/">
                 OpenSAFELY
               </a>
@@ -155,26 +156,24 @@
             </li>
           </ul>
 
-          <ul class="list-inline text-center d-flex flex-column flex-md-row justify-content-center">
-            <li class="list-inline-item mb-3 mb-md-0 mr-0 mr-md-5">
+          <ul class="list-inline mb-4">
+            <li class="list-inline-item">
               <a href="https://www.bennett.ox.ac.uk/">
                 Bennett Institute for Applied Data Science
               </a>
             </li>
 
-            <li class="list-inline-item mb-3 mb-md-0">
+            <li class="list-inline-item ml-4">
               <a href="https://www.ox.ac.uk/">
                 University of Oxford
               </a>
             </li>
           </ul>
 
-          <div class="row">
-            <div class="col-12 offset-md-1 col-md-10 offset-lg-2 col-lg-8 text-center mt-3 mb-0 small">
-              <p>© University of Oxford for the Bennett Institute for Applied Data Science {% now "Y" %}. This work may be copied freely for non-commercial research and study. If you wish to do any of the other acts restricted by the copyright you should apply in writing to <a href="mailto:team@opensafely.org">team@opensafely.org</a>.</p>
-              <p>SNOMED Clinical Terms® content © International Health Terminology Standards Development Organisation.</p>
-              <p>ICD-10 codes, terms and text © World Health Organization, Third Edition. 2007.</p>
-            </div>
+          <div class="small">
+            <p>© University of Oxford for the Bennett Institute for Applied Data Science {% now "Y" %}. This work may be copied freely for non-commercial research and study. If you wish to do any of the other acts restricted by the copyright you should apply in writing to <a href="mailto:team@opensafely.org">team@opensafely.org</a>.</p>
+            <p>SNOMED Clinical Terms® content © International Health Terminology Standards Development Organisation.</p>
+            <p>ICD-10 codes, terms and text © World Health Organization, Third Edition. 2007.</p>
           </div>
         </div>
       </footer>


### PR DESCRIPTION
- Add a privacy notice link to both the base template and the "new" footer template.
- Simplify the styling of both footers by making left aligned menus

## Screenshots

### Before

<img width="1248" alt="" src="https://github.com/user-attachments/assets/51e6a78a-1fa0-46b3-9ec2-ee5f4d72be15" />
<img width="1191" alt="" src="https://github.com/user-attachments/assets/cd70e9b4-e6ba-4914-ad92-c53498a07e10" />

### After

<img width="1241" alt="" src="https://github.com/user-attachments/assets/c1e9395e-7485-491e-a39c-df3f56b5f796" />
<img width="1190" alt="" src="https://github.com/user-attachments/assets/b012ae04-7d33-414f-9b46-fc40377cf9cf" />
