### PR TITLE
Fix db path in bulk load script if `DATABASE_DIR` env var set

### DIFF
--- a/codelists/scripts/bulk_import_codelists.py
+++ b/codelists/scripts/bulk_import_codelists.py
@@ -388,9 +388,11 @@ def get_post_data(
         and coding_system_id not in CODING_SYSTEMS_WITH_OLD_STYLE_CODELISTS
     ):
         db_path = (
-            Path(dbpath)
-            if (dbpath := os.environ.get("DATABASE_DIR"))
-            else (Path(__file__).resolve().parent.parent.parent)
+            (
+                Path(dbpath)
+                if (dbpath := os.environ.get("DATABASE_DIR"))
+                else (Path(__file__).resolve().parent.parent.parent)
+            )
             / "coding_systems"
             / coding_system_id
             / f"{release_db_alias}.sqlite3"

--- a/codelists/scripts/bulk_import_codelists.py
+++ b/codelists/scripts/bulk_import_codelists.py
@@ -385,6 +385,7 @@ def get_post_data(
     if (
         "localhost" in host
         and not os.environ.get("TEST_IN_DOCKER")
+        and not os.environ.get("PYTEST_VERSION")
         and coding_system_id not in CODING_SYSTEMS_WITH_OLD_STYLE_CODELISTS
     ):
         db_path = (


### PR DESCRIPTION
The bulk load script checks the coding system db path and returns with error if the path is not found or not found to be a likely valid coding system database, as a convenience to developers using this script.

It previously did not take account of the `DATABASE_DIR` env var which is used to override the database directory path. A previous attempt to make it do so had missing brackets in the path construction which rendered it useless. This PR contains a commit to fix that.

Test coding system databases live at a different path to production ones, which fails the logic in this check where the above env var is set. Previously, it was bypassed for tests running in docker. This PR also contains a commit to bypass it for tests running locally (i.e. outside of docker).