### PR TITLE
Fix deployment SHA retrieval for opencodelists to fix the deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -83,7 +83,6 @@ jobs:
 
       - name: Deploy
         run: |
-            set -x
             SHA=$(docker inspect --format='{{join .RepoDigests "\n"}}' "$PUBLIC_IMAGE_NAME:latest" | grep "$PUBLIC_IMAGE_NAME")
             echo "Deploying $SHA to dokku3"
             ssh -o "UserKnownHostsFile=/dev/null" -o "StrictHostKeyChecking=no" dokku@dokku3.ebmdatalab.net git:from-image opencodelists $SHA


### PR DESCRIPTION
On Thursday Feb 12, the deploy workflow for JobServer started failing. On Friday Feb 13, RAP team noticed that the workflow for bennettbot started failing too. They investigated the issue and found that the order of RepoDigests changed and was unreliable. Deploy was always getting the first one which wasn't correct.
Replacing that logic with getting all repo digests and then selecting the fully qualified name worked for bennettbot in commit bennettoxford/bennettbot@970e970.

This commit does the same for opencodelists in order to fix the failing deploy workflow.