### PR TITLE
Add a 7 day cool down for npm dependabot PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,8 @@ updates:
       day: "monday"
       time: "08:00"
       timezone: "Europe/London"
+    cooldown:
+      default-days: 7
     groups:
       production-dependencies:
         dependency-type: "production"


### PR DESCRIPTION
[Documentation link](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/optimizing-pr-creation-version-updates#setting-up-a-cooldown-period-for-dependency-updates)