### PR TITLE
Fix methodology template visibility

### DIFF
--- a/codelists/forms.py
+++ b/codelists/forms.py
@@ -240,7 +240,7 @@ class CodelistUpdateForm(forms.Form):
 
             # If the methodology is not set, use the template
             methodology_initial = self.initial.get("methodology", "")
-            if methodology_initial == "":
+            if not methodology_initial:
                 self.initial["methodology"] = methodology_template
 
             # Change the help text if the methodology is not the template i.e. edited by the user

--- a/codelists/tests/test_forms.py
+++ b/codelists/tests/test_forms.py
@@ -215,6 +215,10 @@ def test_codelist_update_form_methodology_initial_values():
     form2 = CodelistUpdateForm(owner_choices=[], initial={"methodology": ""})
     assert form2.initial["methodology"] == methodology_template
 
+    # (2b) A form with methodology initial set to None ends up with initial set to the template
+    form2b = CodelistUpdateForm(owner_choices=[], initial={"methodology": None})
+    assert form2b.initial["methodology"] == methodology_template
+
     # (3) A form with a non-blank methodology has that as the initial value
     custom_methodology = "This is a custom methodology that the user has written."
     form3 = CodelistUpdateForm(

--- a/codelists/tests/views/test_codelist_update.py
+++ b/codelists/tests/views/test_codelist_update.py
@@ -1,5 +1,6 @@
 import datetime
 
+from codelists.forms import methodology_template
 from codelists.models import Codelist
 from codelists.views.codelist_update import get_owner_choices
 
@@ -39,7 +40,7 @@ def test_get_success(client, codelist, organisation):
     assert form.initial["slug"] == codelist.slug
     assert form.initial["owner"] == f"organisation:{organisation.pk}"
     assert form.initial["description"] == codelist.description
-    assert form.initial["methodology"] == codelist.methodology
+    assert form.initial["methodology"] == (codelist.methodology or methodology_template)
 
 
 def test_post_success(client, codelist, organisation_admin):


### PR DESCRIPTION
Currently, if the methodology of a codelist is `""`, then we populate it with the suggested markdown template. However since implementing that feature, the methodology seems to now return as `None` if it doesn't exist. This PR fixes it so that the template is returned if it is not already set, regardless of whether it is `""` or `None`