### PR TITLE
Move backups to block storage instead of copy

### DIFF
--- a/deploy/bin/backup.sh
+++ b/deploy/bin/backup.sh
@@ -142,39 +142,15 @@ verify_file_min_size "${SANITISED_BACKUP_FILEPATH}.zst"
 # Only now remove the uncompressed originals
 rm "$BACKUP_FILEPATH" "$SANITISED_BACKUP_FILEPATH"
 
-# Copy the compressed backups to block storage to reduce local disk usage and
+# Move the compressed backups to block storage to reduce local disk usage and
 # separate them from the production system.
-# This is WIP in https://github.com/opensafely-core/opencodelists/issues/2910
-# For now, just copy the files so they exist in both places. Once we are sure
-# this is working, this could be a move rather than a copy, and we could adjust
-# the symlinks and retention below to refer to the new location.
 mkdir -p "$BLOCK_BACKUP_DIR"
-cp --preserve=mode,timestamps "$BACKUP_FILEPATH.zst" "$BLOCK_BACKUP_DIR"
-cp --preserve=mode,timestamps "$SANITISED_BACKUP_FILEPATH.zst" "$BLOCK_BACKUP_DIR"
+rsync -av --remove-source-files "$BACKUP_FILEPATH.zst" "$BLOCK_BACKUP_DIR"
+rsync -av --remove-source-files "$SANITISED_BACKUP_FILEPATH.zst" "$BLOCK_BACKUP_DIR"
 
 # Symlink to the new latest backups to make it easy to discover.
 # Make the target a relative path -- an absolute one won't mean the same thing
 # in the host file system if executed inside a container as we expect.
-
-# Ensure target backup file exists before trying to link
-if [ -f "${BACKUP_FILEPATH}.zst" ]; then
-    ln -sf "$BACKUP_FILENAME.zst" "$BACKUP_DIR/latest-db.sqlite3.zst"
-else
-    echo "expected compressed raw backup missing: ${BACKUP_FILEPATH}.zst" >&2
-    exit 4
-fi
-
-# Ensure target sanitised backup file exists before trying to link
-if [ -f "${SANITISED_BACKUP_FILEPATH}.zst" ]; then
-    ln -sf "$SANITISED_BACKUP_FILENAME.zst" "$BACKUP_DIR/sanitised-latest-db.sqlite3.zst"
-else
-    echo "expected compressed sanitised backup missing: ${SANITISED_BACKUP_FILEPATH}.zst" >&2
-    exit 5
-fi
-
-# Create symlinks in block storge location.
-# This is WIP in https://github.com/opensafely-core/opencodelists/issues/2910
-# For now, do both. Later we could remove the above ln commands.
 
 # Ensure target backup file exists before trying to link
 if [ -f "$BLOCK_BACKUP_DIR/$BACKUP_FILENAME.zst" ]; then
@@ -193,11 +169,9 @@ else
 fi
 
 # Keep only the last 14 days of raw backups
-find "$BACKUP_DIR" -name "*-db.sqlite3.zst" -type f -mtime +14 -delete
 find "$BLOCK_BACKUP_DIR" -name "*-db.sqlite3.zst" -type f -mtime +14 -delete
 
 # Keep only the most recent sanitised backup.
-find "$BACKUP_DIR" -name "*sanitised*-db.sqlite3.zst" ! -wholename "$SANITISED_BACKUP_FILEPATH.zst" -type f -delete
 find "$BLOCK_BACKUP_DIR" -name "*sanitised*-db.sqlite3.zst" ! -name "$SANITISED_BACKUP_FILENAME.zst" -type f -delete
 
 if [ "$SKIP_SENTRY" != "true" ]; then

--- a/docker/dependencies.txt
+++ b/docker/dependencies.txt
@@ -8,3 +8,5 @@ tzdata
 zstd
 # Needed to make HTTP calls to the Sentry API
 curl
+# Remote file-copying tool, used for copying backups to block storage.
+rsync


### PR DESCRIPTION
Part fixes https://github.com/opensafely-core/opencodelists/issues/2910.

Database backups use significant space on the main volume of dokku3. To save space on the main drive, and to improve our storage capacity, we want to move the backups storage to DigitalOcean Block Storage.

Now that we have seen the backups successfully copy across, we can change the `cp` command to a `mv`, as the backups don't need to exist in both places. This will free up space.

I think it makes sense that the backup generation, sanitisation, and compression will continue to be done locally as the local file system access is likely faster than doing everything directly in block storage.

Cleaning up the existing backup folder can be done manually to free the space once we see that this has worked.

Tested locally with:

```
DATABASE_DIR=. BLOCK_STORAGE_DIR=tmp_block SKIP_SENTRY=true ./deploy/bin/backup.sh
```

Then checking expected files and symlinks were in place in the "block storage" location and not in the "database storage" location.