### PR TITLE
Disable migrations for the django-debug-toolbar

### DIFF
--- a/opencodelists/settings.py
+++ b/opencodelists/settings.py
@@ -67,6 +67,9 @@ DEBUG = os.environ.get("DEBUG", default=False) == "True"
 
 DEBUG_TOOLBAR = os.environ.get("DJANGO_DEBUG_TOOLBAR", default=False) == "True"
 
+# Disable migrations for the django-debug-toolbar
+MIGRATION_MODULES = {"debug_toolbar": None}
+
 BASE_URLS = os.environ.get("BASE_URLS", default="").split(",")
 # note localhost is required on production for dokku checks
 BASE_URLS += ["http://localhost:7000"]


### PR DESCRIPTION
Linked to https://github.com/opensafely-core/job-server/issues/5352