### PR TITLE
Restyle organisation codelists templates

### DIFF
--- a/codelists/tests/views/test_organisations.py
+++ b/codelists/tests/views/test_organisations.py
@@ -51,6 +51,16 @@ def test_paginate_published_codelists(client, organisation, create_codelists):
     assert len(page_obj.object_list) == min(50, len(published_for_organisation) - 50)
 
 
+def test_published_pagination_preserves_search_query(
+    client, organisation, create_codelists
+):
+    create_codelists(70, owner=organisation, status=Status.PUBLISHED)
+
+    rsp = client.get(f"/codelist/{organisation.slug}/", {"q": "Codelist"})
+
+    assert 'href="?page=2&q=Codelist"' in rsp.content.decode()
+
+
 def test_published_index_does_not_duplicate_codelists_with_multiple_published_versions(
     client, organisation, null_codelist
 ):

--- a/templates/_partials/organisation_header.html
+++ b/templates/_partials/organisation_header.html
@@ -1,0 +1,41 @@
+<h2 class="text-2xl/tight font-bold text-slate-900">{{ title }}</h2>
+<p class="mt-2 text-base/snug text-slate-700">{{ description }}</p>
+
+<form
+  action="{{ request_path }}"
+  class="plausible-event-name=Search+button+click mt-6 max-w-2xl"
+  method="get"
+  role="search"
+>
+  <label class="w-fit cursor-pointer font-bold" for="search-codelists">
+    Search for a codelist
+  </label>
+  <div class="flex flex-row items-stretch gap-2">
+    <input
+      aria-label="Search for codelists published by {{ organisation_name }}"
+      class="block w-full rounded-md border border-slate-300 bg-white px-4 py-3 text-base text-slate-900 placeholder:text-slate-600 focus:border-blue-600 focus:ring-2 focus:ring-blue-600/20 focus:outline-none"
+      id="search-codelists"
+      name="q"
+      placeholder="Enter a codelist name…"
+      type="search"
+      value="{{ search_query|default:'' }}"
+    />
+
+    <button
+      class="flex w-fit cursor-pointer items-center justify-center rounded-md border border-blue-700 bg-blue-700 px-6 text-sm/6 font-semibold whitespace-nowrap text-white shadow-xs transition-colors hover:border-blue-600 hover:bg-blue-600 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-700"
+      type="submit"
+    >
+      Search
+    </button>
+
+    {% if search_query %}
+      <a
+        class="flex w-fit cursor-pointer items-center justify-center rounded-md border border-blue-700 bg-white px-6 text-sm/6 font-semibold whitespace-nowrap text-blue-700 shadow-xs transition-colors hover:border-blue-600 hover:bg-blue-50 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-700"
+        href="{{ request_path }}"
+        role="button"
+      >
+        Clear
+      </a>
+    {% endif %}
+  </div>
+</form>

--- a/templates/_partials/organisation_table.html
+++ b/templates/_partials/organisation_table.html
@@ -1,0 +1,48 @@
+{% load text_filters %}
+
+<div class="mt-8 flow-root xl:mx-auto xl:max-w-384 px-4 xl:px-12">
+  <div class="-my-2 overflow-x-auto -mx-2">
+    <div class="inline-block min-w-full py-2 align-middle px-2">
+      <div class="overflow-hidden shadow-sm outline-1 outline-black/5 sm:rounded-lg">
+        <table class="relative min-w-full divide-y divide-slate-200">
+          <thead class="border-b-slate-300 bg-slate-100 text-left text-sm font-semibold text-slate-900">
+            <tr>
+              <th class="px-3 py-3.5 pl-4 whitespace-nowrap sm:pl-6">Name</th>
+              <th class="px-3 py-3.5 whitespace-nowrap">Coding system</th>
+              <th class="px-3 py-3.5 whitespace-nowrap">Description</th>
+              <th class="px-3 py-3.5 pr-3 whitespace-nowrap sm:pr-6">Last updated</th>
+            </tr>
+          </thead>
+          <tbody>
+            {% for codelist in page_obj %}
+              <tr
+                class="bg-white align-top text-sm/relaxed text-slate-900 even:bg-slate-50 hover:bg-yellow-50"
+              >
+                <td class="px-3 py-2 pl-4 text-base/snug font-semibold sm:pl-6">
+                  <a class="link" href="{{ codelist.get_absolute_url }}">
+                    {{ codelist.name }}
+                  </a>
+                </td>
+                <td class="px-3 py-2 whitespace-nowrap">{{ codelist.coding_system_short_name }}</td>
+                <td class="px-3 py-2 max-w-prose">
+                  {% if codelist.description %}
+                    {{ codelist.description|truncatechars:500|truncatelines:4|linebreaksbr }}
+                  {% endif %}
+                </td>
+                <td class="px-3 py-2 pr-3 sm:pr-6">
+                  <time class="whitespace-nowrap" datetime="{{ codelist.updated_at|date:"c" }}">
+                    {{ codelist.updated_at|date:'d M Y' }}
+                  </time>
+                </td>
+              </tr>
+            {% empty %}
+              <tr class="bg-white align-top text-sm/relaxed text-slate-900">
+                <td class="px-3 py-2 pl-4 text-base/snug font-semibold sm:pl-6" colspan="4">No codelist found</td>
+              </tr>
+            {% endfor %}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  </div>
+</div>

--- a/templates/_partials/organisation_table.html
+++ b/templates/_partials/organisation_table.html
@@ -42,6 +42,10 @@
             {% endfor %}
           </tbody>
         </table>
+
+        {% if page_obj.has_other_pages %}
+          {% include "_partials/organisation_table_pagination.html" with page_obj=page_obj q=q only %}
+        {% endif %}
       </div>
     </div>
   </div>

--- a/templates/_partials/organisation_table.html
+++ b/templates/_partials/organisation_table.html
@@ -7,39 +7,69 @@
         <table class="relative min-w-full divide-y divide-slate-200">
           <thead class="border-b-slate-300 bg-slate-100 text-left text-sm font-semibold text-slate-900">
             <tr>
-              <th class="px-3 py-3.5 pl-4 whitespace-nowrap sm:pl-6">Name</th>
-              <th class="px-3 py-3.5 whitespace-nowrap">Coding system</th>
-              <th class="px-3 py-3.5 whitespace-nowrap">Description</th>
-              <th class="px-3 py-3.5 pr-3 whitespace-nowrap sm:pr-6">Last updated</th>
+              {% if under_review_codelists %}
+                <th class="px-3 py-3.5 pl-4 whitespace-nowrap sm:pl-6">Name</th>
+                <th class="px-3 py-3.5 whitespace-nowrap">Version</th>
+                <th class="px-3 py-3.5 pr-3 whitespace-nowrap sm:pr-6">Created</th>
+              {% else %}
+                <th class="px-3 py-3.5 pl-4 whitespace-nowrap sm:pl-6">Name</th>
+                <th class="px-3 py-3.5 whitespace-nowrap">Coding system</th>
+                <th class="px-3 py-3.5 whitespace-nowrap">Description</th>
+                <th class="px-3 py-3.5 pr-3 whitespace-nowrap sm:pr-6">Last updated</th>
+              {% endif %}
             </tr>
           </thead>
           <tbody>
-            {% for codelist in page_obj %}
-              <tr
-                class="bg-white align-top text-sm/relaxed text-slate-900 even:bg-slate-50 hover:bg-yellow-50"
-              >
-                <td class="px-3 py-2 pl-4 text-base/snug font-semibold sm:pl-6">
-                  <a class="link" href="{{ codelist.get_absolute_url }}">
-                    {{ codelist.name }}
-                  </a>
-                </td>
-                <td class="px-3 py-2 whitespace-nowrap">{{ codelist.coding_system_short_name }}</td>
-                <td class="px-3 py-2 max-w-prose">
-                  {% if codelist.description %}
-                    {{ codelist.description|truncatechars:500|truncatelines:4|linebreaksbr }}
-                  {% endif %}
-                </td>
-                <td class="px-3 py-2 pr-3 sm:pr-6">
-                  <time class="whitespace-nowrap" datetime="{{ codelist.updated_at|date:"c" }}">
-                    {{ codelist.updated_at|date:'d M Y' }}
-                  </time>
-                </td>
-              </tr>
-            {% empty %}
-              <tr class="bg-white align-top text-sm/relaxed text-slate-900">
-                <td class="px-3 py-2 pl-4 text-base/snug font-semibold sm:pl-6" colspan="4">No codelist found</td>
-              </tr>
-            {% endfor %}
+            {% if under_review_codelists %}
+              {% for version in page_obj %}
+                <tr
+                  class="bg-white align-top text-sm/relaxed text-slate-900 even:bg-slate-50 hover:bg-yellow-50"
+                >
+                  <td class="px-3 py-2 pl-4 text-base/snug font-semibold sm:pl-6">
+                    <a class="link" href="{{ version.get_absolute_url }}">
+                      {{ version.codelist.name }}
+                    </a>
+                  </td>
+                  <td class="px-3 py-2 whitespace-nowrap tabular-nums">{{ version.tag_or_hash }}</td>
+                  <td class="px-3 py-2 pr-3 sm:pr-6">
+                    <time class="whitespace-nowrap" datetime="{{ version.created_at|date:"c" }}">
+                      {{ version.created_at|date:'d M Y' }}
+                    </time>
+                  </td>
+                </tr>
+              {% empty %}
+                <tr class="bg-white align-top text-sm/relaxed text-slate-900">
+                  <td class="px-3 py-2 pl-4 text-base/snug font-semibold sm:pl-6" colspan="4">No codelist found</td>
+                </tr>
+              {% endfor %}
+            {% else %}
+              {% for codelist in page_obj %}
+                <tr
+                  class="bg-white align-top text-sm/relaxed text-slate-900 even:bg-slate-50 hover:bg-yellow-50"
+                >
+                  <td class="px-3 py-2 pl-4 text-base/snug font-semibold sm:pl-6">
+                    <a class="link" href="{{ codelist.get_absolute_url }}">
+                      {{ codelist.name }}
+                    </a>
+                  </td>
+                  <td class="px-3 py-2 whitespace-nowrap">{{ codelist.coding_system_short_name }}</td>
+                  <td class="px-3 py-2 max-w-prose">
+                    {% if codelist.description %}
+                      {{ codelist.description|truncatechars:500|truncatelines:4|linebreaksbr }}
+                    {% endif %}
+                  </td>
+                  <td class="px-3 py-2 pr-3 sm:pr-6">
+                    <time class="whitespace-nowrap" datetime="{{ codelist.updated_at|date:"c" }}">
+                      {{ codelist.updated_at|date:'d M Y' }}
+                    </time>
+                  </td>
+                </tr>
+              {% empty %}
+                <tr class="bg-white align-top text-sm/relaxed text-slate-900">
+                  <td class="px-3 py-2 pl-4 text-base/snug font-semibold sm:pl-6" colspan="4">No codelist found</td>
+                </tr>
+              {% endfor %}
+            {% endif %}
           </tbody>
         </table>
 

--- a/templates/_partials/organisation_table_pagination.html
+++ b/templates/_partials/organisation_table_pagination.html
@@ -1,0 +1,69 @@
+{% with current_plus_3=page_obj.number|add:'3' current_minus_3=page_obj.number|add:'-3' %}
+  <div class="flex items-center justify-between border-t border-slate-200 bg-white px-4 py-3 sm:px-6 ">
+    <div class="flex flex-1 justify-between sm:hidden">
+      {% if page_obj.has_previous %}
+        <a href="?page={{ page_obj.previous_page_number }}{% if q %}&q={{ q|urlencode }}{% endif %}" class="relative inline-flex items-center rounded-md border border-slate-300 bg-white px-4 py-2 text-sm font-medium text-slate-700 hover:bg-slate-50">Previous</a>
+      {% endif %}
+      {% if page_obj.has_next %}
+        <a href="?page={{ page_obj.next_page_number }}{% if q %}&q={{ q|urlencode }}{% endif %}" class="relative ml-auto inline-flex items-center rounded-md border border-slate-300 bg-white px-4 py-2 text-sm font-medium text-slate-700 hover:bg-slate-50">Next</a>
+      {% endif %}
+    </div>
+    <div class="hidden sm:flex sm:flex-1 sm:items-center sm:justify-between">
+      <div>
+        <p class="text-sm text-slate-700">
+          Showing
+          <span class="font-medium">{{ page_obj.start_index }}</span>
+          to
+          <span class="font-medium">{{ page_obj.end_index }}</span>
+          of
+          <span class="font-medium">{{ page_obj.paginator.count }}</span>
+          codelists
+        </p>
+      </div>
+      <div>
+        <nav aria-label="Pagination" class="isolate inline-flex -space-x-px rounded-md shadow-xs">
+          {% if page_obj.has_previous %}
+            <a href="?page={{ page_obj.previous_page_number }}{% if q %}&q={{ q|urlencode }}{% endif %}" class="relative inline-flex items-center rounded-l-md px-2 py-2 text-slate-400 inset-ring inset-ring-slate-300 hover:bg-slate-50 focus:z-20 focus:outline-offset-0">
+              <span class="sr-only">Previous</span>
+              <svg viewBox="0 0 20 20" fill="currentColor" data-slot="icon" aria-hidden="true" class="size-5">
+                <path d="M11.78 5.22a.75.75 0 0 1 0 1.06L8.06 10l3.72 3.72a.75.75 0 1 1-1.06 1.06l-4.25-4.25a.75.75 0 0 1 0-1.06l4.25-4.25a.75.75 0 0 1 1.06 0Z" clip-rule="evenodd" fill-rule="evenodd" />
+              </svg>
+            </a>
+          {% endif %}
+
+          {% if page_obj.has_previous %}
+            {% if current_minus_3 >= 1 %}
+              <a href="?page=1{% if q %}&q={{ q|urlencode }}{% endif %}" class="relative inline-flex items-center px-4 py-2 text-sm font-semibold text-slate-900 inset-ring inset-ring-slate-300 hover:bg-slate-50 focus:z-20 focus:outline-offset-0">1</a>
+            {% endif %}
+            {% if current_minus_3 > 1 %}
+              <span class="relative inline-flex items-center px-4 py-2 text-sm font-semibold text-slate-700 inset-ring inset-ring-slate-300 focus:outline-offset-0">...</span>
+            {% endif %}
+          {% endif %}
+
+          {% for page_number in page_obj.paginator.page_range %}
+            {% if page_obj.number == page_number %}
+              <span aria-current="page" class="relative z-10 inline-flex items-center bg-blue-700 px-4 py-2 text-sm font-semibold text-white focus:z-20 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-700">{{ page_number }}</span>
+            {% elif page_number > page_obj.number|add:'-3' and page_number < page_obj.number|add:'3' %}
+              <a href="?page={{ page_number }}{% if q %}&q={{ q|urlencode }}{% endif %}" class="relative inline-flex items-center px-4 py-2 text-sm font-semibold text-slate-900 inset-ring inset-ring-slate-300 hover:bg-slate-50 focus:z-20 focus:outline-offset-0">{{ page_number }}</a>
+            {% endif %}
+          {% endfor %}
+
+          {% if page_obj.has_next %}
+            {% if current_plus_3 < page_obj.paginator.num_pages %}
+              <span class="relative inline-flex items-center px-4 py-2 text-sm font-semibold text-slate-700 inset-ring inset-ring-slate-300 focus:outline-offset-0">...</span>
+            {% endif %}
+            {% if current_plus_3 <= page_obj.paginator.num_pages %}
+              <a href="?page={{ page_obj.paginator.num_pages }}{% if q %}&q={{ q|urlencode }}{% endif %}" class="relative inline-flex items-center px-4 py-2 text-sm font-semibold text-slate-900 inset-ring inset-ring-slate-300 hover:bg-slate-50 focus:z-20 focus:outline-offset-0">{{ page_obj.paginator.num_pages }}</a>
+            {% endif %}
+            <a href="?page={{ page_obj.next_page_number }}{% if q %}&q={{ q|urlencode }}{% endif %}" class="relative inline-flex items-center rounded-r-md px-2 py-2 text-slate-400 inset-ring inset-ring-slate-300 hover:bg-slate-50 focus:z-20 focus:outline-offset-0">
+              <span class="sr-only">Next</span>
+              <svg viewBox="0 0 20 20" fill="currentColor" data-slot="icon" aria-hidden="true" class="size-5">
+                <path d="M8.22 5.22a.75.75 0 0 1 1.06 0l4.25 4.25a.75.75 0 0 1 0 1.06l-4.25 4.25a.75.75 0 0 1-1.06-1.06L11.94 10 8.22 6.28a.75.75 0 0 1 0-1.06Z" clip-rule="evenodd" fill-rule="evenodd" />
+              </svg>
+            </a>
+          {% endif %}
+        </nav>
+      </div>
+    </div>
+  </div>
+{% endwith %}

--- a/templates/codelists/organisation_published.html
+++ b/templates/codelists/organisation_published.html
@@ -23,7 +23,7 @@
         {% include "_partials/organisation_header.html" with organisation_name=organisation.name request_path=request.path search_query=q description="All of the codelists published by "|add:organisation.name title="Published codelists" only %}
       </div>
 
-      {% include "_partials/organisation_table.html" with page_obj=page_obj q=q request=request only %}
+      {% include "_partials/organisation_table.html" with page_obj=page_obj q=q only %}
     </section>
   {% endif %}
 {% endblock full_width_content %}

--- a/templates/codelists/organisation_published.html
+++ b/templates/codelists/organisation_published.html
@@ -1,91 +1,29 @@
-{% extends 'base.html' %}
+{% extends 'base-tw.html' %}
 
 {% load django_vite %}
 
-{% load text_filters %}
+{% block title_extra %}{{ organisation.name }} codelists{% endblock %}
 
 {% block content %}
+  <header class="mb-8 border-b border-b-slate-300 py-8">
+    <h1 class="max-w-prose text-2xl font-bold tracking-tight wrap-break-word text-slate-900 md:text-4xl">
+      {{ organisation.name }} codelists
+    </h1>
+  </header>
 
-  {% if not organisation %}
-    <h1>OpenCodelists</h1>
+  {% if not page_obj and not q %}
+    <p class="text-lg/snug text-slate-700">{{ organisation.name }} has not published any codelists.</p>
+  {% endif %}
+{% endblock content %}
 
-    <div class="mt-3">
-      <p>Welcome to OpenCodelists, created by <a href="https://opensafely.org">OpenSAFELY</a> for creating and sharing codelists.</p>
-      <p>Anybody can also use this tool to create and share codelists.  To get started, take a look at the <a href="/docs/">documentation</a> or watch the videos.<p>
-        <p>If you would like to publish codelists on behalf of an organisation, please <a href="https://opensafely.org/contact/">get in touch</a>.</p>
-        <p>Below, you'll find all the codelists that have been used in <a href="https://opensafely.org/research/">OpenSAFELY research</a> to date.</p>
+{% block full_width_content %}
+  {% if page_obj or q %}
+    <section class="pb-24">
+      <div class="container">
+        {% include "_partials/organisation_header.html" with organisation_name=organisation.name request_path=request.path search_query=q description="All of the codelists published by "|add:organisation.name title="Published codelists" only %}
       </div>
 
-        <div class="row my-2">
-          <div class="col-md-6">
-            <div class="youtube-embed">
-              <lite-youtube
-                class="plausible-event-name=Video+Click"
-                videoid="ayRtpbcPFLA"
-                params="controls=1&rel=0&enablejsapi=1"
-              ></lite-youtube>
-            </div>
-          </div>
-          <div class="col-md-6">
-            <lite-youtube
-              class="plausible-event-name=Video+Click"
-              videoid="t-A2kWHZ5lA"
-              params="controls=1&rel=0&enablejsapi=1"
-            ></lite-youtube>
-          </div>
-        </div>
-
-        <hr />
+      {% include "_partials/organisation_table.html" with page_obj=page_obj q=q request=request only %}
+    </section>
   {% endif %}
-
-  <h2 class="h3">
-    {% if organisation %}
-      {{ organisation.name }} codelists
-    {% else %}
-      All codelists
-    {% endif %}
-  </h2>
-  <br />
-
-  {% include "codelists/_search_form.html" %}
-
-  <div class="row">
-    <div class="col-12">
-      <dl class="home-codelists">
-        {% for codelist in page_obj %}
-          <dt>
-            <a href="{{ codelist.get_absolute_url }}">{{ codelist.name }}</a>
-            <span class="badge badge-secondary">{{ codelist.coding_system_short_name }}</span>
-          </dt>
-          <dd>
-
-            {% if codelist.description %}
-              <div>
-                {{ codelist.description|truncatechars:500|truncatelines:4|linebreaksbr }}
-              </div>
-            {% endif %}
-
-            {% if not organisation %}
-              <div>Published by <a href="{% url 'codelists:organisation_published' codelist.organisation_id %}">{{ codelist.organisation.name }}</a></div>
-            {% endif %}
-          </dd>
-        {% endfor %}
-      </dl>
-    </div>
-
-    {% include "./_pagination.html" with page_obj=page_obj %}
-
-  </div>
-{% endblock %}
-
-{% block above_footer %}
-  {% if q %}
-    {% include "_feedback_form.html" %}
-  {% endif %}
-{% endblock %}
-
-{% block extra_js %}
-  {% if q %}
-    {% vite_asset "assets/src/scripts/feedback-form.js" %}
-  {% endif %}
-{% endblock %}
+{% endblock full_width_content %}

--- a/templates/codelists/organisation_review.html
+++ b/templates/codelists/organisation_review.html
@@ -1,26 +1,29 @@
-{% extends 'codelists/index.html' %}
+{% extends 'base-tw.html' %}
 
+{% load django_vite %}
+
+{% block title_extra %}{{ organisation.name }} codelists under review{% endblock %}
 
 {% block content %}
+  <header class="mb-8 border-b border-b-slate-300 py-8">
+    <h1 class="max-w-prose text-2xl font-bold tracking-tight wrap-break-word text-slate-900 md:text-4xl">
+      {{ organisation.name }} codelists under review
+    </h1>
+  </header>
 
-  <h3>{{ organisation.name }}: codelists under review</h3>
-  <br />
+  {% if not page_obj and not q %}
+    <p class="text-lg/snug text-slate-700">{{ organisation.name }} does not have any codelists under review.</p>
+  {% endif %}
+{% endblock content %}
 
-  {% include "codelists/_search_form.html" %}
+{% block full_width_content %}
+  {% if page_obj or q %}
+    <section class="pb-24">
+      <div class="container">
+        {% include "_partials/organisation_header.html" with organisation_name=organisation.name request_path=request.path search_query=q description="All of the under review codelists by "|add:organisation.name title="Under review codelists" only %}
+      </div>
 
-  <div class="row">
-    <div class="col-12">
-      <dl class="home-codelists">
-        {% for version in page_obj %}
-          <dt>
-            <a href="{{ version.get_absolute_url }}">{{ version.codelist.name }} - version {{ version.tag_or_hash }}</a>
-          </dt>
-          <dd>
-        {% endfor %}
-      </dl>
-    </div>
-
-    {% include "./_pagination.html" with page_obj=page_obj %}
-
-  </div>
-{% endblock %}
+      {% include "_partials/organisation_table.html" with page_obj=page_obj q=q under_review_codelists=True only %}
+    </section>
+  {% endif %}
+{% endblock full_width_content %}


### PR DESCRIPTION
Part of fixes #3058

Update the new organisation templates to use Tailwind styles. Use includes for the tables passing only the context required for each template to show.

# Screenshots

## Before

<img width="600" alt="" src="https://github.com/user-attachments/assets/ed2c6b43-31fa-4d42-8d49-0a626db70334" />
<hr />
<img width="600" alt="" src="https://github.com/user-attachments/assets/01bcb1cf-289c-4aec-9eba-82bdb30f03e6" />
<hr />
<img width="600" alt="" src="https://github.com/user-attachments/assets/597cbf30-999b-4eb3-8b65-1592a3637515" />
<hr />
<img width="600" alt="" src="https://github.com/user-attachments/assets/1a5b017c-0b75-4b79-ac1f-725be312c7da" />
<hr />
<img width="600" alt="" src="https://github.com/user-attachments/assets/837937d7-73d2-4424-a0ef-a8ef31fbdf58" />
<hr />

## After

<img width="600" alt="" src="https://github.com/user-attachments/assets/e31a39ea-111e-4815-9345-03379df1af96" />
<hr />
<img width="600" alt="" src="https://github.com/user-attachments/assets/2bfb7412-968b-4863-af6a-263d3b42a918" />
<hr />
<img width="600" alt="" src="https://github.com/user-attachments/assets/b5120f6c-80e1-48cb-9b92-520749f65ff7" />
<hr />
<img width="600" alt="" src="https://github.com/user-attachments/assets/3d25c7a5-a94d-4421-b314-e1c90aa3dbef" />
<hr />
<img width="600" alt="" src="https://github.com/user-attachments/assets/21488c5e-526b-4a7c-afa5-4a9abd4a3a23" />
<hr />