### PR TITLE
Update GitHub Actions with security and workflow improvements

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -21,6 +21,8 @@ on:
   schedule:
     - cron: '16 2 * * 5'
 
+permissions: {}
+
 jobs:
   analyze:
     name: Analyze

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -36,7 +36,7 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v6
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
         persist-credentials: false
 

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -23,6 +23,10 @@ on:
 
 permissions: {}
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   analyze:
     name: Analyze

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -37,6 +37,8 @@ jobs:
     steps:
     - name: Checkout repository
       uses: actions/checkout@v6
+      with:
+        persist-credentials: false
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -67,8 +67,10 @@ jobs:
             }
 
       - name: Publish docker image
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-            echo ${{ secrets.GITHUB_TOKEN }} | docker login $REGISTRY -u ${GITHUB_ACTOR} --password-stdin
+            printf '%s' "$GITHUB_TOKEN" | docker login "$REGISTRY" -u "$GITHUB_ACTOR" --password-stdin
             docker tag $IMAGE_NAME $PUBLIC_IMAGE_NAME:latest
             docker push $PUBLIC_IMAGE_NAME:latest
 
@@ -84,9 +86,11 @@ jobs:
           finalize: false
 
       - name: Setup SSH Agent
+        env:
+          DOKKU3_DEPLOY_SSH_KEY: ${{ secrets.DOKKU3_DEPLOY_SSH_KEY }}
         run: |
             ssh-agent -a $SSH_AUTH_SOCK > /dev/null
-            ssh-add - <<< "${{ secrets.DOKKU3_DEPLOY_SSH_KEY }}"
+            ssh-add - <<< "$DOKKU3_DEPLOY_SSH_KEY"
 
       - name: Deploy
         run: |

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -12,6 +12,8 @@ on:
   push:
     branches: [main]
 
+permissions: {}
+
 concurrency: deploy-production
 
 jobs:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -33,6 +33,7 @@ jobs:
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - uses: opensafely-core/setup-action@v1
         with:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -30,17 +30,17 @@ jobs:
     if: github.ref == 'refs/heads/main'
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
           persist-credentials: false
 
-      - uses: opensafely-core/setup-action@v1
+      - uses: opensafely-core/setup-action@5b3030fbbcf069c94e352b4f0a94100fae4dbd82 # v1.6.1
         with:
           install-just: true
 
       - name: Download docker image
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: opencodelists-image
           path: /tmp/image

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -19,6 +19,7 @@ jobs:
     uses: ./.github/workflows/main.yml
 
   deploy:
+    name: Deploy OpenCodelists
     needs: [test-and-build-docker-image]
 
     runs-on: ubuntu-latest

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -63,7 +63,7 @@ jobs:
 
       - name: Publish docker image
         run: |
-            echo ${{ secrets.GITHUB_TOKEN }} | docker login $REGISTRY -u ${{ github.actor }} --password-stdin
+            echo ${{ secrets.GITHUB_TOKEN }} | docker login $REGISTRY -u ${GITHUB_ACTOR} --password-stdin
             docker tag $IMAGE_NAME $PUBLIC_IMAGE_NAME:latest
             docker push $PUBLIC_IMAGE_NAME:latest
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -14,7 +14,9 @@ on:
 
 permissions: {}
 
-concurrency: deploy-production
+concurrency:
+  group: deploy-production
+  cancel-in-progress: true
 
 jobs:
   test-and-build-docker-image:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,6 +8,10 @@ on:
 
 permissions: {}
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   lint-dockerfile:
     name: Dockerfile lint

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,25 +7,29 @@ on:
   workflow_dispatch:
 
 jobs:
-
   lint-dockerfile:
-    runs-on: ubuntu-latest
+    name: Dockerfile lint
+    runs-on: ubuntu-24.04
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
-      - uses: hadolint/hadolint-action@2332a7b74a6de0dda2e2221d575162eba76ba5e5  # v3.3.0
+
+      - uses: hadolint/hadolint-action@2332a7b74a6de0dda2e2221d575162eba76ba5e5 # v3.3.0
         with:
           dockerfile: docker/Dockerfile
 
   check-py:
-    runs-on: ubuntu-latest
+    name: Python formatting check
+    runs-on: ubuntu-24.04
+    needs: lint-dockerfile
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
+
       - uses: opensafely-core/setup-action@5b3030fbbcf069c94e352b4f0a94100fae4dbd82 # v1.6.1
         with:
           install-just: true
@@ -35,29 +39,16 @@ jobs:
           # build docker and run checks
           just docker-check-py
 
-  check-js:
-    runs-on: ubuntu-latest
-
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          persist-credentials: false
-      - uses: opensafely-core/setup-action@5b3030fbbcf069c94e352b4f0a94100fae4dbd82 # v1.6.1
-        with:
-          install-just: true
-
-      - name: Build docker image and run checks in it
-        run: |
-          # build docker and run checks
-          just docker-check-js
-
   test-py:
-    runs-on: ubuntu-latest
+    name: Python tests
+    runs-on: ubuntu-24.04
+    needs: check-py
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
+
       - uses: opensafely-core/setup-action@5b3030fbbcf069c94e352b4f0a94100fae4dbd82 # v1.6.1
         with:
           install-just: true
@@ -101,7 +92,9 @@ jobs:
             compression-level: 0
 
   test-functional:
-    runs-on: ubuntu-latest
+    name: Functional tests
+    runs-on: ubuntu-24.04
+    needs: check-py
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -116,13 +109,35 @@ jobs:
           # build docker and run test
           TAKE_SCREENSHOTS=True just docker-test-functional --migrations
 
-  test-js:
-    runs-on: ubuntu-latest
+  check-js:
+    name: JS formatting check
+    runs-on: ubuntu-24.04
+    needs: lint-dockerfile
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
+
+      - uses: opensafely-core/setup-action@5b3030fbbcf069c94e352b4f0a94100fae4dbd82 # v1.6.1
+        with:
+          install-just: true
+
+      - name: Build docker image and run checks in it
+        run: |
+          # build docker and run checks
+          just docker-check-js
+
+  test-js:
+    name: JavaScript tests
+    runs-on: ubuntu-24.04
+    needs: check-js
+
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
       - uses: opensafely-core/setup-action@5b3030fbbcf069c94e352b4f0a94100fae4dbd82 # v1.6.1
         with:
           install-just: true

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,6 +6,8 @@ on:
   workflow_call:
   workflow_dispatch:
 
+permissions: {}
+
 jobs:
   lint-dockerfile:
     name: Dockerfile lint

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,6 +13,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       - uses: hadolint/hadolint-action@2332a7b74a6de0dda2e2221d575162eba76ba5e5  # v3.3.0
         with:
           dockerfile: docker/Dockerfile
@@ -22,6 +24,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       - uses: opensafely-core/setup-action@v1
         with:
           install-just: true
@@ -36,6 +40,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       - uses: opensafely-core/setup-action@v1
         with:
           install-just: true
@@ -50,6 +56,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       - uses: opensafely-core/setup-action@v1
         with:
           install-just: true
@@ -97,6 +105,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       - uses: opensafely-core/setup-action@v1
         with:
           install-just: true
@@ -111,6 +121,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       - uses: opensafely-core/setup-action@v1
         with:
           install-just: true

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
       - uses: hadolint/hadolint-action@2332a7b74a6de0dda2e2221d575162eba76ba5e5  # v3.3.0
@@ -23,10 +23,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
-      - uses: opensafely-core/setup-action@v1
+      - uses: opensafely-core/setup-action@5b3030fbbcf069c94e352b4f0a94100fae4dbd82 # v1.6.1
         with:
           install-just: true
 
@@ -39,10 +39,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
-      - uses: opensafely-core/setup-action@v1
+      - uses: opensafely-core/setup-action@5b3030fbbcf069c94e352b4f0a94100fae4dbd82 # v1.6.1
         with:
           install-just: true
 
@@ -55,10 +55,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
-      - uses: opensafely-core/setup-action@v1
+      - uses: opensafely-core/setup-action@5b3030fbbcf069c94e352b4f0a94100fae4dbd82 # v1.6.1
         with:
           install-just: true
 
@@ -94,7 +94,7 @@ jobs:
           docker save opencodelists | zstd --fast -o /tmp/opencodelists.tar.zst
 
       - name: Upload docker image
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
             name: opencodelists-image
             path: /tmp/opencodelists.tar.zst
@@ -104,10 +104,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
-      - uses: opensafely-core/setup-action@v1
+      - uses: opensafely-core/setup-action@5b3030fbbcf069c94e352b4f0a94100fae4dbd82 # v1.6.1
         with:
           install-just: true
 
@@ -120,10 +120,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
-      - uses: opensafely-core/setup-action@v1
+      - uses: opensafely-core/setup-action@5b3030fbbcf069c94e352b4f0a94100fae4dbd82 # v1.6.1
         with:
           install-just: true
 

--- a/.github/workflows/update-python-dependencies.yml
+++ b/.github/workflows/update-python-dependencies.yml
@@ -10,6 +10,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v6
+      with:
+        persist-credentials: false
     - uses: "opensafely-core/setup-action@v1"
       with:
         python-version: "3.12"

--- a/.github/workflows/update-python-dependencies.yml
+++ b/.github/workflows/update-python-dependencies.yml
@@ -30,6 +30,8 @@ jobs:
       with:
         app-id: 1031449  # opensafely-core Create PR app
         private-key: ${{ secrets.CREATE_PR_APP_PRIVATE_KEY }}
+        permission-contents: write
+        permission-pull-requests: write
 
     - uses: bennettoxford/update-dependencies-action@b77a22bcfe1d06020d908e64c9828fe944da3a5e # v1
       with:

--- a/.github/workflows/update-python-dependencies.yml
+++ b/.github/workflows/update-python-dependencies.yml
@@ -7,11 +7,13 @@ on:
 
 jobs:
   update-dependencies:
+    name: Update Python dependencies
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
         persist-credentials: false
+
     - uses: opensafely-core/setup-action@5b3030fbbcf069c94e352b4f0a94100fae4dbd82 # v1.6.1
       with:
         python-version: "3.12"

--- a/.github/workflows/update-python-dependencies.yml
+++ b/.github/workflows/update-python-dependencies.yml
@@ -7,6 +7,10 @@ on:
 
 permissions: {}
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   update-dependencies:
     name: Update Python dependencies

--- a/.github/workflows/update-python-dependencies.yml
+++ b/.github/workflows/update-python-dependencies.yml
@@ -5,6 +5,8 @@ on:
   schedule:
     - cron:  "12 6 * * 1"
 
+permissions: {}
+
 jobs:
   update-dependencies:
     name: Update Python dependencies

--- a/.github/workflows/update-python-dependencies.yml
+++ b/.github/workflows/update-python-dependencies.yml
@@ -9,20 +9,20 @@ jobs:
   update-dependencies:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
         persist-credentials: false
-    - uses: "opensafely-core/setup-action@v1"
+    - uses: opensafely-core/setup-action@5b3030fbbcf069c94e352b4f0a94100fae4dbd82 # v1.6.1
       with:
         python-version: "3.12"
         install-just: true
 
-    - uses: actions/create-github-app-token@v3.1.1
+    - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
       id: generate-token
       with:
         app-id: 1031449  # opensafely-core Create PR app
         private-key: ${{ secrets.CREATE_PR_APP_PRIVATE_KEY }}
 
-    - uses: bennettoxford/update-dependencies-action@v1
+    - uses: bennettoxford/update-dependencies-action@b77a22bcfe1d06020d908e64c9828fe944da3a5e # v1
       with:
         token: ${{ steps.generate-token.outputs.token }}


### PR DESCRIPTION
Closes #3064

The majority of these changes have been spotted by [Zizmor](https://github.com/zizmorcore/zizmor).

- Disable persist credentials in checkout action
    - [`artipacked`](https://docs.zizmor.sh/audits/#artipacked)
- Fix template injection for GitHub Actor
    - [`template-injection`](https://docs.zizmor.sh/audits/#template-injection)
- Pin GitHub Actions versions to specific hashes
    - [`unpinned-uses`](https://docs.zizmor.sh/audits/#unpinned-uses)
- Add `name` and `needs` to each step
    - [`anonymous-definition`](https://docs.zizmor.sh/audits/#anonymous-definition)
- Fix excessive permissions
    - [`excessive-permissions`](https://docs.zizmor.sh/audits/#excessive-permissions)
- Cancel running jobs when workflow is re-triggered
    - [`concurrency-limits`](https://docs.zizmor.sh/audits/#concurrency-limits)
- Fix code injection via template expansion
    - [`template-injection`](https://docs.zizmor.sh/audits/#template-injection)
- Improve usage of GitHub App permissions
    - [`github-app`](https://docs.zizmor.sh/audits/#github-app)
 
## Before

<img alt="Screenshot of the GitHub Actions workflow before" src="https://github.com/user-attachments/assets/da3d7afe-7929-4e32-9b73-806aac8023fe" />

## After

<img alt="Screenshot of the GitHub Actions workflow after" src="https://github.com/user-attachments/assets/179e9d57-9673-4964-88cc-9ecb1885dde7" />