### PR TITLE
Remove `djhtml` hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,13 +23,6 @@ repos:
     - id: check-yaml
     - id: detect-private-key
 
-  - repo: https://github.com/rtts/djhtml
-    rev: 8577ec017145d76a0b954ebb7cb3169d4303014c # v3.0.8
-    hooks:
-      - id: djhtml
-        entry: djhtml --tabwidth 2 # Use a tabwidth of 2 for HTML files
-        files: ^templates/.*\.html$ # Indent only HTML files in template directories
-
   - repo: local
     hooks:
     - id: shellcheck


### PR DESCRIPTION
Originally, the intent was to remove third-party hooks and replace them with inlined versions.

However, on looking, it seems that we already run `djhtml` in `just check`, so removing the additional hook is an improvement because:

* we already run this in the hook that uses [`just check`](https://github.com/opensafely-core/opencodelists/blob/8ef2e4111e51b8c858ff5537bb39c5e49a9aa9a6/justfile#L178-L181), so we're effectively running it twice, two different ways
* it removes the third-party hook dependency
* it stops the third-party hook going out of version sync with the version of `djhtml`