### PR TITLE
Fix empty table for user with no codelists

### DIFF
--- a/templates/opencodelists/this_user.html
+++ b/templates/opencodelists/this_user.html
@@ -37,158 +37,160 @@
       {% endif %}
     </div>
 
-    <div class="mt-8 flow-root xl:mx-auto xl:max-w-384 px-4 xl:px-12">
-      <div class="-my-2 overflow-x-auto -mx-2">
-        <div class="inline-block min-w-full py-2 align-middle px-2">
-          <div class="overflow-hidden shadow-sm outline-1 outline-black/5 sm:rounded-lg dark:shadow-none dark:-outline-offset-1 dark:outline-white/10">
-            <table class="relative min-w-full divide-y divide-slate-200" data-codelist-search-table>
-              <thead class="border-b-slate-300 bg-slate-100 text-left text-sm font-semibold text-slate-900">
-                <tr class="align-bottom">
-                  <th aria-sort="ascending" class="px-3 py-3.5 pl-4 whitespace-nowrap sm:pl-6 group" rowspan="2">
-                    <button
-                      class="cursor-pointer inline-flex items-center gap-x-1 text-slate-900 transition-colors hover:text-slate-950 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-600"
-                      data-codelist-sort-button="string"
-                      data-codelist-sort-column="0"
-                      type="button"
-                    >
-                      Name
-                      <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" class="size-5 border rounded border-slate-300 p-0.5 ml-1 shrink-0 bg-white">
-                        <path class="hidden sort-icon__asc" clip-rule="evenodd" fill-rule="evenodd" d="M10 17a.75.75 0 0 1-.75-.75V5.612L5.29 9.77a.75.75 0 0 1-1.08-1.04l5.25-5.5a.75.75 0 0 1 1.08 0l5.25 5.5a.75.75 0 1 1-1.08 1.04l-3.96-4.158V16.25A.75.75 0 0 1 10 17Z" />
-                        <path class="hidden sort-icon__desc" clip-rule="evenodd" fill-rule="evenodd" d="M10 3a.75.75 0 0 1 .75.75v10.638l3.96-4.158a.75.75 0 1 1 1.08 1.04l-5.25 5.5a.75.75 0 0 1-1.08 0l-5.25-5.5a.75.75 0 1 1 1.08-1.04l3.96 4.158V3.75A.75.75 0 0 1 10 3Z" />
-                        <path class="hidden sort-icon__none" clip-rule="evenodd" fill-rule="evenodd" d="M2.24 6.8a.75.75 0 0 0 1.06-.04l1.95-2.1v8.59a.75.75 0 0 0 1.5 0V4.66l1.95 2.1a.75.75 0 1 0 1.1-1.02l-3.25-3.5a.75.75 0 0 0-1.1 0L2.2 5.74a.75.75 0 0 0 .04 1.06Zm8 6.4a.75.75 0 0 0-.04 1.06l3.25 3.5a.75.75 0 0 0 1.1 0l3.25-3.5a.75.75 0 1 0-1.1-1.02l-1.95 2.1V6.75a.75.75 0 0 0-1.5 0v8.59l-1.95-2.1a.75.75 0 0 0-1.06-.04Z" />
-                      </svg>
-                    </button>
-                  </th>
-                  <th aria-sort="none" class="px-3 py-3.5 whitespace-nowrap" rowspan="2">
-                    <button
-                      class="cursor-pointer inline-flex items-center gap-x-1 text-slate-900 transition-colors hover:text-slate-950 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-600"
-                      data-codelist-sort-button="string"
-                      data-codelist-sort-column="1"
-                      type="button"
-                    >
-                      Owner
-                      <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" class="size-5 border rounded border-slate-300 p-0.5 ml-1 shrink-0 bg-white">
-                        <path class="hidden sort-icon__asc" clip-rule="evenodd" fill-rule="evenodd" d="M10 17a.75.75 0 0 1-.75-.75V5.612L5.29 9.77a.75.75 0 0 1-1.08-1.04l5.25-5.5a.75.75 0 0 1 1.08 0l5.25 5.5a.75.75 0 1 1-1.08 1.04l-3.96-4.158V16.25A.75.75 0 0 1 10 17Z" />
-                        <path class="hidden sort-icon__desc" clip-rule="evenodd" fill-rule="evenodd" d="M10 3a.75.75 0 0 1 .75.75v10.638l3.96-4.158a.75.75 0 1 1 1.08 1.04l-5.25 5.5a.75.75 0 0 1-1.08 0l-5.25-5.5a.75.75 0 1 1 1.08-1.04l3.96 4.158V3.75A.75.75 0 0 1 10 3Z" />
-                        <path class="hidden sort-icon__none" clip-rule="evenodd" fill-rule="evenodd" d="M2.24 6.8a.75.75 0 0 0 1.06-.04l1.95-2.1v8.59a.75.75 0 0 0 1.5 0V4.66l1.95 2.1a.75.75 0 1 0 1.1-1.02l-3.25-3.5a.75.75 0 0 0-1.1 0L2.2 5.74a.75.75 0 0 0 .04 1.06Zm8 6.4a.75.75 0 0 0-.04 1.06l3.25 3.5a.75.75 0 0 0 1.1 0l3.25-3.5a.75.75 0 1 0-1.1-1.02l-1.95 2.1V6.75a.75.75 0 0 0-1.5 0v8.59l-1.95-2.1a.75.75 0 0 0-1.06-.04Z" />
-                      </svg>
-                    </button>
-                  </th>
-                  <th class="px-3 py-3.5 whitespace-nowrap" rowspan="2">Coding system</th>
-                  <th class="sr-only" colspan="4">Versions</th>
-                </tr>
-                <tr>
-                  <th class="px-3 py-3.5 whitespace-nowrap">Version ID</th>
-                  <th class="px-3 py-3.5 whitespace-nowrap">Status</th>
-                  <th class="px-3 py-3.5 whitespace-nowrap">Number of codes</th>
-                  <th aria-sort="none" class="px-3 py-3.5 pr-3 whitespace-nowrap sm:pr-6">
+    {% if all_codelists %}
+      <div class="mt-8 flow-root xl:mx-auto xl:max-w-384 px-4 xl:px-12">
+        <div class="-my-2 overflow-x-auto -mx-2">
+          <div class="inline-block min-w-full py-2 align-middle px-2">
+            <div class="overflow-hidden shadow-sm outline-1 outline-black/5 sm:rounded-lg dark:shadow-none dark:-outline-offset-1 dark:outline-white/10">
+              <table class="relative min-w-full divide-y divide-slate-200" data-codelist-search-table>
+                <thead class="border-b-slate-300 bg-slate-100 text-left text-sm font-semibold text-slate-900">
+                  <tr class="align-bottom">
+                    <th aria-sort="ascending" class="px-3 py-3.5 pl-4 whitespace-nowrap sm:pl-6 group" rowspan="2">
+                      <button
+                        class="cursor-pointer inline-flex items-center gap-x-1 text-slate-900 transition-colors hover:text-slate-950 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-600"
+                        data-codelist-sort-button="string"
+                        data-codelist-sort-column="0"
+                        type="button"
+                      >
+                        Name
+                        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" class="size-5 border rounded border-slate-300 p-0.5 ml-1 shrink-0 bg-white">
+                          <path class="hidden sort-icon__asc" clip-rule="evenodd" fill-rule="evenodd" d="M10 17a.75.75 0 0 1-.75-.75V5.612L5.29 9.77a.75.75 0 0 1-1.08-1.04l5.25-5.5a.75.75 0 0 1 1.08 0l5.25 5.5a.75.75 0 1 1-1.08 1.04l-3.96-4.158V16.25A.75.75 0 0 1 10 17Z" />
+                          <path class="hidden sort-icon__desc" clip-rule="evenodd" fill-rule="evenodd" d="M10 3a.75.75 0 0 1 .75.75v10.638l3.96-4.158a.75.75 0 1 1 1.08 1.04l-5.25 5.5a.75.75 0 0 1-1.08 0l-5.25-5.5a.75.75 0 1 1 1.08-1.04l3.96 4.158V3.75A.75.75 0 0 1 10 3Z" />
+                          <path class="hidden sort-icon__none" clip-rule="evenodd" fill-rule="evenodd" d="M2.24 6.8a.75.75 0 0 0 1.06-.04l1.95-2.1v8.59a.75.75 0 0 0 1.5 0V4.66l1.95 2.1a.75.75 0 1 0 1.1-1.02l-3.25-3.5a.75.75 0 0 0-1.1 0L2.2 5.74a.75.75 0 0 0 .04 1.06Zm8 6.4a.75.75 0 0 0-.04 1.06l3.25 3.5a.75.75 0 0 0 1.1 0l3.25-3.5a.75.75 0 1 0-1.1-1.02l-1.95 2.1V6.75a.75.75 0 0 0-1.5 0v8.59l-1.95-2.1a.75.75 0 0 0-1.06-.04Z" />
+                        </svg>
+                      </button>
+                    </th>
+                    <th aria-sort="none" class="px-3 py-3.5 whitespace-nowrap" rowspan="2">
+                      <button
+                        class="cursor-pointer inline-flex items-center gap-x-1 text-slate-900 transition-colors hover:text-slate-950 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-600"
+                        data-codelist-sort-button="string"
+                        data-codelist-sort-column="1"
+                        type="button"
+                      >
+                        Owner
+                        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" class="size-5 border rounded border-slate-300 p-0.5 ml-1 shrink-0 bg-white">
+                          <path class="hidden sort-icon__asc" clip-rule="evenodd" fill-rule="evenodd" d="M10 17a.75.75 0 0 1-.75-.75V5.612L5.29 9.77a.75.75 0 0 1-1.08-1.04l5.25-5.5a.75.75 0 0 1 1.08 0l5.25 5.5a.75.75 0 1 1-1.08 1.04l-3.96-4.158V16.25A.75.75 0 0 1 10 17Z" />
+                          <path class="hidden sort-icon__desc" clip-rule="evenodd" fill-rule="evenodd" d="M10 3a.75.75 0 0 1 .75.75v10.638l3.96-4.158a.75.75 0 1 1 1.08 1.04l-5.25 5.5a.75.75 0 0 1-1.08 0l-5.25-5.5a.75.75 0 1 1 1.08-1.04l3.96 4.158V3.75A.75.75 0 0 1 10 3Z" />
+                          <path class="hidden sort-icon__none" clip-rule="evenodd" fill-rule="evenodd" d="M2.24 6.8a.75.75 0 0 0 1.06-.04l1.95-2.1v8.59a.75.75 0 0 0 1.5 0V4.66l1.95 2.1a.75.75 0 1 0 1.1-1.02l-3.25-3.5a.75.75 0 0 0-1.1 0L2.2 5.74a.75.75 0 0 0 .04 1.06Zm8 6.4a.75.75 0 0 0-.04 1.06l3.25 3.5a.75.75 0 0 0 1.1 0l3.25-3.5a.75.75 0 1 0-1.1-1.02l-1.95 2.1V6.75a.75.75 0 0 0-1.5 0v8.59l-1.95-2.1a.75.75 0 0 0-1.06-.04Z" />
+                        </svg>
+                      </button>
+                    </th>
+                    <th class="px-3 py-3.5 whitespace-nowrap" rowspan="2">Coding system</th>
+                    <th class="sr-only" colspan="4">Versions</th>
+                  </tr>
+                  <tr>
+                    <th class="px-3 py-3.5 whitespace-nowrap">Version ID</th>
+                    <th class="px-3 py-3.5 whitespace-nowrap">Status</th>
+                    <th class="px-3 py-3.5 whitespace-nowrap">Number of codes</th>
+                    <th aria-sort="none" class="px-3 py-3.5 pr-3 whitespace-nowrap sm:pr-6">
 
-                    <button
-                      class="cursor-pointer inline-flex items-center gap-x-1 text-slate-900 transition-colors hover:text-slate-950 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-600"
-                      data-codelist-sort-button="date"
-                      data-codelist-sort-column="6"
-                      type="button"
-                    >
-                      Last updated
-                      <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" class="size-5 border rounded border-slate-300 p-0.5 ml-1 shrink-0 bg-white">
-                        <path class="hidden sort-icon__asc" clip-rule="evenodd" fill-rule="evenodd" d="M10 17a.75.75 0 0 1-.75-.75V5.612L5.29 9.77a.75.75 0 0 1-1.08-1.04l5.25-5.5a.75.75 0 0 1 1.08 0l5.25 5.5a.75.75 0 1 1-1.08 1.04l-3.96-4.158V16.25A.75.75 0 0 1 10 17Z" />
-                        <path class="hidden sort-icon__desc" clip-rule="evenodd" fill-rule="evenodd" d="M10 3a.75.75 0 0 1 .75.75v10.638l3.96-4.158a.75.75 0 1 1 1.08 1.04l-5.25 5.5a.75.75 0 0 1-1.08 0l-5.25-5.5a.75.75 0 1 1 1.08-1.04l3.96 4.158V3.75A.75.75 0 0 1 10 3Z" />
-                        <path class="hidden sort-icon__none" clip-rule="evenodd" fill-rule="evenodd" d="M2.24 6.8a.75.75 0 0 0 1.06-.04l1.95-2.1v8.59a.75.75 0 0 0 1.5 0V4.66l1.95 2.1a.75.75 0 1 0 1.1-1.02l-3.25-3.5a.75.75 0 0 0-1.1 0L2.2 5.74a.75.75 0 0 0 .04 1.06Zm8 6.4a.75.75 0 0 0-.04 1.06l3.25 3.5a.75.75 0 0 0 1.1 0l3.25-3.5a.75.75 0 1 0-1.1-1.02l-1.95 2.1V6.75a.75.75 0 0 0-1.5 0v8.59l-1.95-2.1a.75.75 0 0 0-1.06-.04Z" />
-                      </svg>
-                    </button>
-                  </th>
-                </tr>
-              </thead>
-              {% for item in all_codelists %}
-                {% if item.versions|length == 1 %}
-                  <tbody class="bg-white even:bg-slate-50">
-                    {% with version=item.versions.0 %}
-                      <tr class="text-sm/relaxed text-slate-900 hover:bg-yellow-50 relative">
-                        <td class="px-3 py-2 pl-4 text-base/snug font-semibold sm:pl-6" data-codelist-search-cell>
-                          {{ item.codelist.name }}
-                        </td>
-                        <td class="px-3 py-2 whitespace-nowrap" data-codelist-search-cell>
-                          {{ item.codelist.owner }}
-                        </td>
-                        <td class="px-3 py-4 whitespace-nowrap" data-codelist-search-cell>
-                          {{ item.codelist.coding_system_short_name }}
-                        </td>
-                        <td class="px-3 py-4">
-                          <a class="link whitespace-nowrap before:absolute before:w-full before:h-full before:inset-0" href="{{ version.get_absolute_url }}">
-                            {{ version.tag_or_hash }}
-                          </a>
-                        </td>
-                        <td class="px-3">
-                          {% if version.is_under_review %}
-                            <span class="inline-flex rounded-full px-2 py-0.5 text-sm/tight font-semibold border bg-blue-200 text-blue-900 border-blue-200 whitespace-nowrap">Under review</span>
-                          {% elif version.is_draft %}
-                            <span class="inline-flex rounded-full px-2 py-0.5 text-sm/tight font-semibold border bg-white text-slate-600 border-slate-200 whitespace-nowrap">Draft</span>
-                          {% elif version.is_published %}
-                            <span class="inline-flex rounded-full px-2 py-0.5 text-sm/tight font-semibold border bg-green-200 text-green-900 border-green-200 whitespace-nowrap">Published</span>
-                          {% endif %}
-                        </td>
-                        <td class="px-3 py-4 whitespace-nowrap">
-                          {{ version.codes|length }} code{{ version.codes|pluralize}}
-                        </td>
-                        <td class="px-3 py-2 pr-3 sm:pr-6">
-                          <time class="whitespace-nowrap" datetime="{{ version.updated_at|date:"c" }}">
-                            {{ version.updated_at|date:'d M Y' }} at {{ version.updated_at|date:'H:i' }}
-                          </time>
-                        </td>
-                      </tr>
-                    {% endwith %}
-                  </tbody>
-                {% else %}
-                  <tbody class="group bg-white even:bg-slate-50 hover:bg-yellow-50">
-                    {% for version in item.versions %}
-                      <tr class="text-sm text-slate-900">
-                        <td class="px-3 py-2 pl-4 text-base/snug font-semibold sm:pl-6" data-codelist-search-cell>
-                          <span class="{% if not forloop.first %}sr-only{% endif %}">{{ item.codelist.name }}</span>
-                        </td>
-                        <td class="px-3 py-2 min-w-[20ch]" data-codelist-search-cell>
-                          <span class="{% if not forloop.first %}sr-only{% endif %}">{{ item.codelist.owner }}</span>
-                        </td>
-                        <td class="px-3 py-2 whitespace-nowrap" data-codelist-search-cell>
-                          <span class="{% if not forloop.first %}sr-only{% endif %}">{{ item.codelist.coding_system_short_name }}</span>
-                        </td>
-                        <td class="px-3 py-2">
-                          <a class="link whitespace-nowrap" href="{{ version.get_absolute_url }}">
-                            {{ version.tag_or_hash }}
-                          </a>
-                        </td>
-                        <td class="px-3">
-                          {% if version.is_under_review %}
-                            <span class="inline-flex rounded-full px-2 py-0.5 text-sm/tight font-semibold border bg-blue-200 text-blue-900 border-blue-200 whitespace-nowrap">Under review</span>
-                          {% elif version.is_draft %}
-                            <span class="inline-flex rounded-full px-2 py-0.5 text-sm/tight font-semibold border bg-white text-slate-600 border-slate-200 whitespace-nowrap">Draft</span>
-                          {% elif version.is_published %}
-                            <span class="inline-flex rounded-full px-2 py-0.5 text-sm/tight font-semibold border bg-green-200 text-green-900 border-green-200 whitespace-nowrap">Published</span>
-                          {% endif %}
-                        </td>
-                        <td class="px-3 py-2 whitespace-nowrap">{{ version.codes|length }} code{{ version.codes|pluralize}}</td>
-                        <td class="px-3 py-2 pr-3 sm:pr-6">
-                          <time class="whitespace-nowrap" datetime="{{ version.updated_at|date:"c" }}">
-                            {{ version.updated_at|date:'d M Y' }} at {{ version.updated_at|date:'H:i' }}
-                          </time>
-                        </td>
-                      </tr>
-                    {% endfor %}
-                  </tbody>
-                {% endif %}
-              {% endfor %}
-              <tbody data-codelist-search-no-results-body>
-                <tr class="hidden bg-white text-slate-700" data-codelist-search-no-results>
-                  <td class="px-3 py-4 pl-4 text-base/snug sm:pl-6" colspan="4">
-                    No codelists found
-                  </td>
-                </tr>
-              </tbody>
-            </table>
+                      <button
+                        class="cursor-pointer inline-flex items-center gap-x-1 text-slate-900 transition-colors hover:text-slate-950 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-600"
+                        data-codelist-sort-button="date"
+                        data-codelist-sort-column="6"
+                        type="button"
+                      >
+                        Last updated
+                        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" class="size-5 border rounded border-slate-300 p-0.5 ml-1 shrink-0 bg-white">
+                          <path class="hidden sort-icon__asc" clip-rule="evenodd" fill-rule="evenodd" d="M10 17a.75.75 0 0 1-.75-.75V5.612L5.29 9.77a.75.75 0 0 1-1.08-1.04l5.25-5.5a.75.75 0 0 1 1.08 0l5.25 5.5a.75.75 0 1 1-1.08 1.04l-3.96-4.158V16.25A.75.75 0 0 1 10 17Z" />
+                          <path class="hidden sort-icon__desc" clip-rule="evenodd" fill-rule="evenodd" d="M10 3a.75.75 0 0 1 .75.75v10.638l3.96-4.158a.75.75 0 1 1 1.08 1.04l-5.25 5.5a.75.75 0 0 1-1.08 0l-5.25-5.5a.75.75 0 1 1 1.08-1.04l3.96 4.158V3.75A.75.75 0 0 1 10 3Z" />
+                          <path class="hidden sort-icon__none" clip-rule="evenodd" fill-rule="evenodd" d="M2.24 6.8a.75.75 0 0 0 1.06-.04l1.95-2.1v8.59a.75.75 0 0 0 1.5 0V4.66l1.95 2.1a.75.75 0 1 0 1.1-1.02l-3.25-3.5a.75.75 0 0 0-1.1 0L2.2 5.74a.75.75 0 0 0 .04 1.06Zm8 6.4a.75.75 0 0 0-.04 1.06l3.25 3.5a.75.75 0 0 0 1.1 0l3.25-3.5a.75.75 0 1 0-1.1-1.02l-1.95 2.1V6.75a.75.75 0 0 0-1.5 0v8.59l-1.95-2.1a.75.75 0 0 0-1.06-.04Z" />
+                        </svg>
+                      </button>
+                    </th>
+                  </tr>
+                </thead>
+                {% for item in all_codelists %}
+                  {% if item.versions|length == 1 %}
+                    <tbody class="bg-white even:bg-slate-50">
+                      {% with version=item.versions.0 %}
+                        <tr class="text-sm/relaxed text-slate-900 hover:bg-yellow-50 relative">
+                          <td class="px-3 py-2 pl-4 text-base/snug font-semibold sm:pl-6" data-codelist-search-cell>
+                            {{ item.codelist.name }}
+                          </td>
+                          <td class="px-3 py-2 whitespace-nowrap" data-codelist-search-cell>
+                            {{ item.codelist.owner }}
+                          </td>
+                          <td class="px-3 py-4 whitespace-nowrap" data-codelist-search-cell>
+                            {{ item.codelist.coding_system_short_name }}
+                          </td>
+                          <td class="px-3 py-4">
+                            <a class="link whitespace-nowrap before:absolute before:w-full before:h-full before:inset-0" href="{{ version.get_absolute_url }}">
+                              {{ version.tag_or_hash }}
+                            </a>
+                          </td>
+                          <td class="px-3">
+                            {% if version.is_under_review %}
+                              <span class="inline-flex rounded-full px-2 py-0.5 text-sm/tight font-semibold border bg-blue-200 text-blue-900 border-blue-200 whitespace-nowrap">Under review</span>
+                            {% elif version.is_draft %}
+                              <span class="inline-flex rounded-full px-2 py-0.5 text-sm/tight font-semibold border bg-white text-slate-600 border-slate-200 whitespace-nowrap">Draft</span>
+                            {% elif version.is_published %}
+                              <span class="inline-flex rounded-full px-2 py-0.5 text-sm/tight font-semibold border bg-green-200 text-green-900 border-green-200 whitespace-nowrap">Published</span>
+                            {% endif %}
+                          </td>
+                          <td class="px-3 py-4 whitespace-nowrap">
+                            {{ version.codes|length }} code{{ version.codes|pluralize}}
+                          </td>
+                          <td class="px-3 py-2 pr-3 sm:pr-6">
+                            <time class="whitespace-nowrap" datetime="{{ version.updated_at|date:"c" }}">
+                              {{ version.updated_at|date:'d M Y' }} at {{ version.updated_at|date:'H:i' }}
+                            </time>
+                          </td>
+                        </tr>
+                      {% endwith %}
+                    </tbody>
+                  {% else %}
+                    <tbody class="group bg-white even:bg-slate-50 hover:bg-yellow-50">
+                      {% for version in item.versions %}
+                        <tr class="text-sm text-slate-900">
+                          <td class="px-3 py-2 pl-4 text-base/snug font-semibold sm:pl-6" data-codelist-search-cell>
+                            <span class="{% if not forloop.first %}sr-only{% endif %}">{{ item.codelist.name }}</span>
+                          </td>
+                          <td class="px-3 py-2 min-w-[20ch]" data-codelist-search-cell>
+                            <span class="{% if not forloop.first %}sr-only{% endif %}">{{ item.codelist.owner }}</span>
+                          </td>
+                          <td class="px-3 py-2 whitespace-nowrap" data-codelist-search-cell>
+                            <span class="{% if not forloop.first %}sr-only{% endif %}">{{ item.codelist.coding_system_short_name }}</span>
+                          </td>
+                          <td class="px-3 py-2">
+                            <a class="link whitespace-nowrap" href="{{ version.get_absolute_url }}">
+                              {{ version.tag_or_hash }}
+                            </a>
+                          </td>
+                          <td class="px-3">
+                            {% if version.is_under_review %}
+                              <span class="inline-flex rounded-full px-2 py-0.5 text-sm/tight font-semibold border bg-blue-200 text-blue-900 border-blue-200 whitespace-nowrap">Under review</span>
+                            {% elif version.is_draft %}
+                              <span class="inline-flex rounded-full px-2 py-0.5 text-sm/tight font-semibold border bg-white text-slate-600 border-slate-200 whitespace-nowrap">Draft</span>
+                            {% elif version.is_published %}
+                              <span class="inline-flex rounded-full px-2 py-0.5 text-sm/tight font-semibold border bg-green-200 text-green-900 border-green-200 whitespace-nowrap">Published</span>
+                            {% endif %}
+                          </td>
+                          <td class="px-3 py-2 whitespace-nowrap">{{ version.codes|length }} code{{ version.codes|pluralize}}</td>
+                          <td class="px-3 py-2 pr-3 sm:pr-6">
+                            <time class="whitespace-nowrap" datetime="{{ version.updated_at|date:"c" }}">
+                              {{ version.updated_at|date:'d M Y' }} at {{ version.updated_at|date:'H:i' }}
+                            </time>
+                          </td>
+                        </tr>
+                      {% endfor %}
+                    </tbody>
+                  {% endif %}
+                {% endfor %}
+                <tbody data-codelist-search-no-results-body>
+                  <tr class="hidden bg-white text-slate-700" data-codelist-search-no-results>
+                    <td class="px-3 py-4 pl-4 text-base/snug sm:pl-6" colspan="4">
+                      No codelists found
+                    </td>
+                  </tr>
+                </tbody>
+              </table>
+            </div>
           </div>
         </div>
       </div>
-    </div>
-  </div>
+    {% endif %}
+  </section>
 {% endblock %}
 
 {% block extra_js %}


### PR DESCRIPTION
As currently it shows an empty table when the user has no codelists, we should hide it and just leave the message "Create your first codelist above.".