### PR TITLE
Document manual steps for block storage backup.

### DIFF
--- a/DEPLOY.md
+++ b/DEPLOY.md
@@ -41,6 +41,30 @@ sudo chmod 755 /mnt/volume_opencodelists_backups/opencodelists
 dokku storage:mount opencodelists /mnt/volume_opencodelists_backups/opencodelists:/block_storage
 ```
 
+You can resize block storage to increase its size but never decrease. You must
+ensure that nothing is writing to the volume while you do this to avoid data
+corruption. Steps:
+
+- Log in to the DigitalOcean Dashboard
+- Go to Droplets
+- Select dokku3
+- Select Volumes tab
+- Select "Increase storage size" from the "..." menu against the volume.
+- Increase by the required amount in the modal and click the "Increase storage size" button.
+
+Then SSH to the droplet to resize the file system to use all available blocks:
+
+```
+# Check the free disk on the mounted device before your change.
+df /mnt/volume_opencodelists_backups/ -h
+# Check the size of the block device.
+lsblk
+# Resize the device in the file system to use all available blocks.
+sudo resize2fs /dev/sda
+# Check the free disk on the mounted device after your change.
+df /mnt/volume_opencodelists_backups/ -h
+```
+
 ### Configure app
 
 ```sh

--- a/DEPLOY.md
+++ b/DEPLOY.md
@@ -24,6 +24,23 @@ dokku$ chown dokku:dokku /var/lib/dokku/data/storage/opencodelists/*
 dokku$ dokku storage:mount opencodelists /var/lib/dokku/data/storage/opencodelists/:/storage
 ```
 
+Add block storage to the droplet with the following steps:
+
+- Log in to the DigitalOcean Dashboard
+- Go to Droplets
+- Select dokku3
+- Select Volumes tab
+- Press the Add Volume button
+- Use the modal to configure, create, and mount the volume, selecting the droplet name, desired volume size,  "Automatically format and mount", and "EXT4".
+
+Run the following commands to set up the mount manually:
+```
+mkdir -p /mnt/volume_opencodelists_backups/opencodelists
+sudo chown -R 10003:10003 /mnt/volume_opencodelists_backups/opencodelists
+sudo chmod 755 /mnt/volume_opencodelists_backups/opencodelists
+dokku storage:mount opencodelists /mnt/volume_opencodelists_backups/opencodelists:/block_storage
+```
+
 ### Configure app
 
 ```sh


### PR DESCRIPTION
Part fixes https://github.com/opensafely-core/opencodelists/issues/2910.

See [Slack thread](https://bennettoxford.slack.com/archives/C069SADHP1Q/p1776954047307589) where initial manual configuration was done. We should record this in case we need to redeploy.