### PR TITLE
Bump base image to 24.04 - remove deadsnakes

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -7,20 +7,11 @@
 # the latest base image, by design.
 #
 # hadolint ignore=DL3007
-FROM ghcr.io/opensafely-core/base-docker:22.04 as base-python
+FROM ghcr.io/opensafely-core/base-docker:24.04 as base-python
 
 # we are going to use an apt cache on the host, so disable the default debian
 # docker clean up that deletes that cache on every apt install
 RUN rm -f /etc/apt/apt.conf.d/docker-clean
-
-# Add deadsnakes PPA for installing new Python versions
-# ensure fully working base python3 installation
-# see: https://gist.github.com/tiran/2dec9e03c6f901814f6d1e8dad09528e
-# use space efficient utility from base image
-
-RUN --mount=type=cache,target=/var/cache/apt \
-    echo "deb https://ppa.launchpadcontent.net/deadsnakes/ppa/ubuntu jammy main" > /etc/apt/sources.list.d/deadsnakes-ppa.list &&\
-    /usr/lib/apt/apt-helper download-file 'https://keyserver.ubuntu.com/pks/lookup?op=get&search=0xf23c5a6cf475977595c89f51ba6932366a755776' /etc/apt/trusted.gpg.d/deadsnakes.asc
 
 # install any system dependencies
 COPY docker/dependencies.txt /tmp/dependencies.txt


### PR DESCRIPTION
Test to see if we can use the 24.04 base image, and then remove the dependency on deadsnakes PPA which is currently only used because python 3.12 is not in "apt" in 22.04