### PR TITLE
Add cooldown for Dependabot GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -24,4 +24,6 @@ updates:
       day: "monday"
       time: "08:00"
       timezone: "Europe/London"
+    cooldown:
+      default-days: 7
     open-pull-requests-limit: 20


### PR DESCRIPTION
To match our dependency updates policy.