### PR TITLE
Fix bnfdmd mapping release import

### DIFF
--- a/mappings/bnfdmd/import_data.py
+++ b/mappings/bnfdmd/import_data.py
@@ -1,4 +1,4 @@
-import os
+from pathlib import Path
 from tempfile import TemporaryDirectory
 from zipfile import ZipFile
 
@@ -50,6 +50,9 @@ def import_release(release_zipfile, release_name, valid_from):
         release_zip = ZipFile(str(release_zipfile))
         logger.info("Extracting", release_zip=release_zip.filename)
         release_zip.extractall(path=tempdir)
-        import_data(
-            os.path.join(tempdir, release_zipfile.name.replace(".zip", ".xlsx"))
-        )
+        xlsx_files = list(Path(tempdir).rglob("*.xlsx"))
+        if len(xlsx_files) != 1:
+            raise ValueError(
+                f"Expected exactly one .xlsx file in {release_zipfile}, found {xlsx_files}"
+            )
+        import_data(str(xlsx_files[0]))

--- a/mappings/bnfdmd/tests/test_import_data.py
+++ b/mappings/bnfdmd/tests/test_import_data.py
@@ -1,3 +1,8 @@
+from unittest.mock import patch
+from zipfile import ZipFile
+
+import pytest
+
 from mappings.bnfdmd.import_data import import_release
 from mappings.bnfdmd.models import Mapping
 
@@ -35,3 +40,81 @@ def test_import_release():
         mapping = Mapping.objects.get(dmd_type=dmd_type)
         assert mapping.dmd_code == dmd
         assert mapping.bnf_concept_id == bnf
+
+
+@pytest.mark.parametrize(
+    "workbook_zip_archive_path",
+    [
+        pytest.param(
+            "BNF Snomed Mapping data 20260519.xlsx",
+            id="root-xlsx-matching-zip-name",
+        ),
+        pytest.param(
+            "BNF+Snomed+Mapping+data+20260319.xlsx",
+            id="root-xlsx-not-matching-zip-name",
+        ),
+        pytest.param(
+            "BNF Snomed Mapping data 20260519/BNF Snomed Mapping data 20260519.xlsx",
+            id="nested-xlsx-matching-zip-name",
+        ),
+        pytest.param(
+            "BNF Snomed Mapping data 20260519/BNF+Snomed+Mapping+data+20260319.xlsx",
+            id="nested-xlsx-not-matching-zip-name",
+        ),
+    ],
+)
+def test_import_release_passes_correct_xlsx_path_to_import_data(
+    tmp_path, workbook_zip_archive_path
+):
+    """
+    Test that import_release() passes the correct xlsx workbook path to import_data().
+    """
+    zip_path = tmp_path / "BNF Snomed Mapping data 20260519.zip"
+
+    # The NHSBSA BNF SNOMED mapping release is a ZIP file containing one XLSX workbook.
+    with ZipFile(zip_path, "w") as zip_file:
+        zip_file.writestr(
+            workbook_zip_archive_path,
+            "dummy_workbook_data",
+        )
+
+    with patch("mappings.bnfdmd.import_data.import_data") as mock_import_data:
+        import_release(zip_path, None, None)
+
+    mock_import_data.assert_called_once()
+
+    workbook_path = mock_import_data.call_args.args[0]
+
+    assert workbook_path.endswith(workbook_zip_archive_path)
+
+
+@pytest.mark.parametrize(
+    "zip_archive_files",
+    [
+        pytest.param({}, id="no-files"),
+        pytest.param(
+            {"README.txt": "non-workbook contents"},
+            id="no-xlsx-files",
+        ),
+        pytest.param(
+            {
+                "workbook file_1.xlsx": "workbook 1 contents",
+                "workbook file_2.xlsx": "workbook 2 contents",
+            },
+            id="two-xlsx-files",
+        ),
+    ],
+)
+def test_import_release_error_if_xlsx_count_not_one(tmp_path, zip_archive_files):
+    """
+    Test that import_release() raises an error if the extracted archive does not
+    contain exactly one .xlsx file.
+    """
+    zip_path = tmp_path / "BNF Snomed Mapping data 20260519.zip"
+
+    with ZipFile(zip_path, "w") as zip_file:
+        for path_to_file, contents in zip_archive_files.items():
+            zip_file.writestr(path_to_file, contents)
+
+    with pytest.raises(ValueError, match="Expected exactly one .xlsx file"):
+        import_release(zip_path, None, None)


### PR DESCRIPTION
New [BNF/dm+d (SNOMED) mapping data](https://www.nhsbsa.nhs.uk/prescription-data/understanding-our-data/bnf-snomed-mapping) is released by the NHS Business Services Authority (NHSBSA) every month. Every Wednesday we run a cron job that downloads and imports the latest mapping release.

The mapping data is downloaded as a ZIP file with an `.xlsx` workbook inside it. During the import process, `import_release()` extracts the ZIP, and then runs `import_data()` passing in the full path to the workbook file that the mapping data should be imported from.

Previously, `import_release()` assumed that the workbook had the same filename as the ZIP file (with `.xlsx` instead of `.zip`). However, for the May 2026 release, the workbook had a different filename from the ZIP file, meaning the path passed to `import_data()` was incorrect. This caused a `FileNotFoundError` and triggered a [Sentry alert](https://ebm-datalab.sentry.io/issues/7510271220/?alert_rule_id=1877862&alert_type=issue&notification_uuid=0dc684c5-96e8-40d5-9065-9ed963e578de&project=5248013&referrer=slack&statsPeriod=90d). 

### Work done:
Updated the `import_release()` to get the path to the workbook from the extracted ZIP contents, rather than constructing a path from the ZIP filename. `import_release()` now also checks that we find exactly one workbook (expected) before calling `import_data()`, and raises an error if not. Thank you for the [suggestions](https://bennettoxford.slack.com/archives/C069SADHP1Q/p1780578444868179?thread_ts=1780562790.214199&cid=C069SADHP1Q) @nishtha-kalra  :) 

### Testing:
Added tests covering different workbook filename formats, archive layouts, and workbook counts (zero, and multiple `.xlsx` files).