### PR TITLE
Clarify wording about what codelists can be cloned

### DIFF
--- a/userdocs/cloning-a-codelist.md
+++ b/userdocs/cloning-a-codelist.md
@@ -1,7 +1,8 @@
 ## Cloning a codelist
 
-You can make a clone, or copy, of a codelist that is owned by an organisation, another user, or even yourself.
-To do this, click _Clone this codelist_ on the codelist homepage.
+You can make a clone, or copy, of any published codelist that is owned by an organisation, another user, or even yourself.
+You may also clone a codelist that is not yet published if you also have permission to edit it.
+To clone a codelist, click _Clone this codelist_ on the codelist homepage.
 
 This will create a clone of the most recent version of this codelist in your codelists,
 with the same name as the source codelist, and all of its metadata (including a link back to the source codelist).


### PR DESCRIPTION
It's currently not possible to clone Under Review codelists, which has caused some issues/confusion. So we should be clear about the current behaviour in the documentation.

Refs #2979