### PR TITLE
Fix link html parsing for Sept 2025 release

### DIFF
--- a/mappings/bnfdmd/data_downloader.py
+++ b/mappings/bnfdmd/data_downloader.py
@@ -47,7 +47,10 @@ class Downloader:
                     valid_from := datepat.search(inner_text.replace("\xa0", " "))
                 ):
                     # sometimes "valid from" inner text is across adjacent elements
-                    inner_text += a_tag.next_sibling()[0].text
+                    if a_tag.next_sibling:
+                        inner_text += a_tag.next_sibling.text
+                    elif a_tag.previous_sibling:
+                        inner_text = a_tag.previous_sibling.text + inner_text
                 valid_from = datetime.strptime(valid_from.group(), datefmt)
                 matches.append((match.group("date"), url, filename, valid_from))
 

--- a/mappings/bnfdmd/tests/conftest.py
+++ b/mappings/bnfdmd/tests/conftest.py
@@ -39,7 +39,8 @@ def mocked_responses_homepage():
             "https://www.nhsbsa.nhs.uk/prescription-data/understanding-our-data/bnf-snomed-mapping",
             body=f"""
             <p><a href="/sites/default/files/{MOCK_FILEPATH}">January 2024 (ZIP file: 16.76MB)</a></p>
-            <p><a href="/sites/default/files/2023-01/BNF%20Snomed%20Mapping%20data%2020230116.zip">January 2023 (ZIP file: 16.76MB)</a></p>
+            <p><a href="/sites/default/files/2023-01/BNF%20Snomed%20Mapping%20data%2020230116.zip">January</a> 2023 (ZIP file: 16.76MB)</p>
+            <p>September<a href="/sites/default/files/2023-11/BNF%20Snomed%20Mapping%20data%2020231120.zip"> 2023 (ZIP file: 18.77MB)</a></p>
         """,
             status=200,
         )

--- a/mappings/bnfdmd/tests/test_data_downloader.py
+++ b/mappings/bnfdmd/tests/test_data_downloader.py
@@ -17,3 +17,10 @@ def test_get_latest_release_with_existing(mocked_responses_homepage, tmp_path):
     downloader = Downloader(tmp_path)
     with pytest.raises(ValueError, match="Latest release already exists"):
         downloader.download_latest_release()
+
+
+def test_historical_release_dates_parsed(mocked_responses_homepage, tmp_path):
+    downloader = Downloader(tmp_path)
+    releases = downloader.get_releases()
+
+    assert len(releases) == 3


### PR DESCRIPTION
When the September release was moved to the historical releases section with the release of the October release,
the HTML for its link was in a new and unexpected format:

```html
<p>September<a href="/sites/default/files/2025-11/BNF%20Snomed%20Mapping%20data%2020251120.zip"> 2025 (ZIP file: 18.77MB)</a></p>
```

vs

```html
<p><a href="/sites/default/files/2025-10/BNF%20Snomed%20Mapping%20data%2020251017.zip">August 2025 (ZIP file: 18.2MB)</a></p>
```

The previous code assumed that if the link text didn't fit the "month YYYY" pattern then only the month part of the "valid from" date was part of the link text and the year part was in the following element. This was the only form of malformed historical release link we'd seen, but this fails with this new case since the missing date part is in the preceding element (and there is no following element).

This commit accounts for both these types of malformed link, with an accompanying test.


Fixes #2942 