### PR TITLE
Fix rendering of cloned codelist name underscores

### DIFF
--- a/opencodelists/templatetags/methodology_cloned_codelist_name_filter.py
+++ b/opencodelists/templatetags/methodology_cloned_codelist_name_filter.py
@@ -1,0 +1,26 @@
+import re
+
+from django import template
+
+
+register = template.Library()
+
+# Reference: see `validate_slug` definition in Django source.
+CLONED_CODELIST_NAME_PATTERN = re.compile(
+    r"Cloned from codelist : \[(?P<name>[-a-zA-Z0-9_]+)\]"
+)
+
+
+@register.filter
+def methodology_cloned_codelist_name_filter(methodology_text):
+    """Template filter to escape methodology markdown formatting for cloned codelist names with underscore characters."""
+    match = re.search(CLONED_CODELIST_NAME_PATTERN, methodology_text)
+    if not match:
+        return methodology_text
+
+    escaped_name = match.group("name").replace("_", r"\_")
+    return (
+        methodology_text[: match.start("name")]
+        + escaped_name
+        + methodology_text[match.end("name") :]
+    )

--- a/opencodelists/tests/templatetags/test_markdown_filter.py
+++ b/opencodelists/tests/templatetags/test_markdown_filter.py
@@ -1,0 +1,46 @@
+import pytest
+
+from opencodelists.templatetags.methodology_cloned_codelist_name_filter import (
+    methodology_cloned_codelist_name_filter,
+)
+
+
+@pytest.mark.parametrize(
+    "input,expected",
+    [
+        (
+            "Cloned from codelist : [Codelist_to_be_cloned](/codelist/user/katieb5/codelist_to_be_cloned/2ed738d9/)\r\nSome additional methodology text",
+            "Cloned from codelist : [Codelist\\_to\\_be\\_cloned](/codelist/user/katieb5/codelist_to_be_cloned/2ed738d9/)\r\nSome additional methodology text",
+        ),
+        (
+            "Cloned from codelist : [Codelist_to_be_cloned](/codelist/user/katieb5/codelist_to_be_cloned/2ed738d9/)\r\nSome_additional_methodology_text_with_underscores",
+            "Cloned from codelist : [Codelist\\_to\\_be\\_cloned](/codelist/user/katieb5/codelist_to_be_cloned/2ed738d9/)\r\nSome_additional_methodology_text_with_underscores",
+        ),
+        (
+            "Cloned from codelist : [ClonedCodelistWithoutUnderscores](/codelist/user/katieb5/clonedcodelistwithoutunderscores/2ed738d9/)\r\nSome additional methodology text",
+            "Cloned from codelist : [ClonedCodelistWithoutUnderscores](/codelist/user/katieb5/clonedcodelistwithoutunderscores/2ed738d9/)\r\nSome additional methodology text",
+        ),
+        (
+            "Methodology text without cloned codelist",
+            "Methodology text without cloned codelist",
+        ),
+        (
+            "",
+            "",
+        ),
+        (
+            "Some other text. Cloned from codelist : [Codelist_to_be_cloned](/codelist/user/katieb5/codelist_to_be_cloned/2ed738d9/)\r\nSome additional methodology text",
+            "Some other text. Cloned from codelist : [Codelist\\_to\\_be\\_cloned](/codelist/user/katieb5/codelist_to_be_cloned/2ed738d9/)\r\nSome additional methodology text",
+        ),
+    ],
+    ids=[
+        "cloned_codelist_with_underscores",
+        "cloned_codelist_with_underscores_and_underscored_following_text",
+        "cloned_codelist_without_underscores",
+        "no_cloned_codelist_prefix",
+        "empty_string",
+        "cloned_codelist_not_at_start_of_text",
+    ],
+)
+def test_methodology_cloned_codelist_name_filter(input, expected):
+    assert methodology_cloned_codelist_name_filter(input) == expected

--- a/templates/codelists/_about_tab.html
+++ b/templates/codelists/_about_tab.html
@@ -1,3 +1,4 @@
+{% load methodology_cloned_codelist_name_filter %}
 {% load markdown_filter %}
 
 <style>
@@ -29,7 +30,7 @@
   {% if codelist.methodology %}
     <h3 class="h4">Methodology</h3>
     <div class="about__markdown">
-      {{ codelist.methodology|markdown_filter|safe }}
+      {{ codelist.methodology|methodology_cloned_codelist_name_filter|markdown_filter|safe }}
     </div>
   {% endif %}
 


### PR DESCRIPTION
Closes #2980

A user reported a small bug that caused cloned codelist names containing underscores (e.g. "Codelist_name_example") to render with unintended italics in the Methodology section of the About tab of the codelist version page (original issue contains user's screenshot of this). This occurred because the name was interpreted as
[markdown](https://www.markdownguide.org/basic-syntax/#italic), when we pass the `codelist.methodology` (that we set [here](https://github.com/opensafely-core/opencodelists/blob/bc3b482376e2580dff46d90b86b2657fc6bb18d5/codelists/actions.py#L811)) through `markdown_filter` in the `_about_tab.html` template (as far as I understand it).

This PR introduces a [custom template filter](https://docs.djangoproject.com/en/6.0/howto/custom-template-tags/#writing-custom-template-filters) to escape underscores in cloned codelist names within `codelist.methodology` prior to markdown rendering, ensuring names are displayed correctly with underscores preserved.

The fix is applied at render time to keep the fix scoped to presentation logic rather than, for example, changing what we store in `codelist.methodology` when we clone a codelist. 

**Screenshot with template filter applied:**
<img width="1205" height="393" alt="cloned_codelist_name_after" src="https://github.com/user-attachments/assets/49bfcdb9-9ef5-4c32-9d32-46dc971c6810" />


**Notes for the reviewer:**

- I struggled with sensible/reasonable names for my functions and variables in this PR so if you have any alternative suggestions I'd be grateful for them
