### PR TITLE
Add permissions for CodeQL Analysis action

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -21,7 +21,10 @@ on:
   schedule:
     - cron: '16 2 * * 5'
 
-permissions: {}
+permissions:
+  actions: read
+  contents: read
+  security-events: write
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}


### PR DESCRIPTION
As it fails with the restrictive permissions.