### PR TITLE
Install uv on GHA runner

### DIFF
--- a/.github/workflows/update-python-dependencies.yml
+++ b/.github/workflows/update-python-dependencies.yml
@@ -23,6 +23,7 @@ jobs:
     - uses: opensafely-core/setup-action@5b3030fbbcf069c94e352b4f0a94100fae4dbd82 # v1.6.1
       with:
         install-just: true
+        install-uv: true
 
     - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
       id: generate-token


### PR DESCRIPTION
We recently moved dependency management over to uv locally and in CI. Most of our workflows do not use uv in CI, and only require uv for processes that run inside docker containers where uv is installed.

However, our update-dependencies workflow runs a 'bump-cutoff' recipe. This recipe first tries to execute uvx but because uv isn't installed on the runner, the workflow fails.

This PR adds the uv install we need on the runner for this workflow.