### PR TITLE
Copy backups to block storage

### DIFF
--- a/DEPLOY.md
+++ b/DEPLOY.md
@@ -40,6 +40,7 @@ dokku$ dokku config:set opencodelists OTEL_SERVICE_NAME='opencodelists'
 dokku$ dokku config:set opencodelists DJANGO_SETTINGS_MODULE="opencodelists.settings"
 dokku$ dokku config:set opencodelists EMAIL_BACKEND='anymail.backends.mailgun.EmailBackend'
 dokku$ dokku config:set opencodelists MAILGUN_API_KEY='xxx'
+dokku$ dokku config:set opencodelists BLOCK_STORAGE_DIR='/block_storage'
 ```
 
 ### Configure nginx

--- a/deploy/bin/backup.sh
+++ b/deploy/bin/backup.sh
@@ -36,7 +36,9 @@ on_error() { # shellcheck disable=SC2329
     RESULT=${exit_code:-1}
 
     # Clean up a stale tmp on failure
-    [ -n "${SANITISED_BACKUP_TMP:-}" ] && rm -f "$SANITISED_BACKUP_TMP" 2>/dev/null || true
+    if [ -n "${SANITISED_BACKUP_TMP:-}" ]; then
+      rm -f "$SANITISED_BACKUP_TMP" 2>/dev/null || true
+    fi
 
     # Avoid exiting inside the handler on failures of Sentry call
     set +e

--- a/deploy/bin/backup.sh
+++ b/deploy/bin/backup.sh
@@ -25,8 +25,9 @@ if [ "$SKIP_SENTRY" != "true" ]; then
     SENTRY_CRON_URL=$(sentry_cron_url "$SENTRY_DSN" "$SENTRY_MONITOR_NAME")
 fi
 
-# DATABASE_DIR is configured via dokku (see DEPLOY.md)
+# DATABASE_DIR and BLOCK_STORAGE_DIR are configured via dokku (see DEPLOY.md)
 BACKUP_DIR="$DATABASE_DIR/backup/db"
+BLOCK_BACKUP_DIR="$BLOCK_STORAGE_DIR/backup/db"
 BACKUP_FILENAME="$(date +%F)-db.sqlite3"
 BACKUP_FILEPATH="$BACKUP_DIR/$BACKUP_FILENAME"
 
@@ -141,6 +142,16 @@ verify_file_min_size "${SANITISED_BACKUP_FILEPATH}.zst"
 # Only now remove the uncompressed originals
 rm "$BACKUP_FILEPATH" "$SANITISED_BACKUP_FILEPATH"
 
+# Copy the compressed backups to block storage to reduce local disk usage and
+# separate them from the production system.
+# This is WIP in https://github.com/opensafely-core/opencodelists/issues/2910
+# For now, just copy the files so they exist in both places. Once we are sure
+# this is working, this could be a move rather than a copy, and we could adjust
+# the symlinks and retention below to refer to the new location.
+mkdir -p "$BLOCK_BACKUP_DIR"
+cp --preserve=mode,timestamps "$BACKUP_FILEPATH.zst" "$BLOCK_BACKUP_DIR"
+cp --preserve=mode,timestamps "$SANITISED_BACKUP_FILEPATH.zst" "$BLOCK_BACKUP_DIR"
+
 # Symlink to the new latest backups to make it easy to discover.
 # Make the target a relative path -- an absolute one won't mean the same thing
 # in the host file system if executed inside a container as we expect.
@@ -161,11 +172,33 @@ else
     exit 5
 fi
 
+# Create symlinks in block storge location.
+# This is WIP in https://github.com/opensafely-core/opencodelists/issues/2910
+# For now, do both. Later we could remove the above ln commands.
+
+# Ensure target backup file exists before trying to link
+if [ -f "$BLOCK_BACKUP_DIR/$BACKUP_FILENAME.zst" ]; then
+    ln -sf "$BACKUP_FILENAME.zst" "$BLOCK_BACKUP_DIR/latest-db.sqlite3.zst"
+else
+    echo "expected compressed raw backup missing: $BLOCK_BACKUP_DIR/$BACKUP_FILENAME.zst" >&2
+    exit 4
+fi
+
+# Ensure target sanitised backup file exists before trying to link
+if [ -f "$BLOCK_BACKUP_DIR/${SANITISED_BACKUP_FILENAME}.zst" ]; then
+    ln -sf "$SANITISED_BACKUP_FILENAME.zst" "$BLOCK_BACKUP_DIR/sanitised-latest-db.sqlite3.zst"
+else
+    echo "expected compressed sanitised backup missing: $BLOCK_BACKUP_DIR/${SANITISED_BACKUP_FILENAME}.zst" >&2
+    exit 5
+fi
+
 # Keep only the last 14 days of raw backups
 find "$BACKUP_DIR" -name "*-db.sqlite3.zst" -type f -mtime +14 -delete
+find "$BLOCK_BACKUP_DIR" -name "*-db.sqlite3.zst" -type f -mtime +14 -delete
 
 # Keep only the most recent sanitised backup.
 find "$BACKUP_DIR" -name "*sanitised*-db.sqlite3.zst" ! -wholename "$SANITISED_BACKUP_FILEPATH.zst" -type f -delete
+find "$BLOCK_BACKUP_DIR" -name "*sanitised*-db.sqlite3.zst" ! -name "$SANITISED_BACKUP_FILENAME.zst" -type f -delete
 
 if [ "$SKIP_SENTRY" != "true" ]; then
 # If we've reached this point, send ok to Sentry cron monitoring

--- a/deploy/bin/backup.sh
+++ b/deploy/bin/backup.sh
@@ -9,15 +9,21 @@
 #              command substitutions
 set -euxo pipefail -o errtrace
 
-# Import Sentry functions
-# Must be in same directory as this script
 SCRIPT_DIR=$(dirname "$0")
-source "$SCRIPT_DIR/sentry_cron_functions.sh"
 
-# Set up Sentry cron monitoring
-SENTRY_MONITOR_NAME=$(basename "$0")
-CRONTAB=$(extract_crontab "$SENTRY_MONITOR_NAME" "/app/app.json")
-SENTRY_CRON_URL=$(sentry_cron_url "$SENTRY_DSN" "$SENTRY_MONITOR_NAME")
+# Set this environment variable to 'true' to test locally without Sentry.
+SKIP_SENTRY="${SKIP_SENTRY:-false}"
+
+if [ "$SKIP_SENTRY" != "true" ]; then
+    # Import Sentry functions
+    # Must be in same directory as this script
+    source "$SCRIPT_DIR/sentry_cron_functions.sh"
+
+    # Set up Sentry cron monitoring
+    SENTRY_MONITOR_NAME=$(basename "$0")
+    CRONTAB=$(extract_crontab "$SENTRY_MONITOR_NAME" "/app/app.json")
+    SENTRY_CRON_URL=$(sentry_cron_url "$SENTRY_DSN" "$SENTRY_MONITOR_NAME")
+fi
 
 # DATABASE_DIR is configured via dokku (see DEPLOY.md)
 BACKUP_DIR="$DATABASE_DIR/backup/db"
@@ -40,13 +46,15 @@ on_error() { # shellcheck disable=SC2329
       rm -f "$SANITISED_BACKUP_TMP" 2>/dev/null || true
     fi
 
-    # Avoid exiting inside the handler on failures of Sentry call
-    set +e
-    echo "Backup failed with exit code $RESULT" >&2
+    if [ "$SKIP_SENTRY" != "true" ]; then
+        # Avoid exiting inside the handler on failures of Sentry call
+        set +e
+        echo "Backup failed with exit code $RESULT" >&2
 
-    # Best-effort Sentry error reporting - do not cause further exit if it fails
-    sentry_cron_error "$SENTRY_CRON_URL" || true
-    exit "$RESULT"
+        # Best-effort Sentry error reporting - do not cause further exit if it fails
+        sentry_cron_error "$SENTRY_CRON_URL" || true
+        exit "$RESULT"
+    fi
 }
 trap on_error ERR
 
@@ -85,8 +93,10 @@ verify_file_min_size() {
     return 0
 }
 
-# Log start of backup in a way that won't fail the whole script if Sentry down
-sentry_cron_start "$SENTRY_CRON_URL" "$CRONTAB" || true
+if [ "$SKIP_SENTRY" != "true" ]; then
+    # Log start of backup in a way that won't fail the whole script if Sentry down
+    sentry_cron_start "$SENTRY_CRON_URL" "$CRONTAB" || true
+fi
 
 # Make the backup directory if it doesn't exist
 mkdir -p "$BACKUP_DIR"
@@ -157,5 +167,7 @@ find "$BACKUP_DIR" -name "*-db.sqlite3.zst" -type f -mtime +14 -delete
 # Keep only the most recent sanitised backup.
 find "$BACKUP_DIR" -name "*sanitised*-db.sqlite3.zst" ! -wholename "$SANITISED_BACKUP_FILEPATH.zst" -type f -delete
 
+if [ "$SKIP_SENTRY" != "true" ]; then
 # If we've reached this point, send ok to Sentry cron monitoring
-sentry_cron_ok "$SENTRY_CRON_URL"
+    sentry_cron_ok "$SENTRY_CRON_URL"
+fi


### PR DESCRIPTION
Part fixes #2910.

I think it makes sense that the backup generation, sanitisation, and
compression will continue to be done locally as the local file system access is
likely faster than doing everything directly in block storage.

For now, copy the compressed backups that are created locally to block storage,
and repeat the symlink and retention steps. This allows us to see that the new
location works, without changing the current process for downloading the
backups. If it seems to work in production, we can change the `cp`s to `mv`s
and remove the older commands.

This adds one more dokku environment variable, `BLOCK_BACKUP_DIR`. I will add that to the
production configuration at the time of merging this.

Tested locally with:

```
DATABASE_DIR=. BLOCK_STORAGE_DIR=tmp_block SKIP_SENTRY=true ./deploy/bin/backup.sh
```

Then checking expected files and symlinks were in place.