### PR TITLE
Pin pre-commit hooks to commits

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,7 +12,7 @@ repos:
       require_serial: true
 
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.3.0
+    rev: 3e8a8703264a2f4a69428a0aa4dcb512790b2c8c # v6.0.0
     hooks:
     - id: trailing-whitespace
     - id: end-of-file-fixer
@@ -24,7 +24,7 @@ repos:
     - id: detect-private-key
 
   - repo: https://github.com/rtts/djhtml
-    rev: "3.0.8"
+    rev: 8577ec017145d76a0b954ebb7cb3169d4303014c # v3.0.8
     hooks:
       - id: djhtml
         entry: djhtml --tabwidth 2 # Use a tabwidth of 2 for HTML files

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -30,9 +30,14 @@ repos:
         entry: djhtml --tabwidth 2 # Use a tabwidth of 2 for HTML files
         files: ^templates/.*\.html$ # Indent only HTML files in template directories
 
-  - repo: https://github.com/jumanjihouse/pre-commit-hooks
-    rev: 2.1.6
+  - repo: local
     hooks:
     - id: shellcheck
+      name: shellcheck
+      description: Test shell scripts with shellcheck
+      entry: shellcheck
+      language: system
+      types: [shell]
+      args: [-e, SC1091]
 
 exclude: coding_systems/snomedct/parser_utils/


### PR DESCRIPTION
And replace the external `shellcheck` one with a similar inline check.