### PR TITLE
Update medication banner behaviour

### DIFF
--- a/codelists/tests/views/test_version.py
+++ b/codelists/tests/views/test_version.py
@@ -3,10 +3,6 @@ import re
 from bs4 import BeautifulSoup
 from django.urls import reverse
 
-from builder.actions import save as save_for_review
-from codelists.actions import publish_version
-from codelists.models import Status
-
 from .helpers import force_login
 
 
@@ -46,34 +42,66 @@ def test_non_builder_compatible_coding_system(client, dmd_version_asthma_medicat
     assert rsp.status_code == 200
 
 
-def test_medication_banner_only_on_published(client, dmd_version_asthma_medication):
-    # The banner is not visible on an unpublished dm+d codelist version
-    rsp = client.get(dmd_version_asthma_medication.get_absolute_url())
-    assert rsp.status_code == 200
-    assert b"Medication codelists can quickly become outdated" not in rsp.content
+def test_medication_banner_visible_for_outdated_coding_system_release(
+    client,
+    create_coding_system_release,
+    dmd_version_asthma_medication,
+    dmd_version_asthma_medication_published,
+):
+    """Test medication warning banner is shown for Under review and Published codelist versions that use an outdated coding system release."""
 
-    # The banner is visible on a published dm+d codelist version
-    publish_version(version=dmd_version_asthma_medication)
+    # Create a newer dm+d release so the version used to build the codelists under test becomes outdated
+    create_coding_system_release("dmd")
+
+    # dmd_version_asthma_medication = Under Review.
     rsp = client.get(dmd_version_asthma_medication.get_absolute_url())
     assert rsp.status_code == 200
     assert b"Medication codelists can quickly become outdated" in rsp.content
 
+    rsp = client.get(dmd_version_asthma_medication_published.get_absolute_url())
+    assert rsp.status_code == 200
+    assert b"Medication codelists can quickly become outdated" in rsp.content
 
-def test_medication_banner_only_on_medication(
-    client, bnf_version_asthma, latest_published_version
+
+def test_medication_banner_visible_with_dmd_or_bnf_coding_systems_only(
+    client, create_coding_system_release, bnf_version_asthma, latest_published_version
 ):
-    # The banner is not visible on a published SNOMED CT codelist (latest_published_version)
+    """Test medication warning banner is only visible for codelist versions that use a medication coding system"""
+
+    # Create newer snomedct and bnf releases so the versions used to
+    # build the codelists under test become outdated
+    create_coding_system_release("snomedct")
+    create_coding_system_release("bnf")
+
     rsp = client.get(latest_published_version.get_absolute_url())
     assert rsp.status_code == 200
     assert b"Medication codelists can quickly become outdated" not in rsp.content
 
-    # The banner is visible on a published BNF codelist (bnf_version_asthma)
     rsp = client.get(bnf_version_asthma.get_absolute_url())
     assert rsp.status_code == 200
     assert b"Medication codelists can quickly become outdated" in rsp.content
 
 
-def test_medication_banner_for_owner_of_codelist(client, bnf_version_asthma):
+def test_medication_banner_not_visible_for_current_coding_system_release(
+    client, bnf_version_asthma
+):
+    """Test medication warning banner is not shown when a codelist version uses the current coding system release"""
+
+    rsp = client.get(bnf_version_asthma.get_absolute_url())
+    assert rsp.status_code == 200
+    assert b"Medication codelists can quickly become outdated" not in rsp.content
+
+
+def test_medication_banner_for_owner_of_codelist(
+    client,
+    create_coding_system_release,
+    bnf_version_asthma,
+    dmd_version_asthma_medication,
+):
+    # Create newer BNF and dm+d releases so the meds banner is shown.
+    create_coding_system_release("bnf")
+    create_coding_system_release("dmd")
+
     # If you can't create a new version (not the owner or in the org) then you
     # are offered to "create your own" rather than "create a new version"
     rsp = client.get(bnf_version_asthma.get_absolute_url())
@@ -94,12 +122,7 @@ def test_medication_banner_for_owner_of_codelist(client, bnf_version_asthma):
 
     # If you can create a new version (the owner or in the org), and there is
     # not already a draft version, then you are invited to "create a new version"
-    bnf_draft_version = bnf_version_asthma.codelist.versions.filter(
-        status=Status.DRAFT
-    ).first()
-    save_for_review(draft=bnf_draft_version)
-    publish_version(version=bnf_draft_version)
-    rsp = client.get(bnf_version_asthma.get_absolute_url())
+    rsp = client.get(dmd_version_asthma_medication.get_absolute_url())
     assert rsp.status_code == 200
     assert b"create your own" not in rsp.content
     assert b"create a new version" in rsp.content

--- a/codelists/views/version.py
+++ b/codelists/views/version.py
@@ -2,10 +2,15 @@ from django.contrib import messages
 from django.shortcuts import render
 from django.utils.html import format_html
 
+from coding_systems.versioning.models import CodingSystemRelease
+
 from ..models import Status
 from ..presenters import present_search_results
 from ..tree_data import build_tree_data
 from .decorators import load_version
+
+
+MEDICATION_WARNING_BANNER_CODING_SYSTEMS = ["dmd", "bnf"]
 
 
 @load_version
@@ -66,6 +71,16 @@ def version(request, clv):
     except AttributeError:
         latest_published_version_url = None
 
+    # Check whether this codelist was built from an outdated coding system release,
+    # so we know whether to show the medication warning banner.
+    if clv.coding_system_id in MEDICATION_WARNING_BANNER_CODING_SYSTEMS:
+        coding_system_release_outdated = CodingSystemRelease.objects.filter(
+            coding_system=clv.coding_system_id,
+            valid_from__gt=clv.coding_system_release.valid_from,
+        ).exists()
+    else:
+        coding_system_release_outdated = False
+
     ctx = {
         "clv": clv,
         "codelist": clv.codelist,
@@ -80,5 +95,6 @@ def version(request, clv):
         "tree_data": tree_data,
         "latest_published_version_url": latest_published_version_url,
         "count_codes_included": len(rows),
+        "coding_system_release_outdated": coding_system_release_outdated,
     }
     return render(request, "codelists/version.html", ctx)

--- a/codelists/views/version.py
+++ b/codelists/views/version.py
@@ -74,10 +74,14 @@ def version(request, clv):
     # Check whether this codelist was built from an outdated coding system release,
     # so we know whether to show the medication warning banner.
     if clv.coding_system_id in MEDICATION_WARNING_BANNER_CODING_SYSTEMS:
-        coding_system_release_outdated = CodingSystemRelease.objects.filter(
-            coding_system=clv.coding_system_id,
-            valid_from__gt=clv.coding_system_release.valid_from,
-        ).exists()
+        coding_system_release_outdated = (
+            CodingSystemRelease.objects.ready()
+            .filter(
+                coding_system=clv.coding_system_id,
+                valid_from__gt=clv.coding_system_release.valid_from,
+            )
+            .exists()
+        )
     else:
         coding_system_release_outdated = False
 

--- a/opencodelists/tests/fixtures.py
+++ b/opencodelists/tests/fixtures.py
@@ -101,6 +101,7 @@ AB  239964003  Soft tissue lesion of elbow region                       X
 
 import csv
 from copy import deepcopy
+from datetime import date
 from io import StringIO
 from pathlib import Path
 
@@ -123,6 +124,7 @@ from codelists.coding_systems import CODING_SYSTEMS, most_recent_database_alias
 from codelists.models import Status
 from codelists.search import do_search
 from coding_systems.base.coding_system_base import BuilderCompatibleCodingSystem
+from coding_systems.versioning.models import CodingSystemRelease, ReleaseState
 from opencodelists.actions import (
     add_user_to_organisation,
     create_organisation,
@@ -1022,3 +1024,53 @@ def icd10_data():
         "icd10.icd10_test_20200101.json",
     )
     call_command("loaddata", path, database="icd10_test_20200101")
+
+
+# Fixtures for testing the medication warning banner
+@pytest.fixture
+def dmd_version_asthma_medication_published(
+    dmd_codelist,
+    dmd_version_asthma_medication,
+):
+    version = create_old_style_version(
+        codelist=dmd_codelist,
+        csv_data=dmd_version_asthma_medication.csv_data,
+        coding_system_database_alias=most_recent_database_alias("dmd"),
+    )
+
+    version.status = Status.PUBLISHED
+    version.save()
+
+    return version
+
+
+@pytest.fixture
+def create_coding_system_release():
+    """
+    Create a CodingSystemRelease that is newer than the fixture data.
+
+    Args:
+        coding_system (str): Coding system identifier, e.g. "dmd", "bnf", or "snomedct".
+
+    Defaults:
+        release_name = f"test_{coding_system}"
+        valid_from = date.today()
+        state = ReleaseState.READY
+
+    Note:
+        This fixture creates a CodingSystemRelease record only. It does not create or configure
+        a corresponding coding system database. Tests that exercise code
+        which accesses release.database_alias may require a real
+        configured coding system database.
+    """
+
+    def make_new_coding_system_release(coding_system):
+        new_coding_system_release = CodingSystemRelease.objects.create(
+            coding_system=coding_system,
+            release_name=f"test_{coding_system}",
+            valid_from=date.today(),
+            state=ReleaseState.READY,
+        )
+        return new_coding_system_release
+
+    return make_new_coding_system_release

--- a/templates/codelists/version.html
+++ b/templates/codelists/version.html
@@ -333,10 +333,8 @@
     </div>
 
     <div class="col-md-9">
-      {% if clv.is_published %}
-        {% if clv.coding_system_id == "dmd" or clv.coding_system_id == "bnf" %}
-          {% include "./_medication_warning_banner.html" %}
-        {% endif %}
+      {% if coding_system_release_outdated %}
+        {% include "./_medication_warning_banner.html" %}
       {% endif %}
       <ul id="tab-list" class="nav nav-tabs" role="tablist">
         {% include "./_tab_nav.html" with label="About" tabname="about" active=True %}


### PR DESCRIPTION
Fixes #3059. Note: User research findings mentioned in the issue will be shared separately in the TeamREX Slack channel.

Following user feedback and [team discussion](https://bennettoxford.slack.com/archives/C069SADHP1Q/p1779357784043099), the medication warning banner banner is now shown when a codelist version was built using an outdated dm+d or BNF coding system release, rather than being tied to publication status.

A coding system release is considered outdated when a newer release is available in OpenCodelists for the same coding system.