### PR TITLE
Check for and fix incorrect django settings imports

### DIFF
--- a/opencodelists/management/commands/remove_spam_users.py
+++ b/opencodelists/management/commands/remove_spam_users.py
@@ -1,13 +1,13 @@
 import csv
 from datetime import datetime
 
+from django.conf import settings
 from django.core.management import BaseCommand
 from django.db import transaction
 from django.db.models import F, Q
 
 from codelists.models import Collaboration, Handle, SignOff
 from opencodelists.models import Membership, User
-from opencodelists.settings import DATABASE_DIR
 
 
 class Command(BaseCommand):
@@ -105,7 +105,7 @@ class Command(BaseCommand):
         userfields = [f.name for f in User._meta.fields if f != "password"]
 
         # dump them to csv just in case
-        dump_path = DATABASE_DIR / "deleted-user-dumps"
+        dump_path = settings.DATABASE_DIR / "deleted-user-dumps"
         dump_path.mkdir(parents=False, exist_ok=True)
         dump_file_path = dump_path / f"deletedusers_{datetime.now().isoformat()}.csv"
         with (dump_file_path).open("w") as f:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -108,6 +108,7 @@ extend-select = [
   "ISC",  # flake8-implicit-str-concat
   "UP",  # pyupgrade
   "W",  # pycodestyle warning
+  "TID251", # banned imports
 ]
 extend-ignore = [
   "E501",
@@ -122,6 +123,9 @@ lines-after-imports = 2
 "manage.py" = ["INP001"]
 "codelists/views/__init__.py" = ["F401"]
 "opencodelists/views/__init__.py" = ["F401"]
+
+[tool.ruff.lint.flake8-tidy-imports.banned-api]
+"opencodelists.settings".msg = "Use 'from django.conf import settings' instead."
 
 # Note: any `exclude-newer-package` timestamps should be removed if > 7 days old.
 # See https://github.com/opensafely-core/opencodelists/blob/main/DEVELOPERS.md for details.


### PR DESCRIPTION
Django project settings should be imported `from django.config` per [the django docs](https://docs.djangoproject.com/en/6.0/topics/settings/#using-settings-in-python-code), not from the project root.

At @iaindillingham 's suggestion, this PR introduces a `ruff` rule to check for this, and a commit that fixes the one instance that was found to contravene this rule.