### PR TITLE
Enable sorting of organisation codelists

### DIFF
--- a/codelists/tests/views/test_organisations.py
+++ b/codelists/tests/views/test_organisations.py
@@ -1,6 +1,17 @@
+from datetime import datetime
+
+import pytest
+from django.utils import timezone
+
 from codelists.actions import publish_version
-from codelists.models import Handle, Status
+from codelists.models import Codelist, CodelistVersion, Handle, Status
 from opencodelists.list_utils import flatten
+
+
+def aware_datetime(year: int, month: int, day: int) -> datetime:
+    """Return a timezone-aware datetime for deterministic timestamp assertions."""
+
+    return timezone.make_aware(datetime(year, month, day))
 
 
 def test_published_index_only_returns_public_codelists_with_published_versions(
@@ -51,14 +62,76 @@ def test_paginate_published_codelists(client, organisation, create_codelists):
     assert len(page_obj.object_list) == min(50, len(published_for_organisation) - 50)
 
 
-def test_published_pagination_preserves_search_query(
-    client, organisation, create_codelists
+@pytest.mark.parametrize(
+    ("path", "status"),
+    [
+        ("", Status.PUBLISHED),
+        ("under-review/", Status.UNDER_REVIEW),
+    ],
+)
+def test_organisation_pagination_preserves_search_and_sort_query(
+    client, organisation, create_codelists, path, status
 ):
-    create_codelists(70, owner=organisation, status=Status.PUBLISHED)
+    create_codelists(70, owner=organisation, status=status)
 
-    rsp = client.get(f"/codelist/{organisation.slug}/", {"q": "Codelist"})
+    rsp = client.get(
+        f"/codelist/{organisation.slug}/{path}",
+        {"q": "Codelist", "sort": "name", "direction": "desc"},
+    )
 
-    assert 'href="?page=2&q=Codelist"' in rsp.content.decode()
+    assert rsp.context["pagination"]["next_url"] == (
+        "?page=2&q=Codelist&sort=name&direction=desc"
+    )
+    assert 'href="?page=2&amp;q=Codelist&amp;sort=name&amp;direction=desc"' in (
+        rsp.content.decode()
+    )
+
+
+@pytest.mark.parametrize(
+    ("sort", "direction", "expected_names"),
+    [
+        (
+            "name",
+            "asc",
+            ["SNOMED alpha", "SNOMED Bravo", "SNOMED Charlie"],
+        ),
+        (
+            "name",
+            "desc",
+            ["SNOMED Charlie", "SNOMED Bravo", "SNOMED alpha"],
+        ),
+        (
+            "updated_at",
+            "asc",
+            ["SNOMED Charlie", "SNOMED alpha", "SNOMED Bravo"],
+        ),
+        (
+            "updated_at",
+            "desc",
+            ["SNOMED Bravo", "SNOMED alpha", "SNOMED Charlie"],
+        ),
+    ],
+)
+def test_published_codelists_search_and_sort(
+    client, organisation, create_codelist, sort, direction, expected_names
+):
+    bravo = create_codelist("SNOMED Bravo")
+    alpha = create_codelist("SNOMED alpha")
+    charlie = create_codelist("SNOMED Charlie")
+    create_codelist("Ignored published")
+
+    Codelist.objects.filter(pk=bravo.pk).update(updated_at=aware_datetime(2020, 3, 1))
+    Codelist.objects.filter(pk=alpha.pk).update(updated_at=aware_datetime(2020, 2, 1))
+    Codelist.objects.filter(pk=charlie.pk).update(updated_at=aware_datetime(2020, 1, 1))
+
+    rsp = client.get(
+        f"/codelist/{organisation.slug}/",
+        {"q": "SNOMED", "sort": sort, "direction": direction},
+    )
+
+    assert [
+        codelist.name for codelist in rsp.context["page_obj"].object_list
+    ] == expected_names
 
 
 def test_published_index_does_not_duplicate_codelists_with_multiple_published_versions(
@@ -148,6 +221,59 @@ def test_paginate_under_review_versions(client, organisation, create_codelists):
     rsp = client.get(f"/codelist/{organisation.slug}/under-review/?page=2")
     page_obj = rsp.context["page_obj"]
     assert len(page_obj.object_list) == min(50, len(under_review_for_organisation) - 50)
+
+
+@pytest.mark.parametrize(
+    ("sort", "direction", "expected_names"),
+    [
+        (
+            "name",
+            "asc",
+            ["DM+D alpha", "DM+D Bravo", "DM+D Charlie"],
+        ),
+        (
+            "name",
+            "desc",
+            ["DM+D Charlie", "DM+D Bravo", "DM+D alpha"],
+        ),
+        (
+            "created_at",
+            "asc",
+            ["DM+D Charlie", "DM+D alpha", "DM+D Bravo"],
+        ),
+        (
+            "created_at",
+            "desc",
+            ["DM+D Bravo", "DM+D alpha", "DM+D Charlie"],
+        ),
+    ],
+)
+def test_under_review_versions_search_and_sort(
+    client, organisation, create_codelist, sort, direction, expected_names
+):
+    bravo = create_codelist("DM+D Bravo", status=Status.UNDER_REVIEW)
+    alpha = create_codelist("DM+D alpha", status=Status.UNDER_REVIEW)
+    charlie = create_codelist("DM+D Charlie", status=Status.UNDER_REVIEW)
+    create_codelist("Ignored review", status=Status.UNDER_REVIEW)
+
+    CodelistVersion.objects.filter(codelist=bravo).update(
+        created_at=aware_datetime(2020, 3, 1)
+    )
+    CodelistVersion.objects.filter(codelist=alpha).update(
+        created_at=aware_datetime(2020, 2, 1)
+    )
+    CodelistVersion.objects.filter(codelist=charlie).update(
+        created_at=aware_datetime(2020, 1, 1)
+    )
+
+    rsp = client.get(
+        f"/codelist/{organisation.slug}/under-review/",
+        {"q": "DM+D", "sort": sort, "direction": direction},
+    )
+
+    assert (
+        [version.codelist.name for version in rsp.context["page_obj"].object_list]
+    ) == expected_names
 
 
 def test_search_only_returns_codelists_with_under_review_versions(

--- a/codelists/views/organisations.py
+++ b/codelists/views/organisations.py
@@ -32,46 +32,48 @@ def organisation_published(
     request: HttpRequest, organisation_slug: str
 ) -> HttpResponse:
     organisation, handles, q = _get_organisation_handles(request, organisation_slug)
-    sort, direction = _get_sort(request, Status.PUBLISHED)
+    sort_by, sort_direction = _get_sort(request, Status.PUBLISHED)
     published_handles = _handles_with_status(
         handles, Status.PUBLISHED
     ).prefetch_related(_current_handle_prefetch("codelist__handles"))
     codelists = _sort_published_codelists(
-        [handle.codelist for handle in published_handles], sort, direction
+        [handle.codelist for handle in published_handles], sort_by, sort_direction
     )
 
     page_obj = Paginator(codelists, PAGE_SIZE).get_page(request.GET.get("page"))
 
     ctx = {
         "page_obj": page_obj,
-        "pagination": _pagination_context(page_obj, q, (sort, direction)),
+        "pagination": _pagination_context(page_obj, q, sort_by, sort_direction),
         "organisation": organisation,
         "q": q,
-        "sort": sort,
-        "direction": direction,
-        "sort_options": _sort_options_context(q, sort, direction, SORT_FOR_PUBLISHED),
+        "sort_by": sort_by,
+        "sort_direction": sort_direction,
+        "sort_options": _sort_options_context(
+            q, sort_by, sort_direction, SORT_FOR_PUBLISHED
+        ),
     }
     return render(request, "codelists/organisation_published.html", ctx)
 
 
 def organisation_review(request: HttpRequest, organisation_slug: str) -> HttpResponse:
     organisation, handles, q = _get_organisation_handles(request, organisation_slug)
-    sort, direction = _get_sort(request, Status.UNDER_REVIEW)
+    sort_by, sort_direction = _get_sort(request, Status.UNDER_REVIEW)
     versions = _sort_under_review_versions(
-        _under_review_versions(handles), sort, direction
+        _under_review_versions(handles), sort_by, sort_direction
     )
 
     page_obj = Paginator(versions, PAGE_SIZE).get_page(request.GET.get("page"))
 
     ctx = {
         "page_obj": page_obj,
-        "pagination": _pagination_context(page_obj, q, (sort, direction)),
+        "pagination": _pagination_context(page_obj, q, sort_by, sort_direction),
         "organisation": organisation,
         "q": q,
-        "sort": sort,
-        "direction": direction,
+        "sort_by": sort_by,
+        "sort_direction": sort_direction,
         "sort_options": _sort_options_context(
-            q, sort, direction, SORT_FOR_UNDER_REVIEW
+            q, sort_by, sort_direction, SORT_FOR_UNDER_REVIEW
         ),
     }
     return render(request, "codelists/organisation_review.html", ctx)
@@ -132,10 +134,12 @@ def _current_handle_prefetch(lookup: str) -> Prefetch:
     )
 
 
-def _get_sort(request: HttpRequest, status: Status) -> tuple[str, str]:
-    direction = request.GET.get("direction", SORT_DIRECTION_ASC)
-    if direction not in SORT_DIRECTIONS:
-        direction = SORT_DIRECTION_ASC
+def _get_sort(request, status):
+    query_sort_direction = request.GET.get("direction")
+    if query_sort_direction in SORT_DIRECTIONS:
+        sort_direction = query_sort_direction
+    else:
+        sort_direction = SORT_DIRECTION_ASC
 
     sort_options_by_status = {
         Status.PUBLISHED: SORT_FOR_PUBLISHED,
@@ -143,14 +147,16 @@ def _get_sort(request: HttpRequest, status: Status) -> tuple[str, str]:
     }
     sort_options = sort_options_by_status.get(status, {SORT_BY_NAME})
 
-    sort = request.GET.get("sort", SORT_BY_NAME)
-    if sort not in sort_options:
-        sort = SORT_BY_NAME
+    query_sort_by = request.GET.get("sort")
+    if query_sort_by in sort_options:
+        sort_by = query_sort_by
+    else:
+        sort_by = SORT_BY_NAME
 
-    return sort, direction
+    return sort_by, sort_direction
 
 
-def _sort_published_codelists(codelists, sort: str, direction: str):
+def _sort_published_codelists(codelists, sort_by, sort_direction):
     sort_key_funcs = {
         SORT_BY_NAME: lambda codelist: codelist.name.casefold(),
         SORT_BY_UPDATED_AT: lambda codelist: codelist.updated_at,
@@ -158,12 +164,12 @@ def _sort_published_codelists(codelists, sort: str, direction: str):
 
     return sorted(
         codelists,
-        key=sort_key_funcs[sort],
-        reverse=direction == SORT_DIRECTION_DESC,
+        key=sort_key_funcs[sort_by],
+        reverse=sort_direction == SORT_DIRECTION_DESC,
     )
 
 
-def _sort_under_review_versions(versions, sort: str, direction: str):
+def _sort_under_review_versions(versions, sort_by, sort_direction):
     sort_key_funcs = {
         SORT_BY_NAME: lambda version: version.codelist.name.casefold(),
         SORT_BY_CREATED_AT: lambda version: version.created_at,
@@ -171,21 +177,20 @@ def _sort_under_review_versions(versions, sort: str, direction: str):
 
     return sorted(
         versions,
-        key=sort_key_funcs[sort],
-        reverse=direction == SORT_DIRECTION_DESC,
+        key=sort_key_funcs[sort_by],
+        reverse=sort_direction == SORT_DIRECTION_DESC,
     )
 
 
-def _pagination_context(page_obj, q: str | None, sort_state: tuple[str, str]):
+def _pagination_context(page_obj, q, sort_by, sort_direction):
     paginator = page_obj.paginator
-    sort, direction = sort_state
 
-    def url_for(page_number: int) -> str:
+    def url_for(page_number):
         params = {
             "page": page_number,
             "q": q or "",
-            "sort": sort,
-            "direction": direction,
+            "sort": sort_by,
+            "direction": sort_direction,
         }
         return f"?{urlencode(params)}"
 
@@ -207,32 +212,32 @@ def _pagination_context(page_obj, q: str | None, sort_state: tuple[str, str]):
     }
 
 
-def _sort_options_context(
-    q: str | None, current_sort: str, current_direction: str, sort_options: set[str]
-) -> dict[str, dict[str, str]]:
+def _sort_options_context(q, current_sort_by, current_sort_direction, sort_options):
     return {
-        sort: _sort_context(q, current_sort, current_direction, sort)
-        for sort in sort_options
+        sort_by: _sort_context(q, current_sort_by, current_sort_direction, sort_by)
+        for sort_by in sort_options
     }
 
 
-def _sort_context(
-    q: str | None, current_sort: str, current_direction: str, sort: str
-) -> dict[str, str]:
-    direction = SORT_DIRECTION_ASC
-    if current_sort == sort and current_direction == SORT_DIRECTION_ASC:
-        direction = SORT_DIRECTION_DESC
+def _sort_context(q, current_sort_by, current_sort_direction, sort_by):
+    sort_direction = SORT_DIRECTION_ASC
+    if current_sort_by == sort_by and current_sort_direction == SORT_DIRECTION_ASC:
+        sort_direction = SORT_DIRECTION_DESC
 
     aria = "none"
     icon = "none"
-    if current_sort == sort:
-        icon = current_direction
-        aria = "ascending" if current_direction == SORT_DIRECTION_ASC else "descending"
+    if current_sort_by == sort_by:
+        icon = current_sort_direction
+        aria = (
+            "ascending"
+            if current_sort_direction == SORT_DIRECTION_ASC
+            else "descending"
+        )
 
     params = {
         "q": q or "",
-        "sort": sort,
-        "direction": direction,
+        "sort": sort_by,
+        "direction": sort_direction,
     }
 
     return {

--- a/codelists/views/organisations.py
+++ b/codelists/views/organisations.py
@@ -1,3 +1,5 @@
+from urllib.parse import urlencode
+
 from django.core.paginator import Paginator
 from django.db.models import Exists, OuterRef, Prefetch
 from django.db.models.query import QuerySet
@@ -38,8 +40,11 @@ def organisation_published(
         [handle.codelist for handle in published_handles], sort, direction
     )
 
+    page_obj = Paginator(codelists, PAGE_SIZE).get_page(request.GET.get("page"))
+
     ctx = {
-        "page_obj": Paginator(codelists, PAGE_SIZE).get_page(request.GET.get("page")),
+        "page_obj": page_obj,
+        "pagination": _pagination_context(page_obj, q, (sort, direction)),
         "organisation": organisation,
         "q": q,
         "sort": sort,
@@ -55,8 +60,11 @@ def organisation_review(request: HttpRequest, organisation_slug: str) -> HttpRes
         _under_review_versions(handles), sort, direction
     )
 
+    page_obj = Paginator(versions, PAGE_SIZE).get_page(request.GET.get("page"))
+
     ctx = {
-        "page_obj": Paginator(versions, PAGE_SIZE).get_page(request.GET.get("page")),
+        "page_obj": page_obj,
+        "pagination": _pagination_context(page_obj, q, (sort, direction)),
         "organisation": organisation,
         "q": q,
         "sort": sort,
@@ -162,3 +170,34 @@ def _sort_under_review_versions(versions, sort: str, direction: str):
         key=sort_key_funcs[sort],
         reverse=direction == SORT_DIRECTION_DESC,
     )
+
+
+def _pagination_context(page_obj, q: str | None, sort_state: tuple[str, str]):
+    paginator = page_obj.paginator
+    sort, direction = sort_state
+
+    def url_for(page_number: int) -> str:
+        params = {
+            "page": page_number,
+            "q": q or "",
+            "sort": sort,
+            "direction": direction,
+        }
+        return f"?{urlencode(params)}"
+
+    return {
+        "previous_url": (
+            url_for(page_obj.previous_page_number())
+            if page_obj.has_previous()
+            else None
+        ),
+        "next_url": url_for(page_obj.next_page_number())
+        if page_obj.has_next()
+        else None,
+        "first_url": url_for(1),
+        "last_url": url_for(paginator.num_pages),
+        "page_links": [
+            {"number": page_number, "url": url_for(page_number)}
+            for page_number in paginator.page_range
+        ],
+    }

--- a/codelists/views/organisations.py
+++ b/codelists/views/organisations.py
@@ -49,6 +49,7 @@ def organisation_published(
         "q": q,
         "sort": sort,
         "direction": direction,
+        "sort_options": _sort_options_context(q, sort, direction, SORT_FOR_PUBLISHED),
     }
     return render(request, "codelists/organisation_published.html", ctx)
 
@@ -69,6 +70,9 @@ def organisation_review(request: HttpRequest, organisation_slug: str) -> HttpRes
         "q": q,
         "sort": sort,
         "direction": direction,
+        "sort_options": _sort_options_context(
+            q, sort, direction, SORT_FOR_UNDER_REVIEW
+        ),
     }
     return render(request, "codelists/organisation_review.html", ctx)
 
@@ -200,4 +204,39 @@ def _pagination_context(page_obj, q: str | None, sort_state: tuple[str, str]):
             {"number": page_number, "url": url_for(page_number)}
             for page_number in paginator.page_range
         ],
+    }
+
+
+def _sort_options_context(
+    q: str | None, current_sort: str, current_direction: str, sort_options: set[str]
+) -> dict[str, dict[str, str]]:
+    return {
+        sort: _sort_context(q, current_sort, current_direction, sort)
+        for sort in sort_options
+    }
+
+
+def _sort_context(
+    q: str | None, current_sort: str, current_direction: str, sort: str
+) -> dict[str, str]:
+    direction = SORT_DIRECTION_ASC
+    if current_sort == sort and current_direction == SORT_DIRECTION_ASC:
+        direction = SORT_DIRECTION_DESC
+
+    aria = "none"
+    icon = "none"
+    if current_sort == sort:
+        icon = current_direction
+        aria = "ascending" if current_direction == SORT_DIRECTION_ASC else "descending"
+
+    params = {
+        "q": q or "",
+        "sort": sort,
+        "direction": direction,
+    }
+
+    return {
+        "aria": aria,
+        "icon": icon,
+        "url": f"?{urlencode(params)}",
     }

--- a/codelists/views/organisations.py
+++ b/codelists/views/organisations.py
@@ -15,32 +15,52 @@ from .index import (
 
 PAGE_SIZE = 50
 
+SORT_DIRECTION_ASC = "asc"
+SORT_DIRECTION_DESC = "desc"
+SORT_DIRECTIONS = {SORT_DIRECTION_ASC, SORT_DIRECTION_DESC}
+
+SORT_BY_CREATED_AT = "created_at"
+SORT_BY_NAME = "name"
+SORT_BY_UPDATED_AT = "updated_at"
+SORT_FOR_PUBLISHED = {SORT_BY_NAME, SORT_BY_UPDATED_AT}
+SORT_FOR_UNDER_REVIEW = {SORT_BY_NAME, SORT_BY_CREATED_AT}
+
 
 def organisation_published(
     request: HttpRequest, organisation_slug: str
 ) -> HttpResponse:
     organisation, handles, q = _get_organisation_handles(request, organisation_slug)
+    sort, direction = _get_sort(request, Status.PUBLISHED)
     published_handles = _handles_with_status(
         handles, Status.PUBLISHED
     ).prefetch_related(_current_handle_prefetch("codelist__handles"))
-    codelists = [handle.codelist for handle in published_handles]
+    codelists = _sort_published_codelists(
+        [handle.codelist for handle in published_handles], sort, direction
+    )
 
     ctx = {
         "page_obj": Paginator(codelists, PAGE_SIZE).get_page(request.GET.get("page")),
         "organisation": organisation,
         "q": q,
+        "sort": sort,
+        "direction": direction,
     }
     return render(request, "codelists/organisation_published.html", ctx)
 
 
 def organisation_review(request: HttpRequest, organisation_slug: str) -> HttpResponse:
     organisation, handles, q = _get_organisation_handles(request, organisation_slug)
-    versions = _under_review_versions(handles)
+    sort, direction = _get_sort(request, Status.UNDER_REVIEW)
+    versions = _sort_under_review_versions(
+        _under_review_versions(handles), sort, direction
+    )
 
     ctx = {
         "page_obj": Paginator(versions, PAGE_SIZE).get_page(request.GET.get("page")),
         "organisation": organisation,
         "q": q,
+        "sort": sort,
+        "direction": direction,
     }
     return render(request, "codelists/organisation_review.html", ctx)
 
@@ -97,4 +117,48 @@ def _current_handle_prefetch(lookup: str) -> Prefetch:
     return Prefetch(
         lookup,
         queryset=Handle.objects.filter(is_current=True).select_related("organisation"),
+    )
+
+
+def _get_sort(request: HttpRequest, status: Status) -> tuple[str, str]:
+    direction = request.GET.get("direction", SORT_DIRECTION_ASC)
+    if direction not in SORT_DIRECTIONS:
+        direction = SORT_DIRECTION_ASC
+
+    sort_options_by_status = {
+        Status.PUBLISHED: SORT_FOR_PUBLISHED,
+        Status.UNDER_REVIEW: SORT_FOR_UNDER_REVIEW,
+    }
+    sort_options = sort_options_by_status.get(status, {SORT_BY_NAME})
+
+    sort = request.GET.get("sort", SORT_BY_NAME)
+    if sort not in sort_options:
+        sort = SORT_BY_NAME
+
+    return sort, direction
+
+
+def _sort_published_codelists(codelists, sort: str, direction: str):
+    sort_key_funcs = {
+        SORT_BY_NAME: lambda codelist: codelist.name.casefold(),
+        SORT_BY_UPDATED_AT: lambda codelist: codelist.updated_at,
+    }
+
+    return sorted(
+        codelists,
+        key=sort_key_funcs[sort],
+        reverse=direction == SORT_DIRECTION_DESC,
+    )
+
+
+def _sort_under_review_versions(versions, sort: str, direction: str):
+    sort_key_funcs = {
+        SORT_BY_NAME: lambda version: version.codelist.name.casefold(),
+        SORT_BY_CREATED_AT: lambda version: version.created_at,
+    }
+
+    return sorted(
+        versions,
+        key=sort_key_funcs[sort],
+        reverse=direction == SORT_DIRECTION_DESC,
     )

--- a/templates/_partials/organisation_header.html
+++ b/templates/_partials/organisation_header.html
@@ -21,6 +21,13 @@
       value="{{ search_query|default:'' }}"
     />
 
+    {% if sort %}
+      <input name="sort" type="hidden" value="{{ sort }}">
+    {% endif %}
+    {% if direction %}
+      <input name="direction" type="hidden" value="{{ direction }}">
+    {% endif %}
+
     <button
       class="flex w-fit cursor-pointer items-center justify-center rounded-md border border-blue-700 bg-blue-700 px-6 text-sm/6 font-semibold whitespace-nowrap text-white shadow-xs transition-colors hover:border-blue-600 hover:bg-blue-600 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-700"
       type="submit"

--- a/templates/_partials/organisation_header.html
+++ b/templates/_partials/organisation_header.html
@@ -21,11 +21,11 @@
       value="{{ search_query|default:'' }}"
     />
 
-    {% if sort %}
-      <input name="sort" type="hidden" value="{{ sort }}">
+    {% if sort_by %}
+      <input name="sort" type="hidden" value="{{ sort_by }}">
     {% endif %}
-    {% if direction %}
-      <input name="direction" type="hidden" value="{{ direction }}">
+    {% if sort_direction %}
+      <input name="direction" type="hidden" value="{{ sort_direction }}">
     {% endif %}
 
     <button

--- a/templates/_partials/organisation_table.html
+++ b/templates/_partials/organisation_table.html
@@ -74,7 +74,7 @@
         </table>
 
         {% if page_obj.has_other_pages %}
-          {% include "_partials/organisation_table_pagination.html" with direction=direction page_obj=page_obj q=q sort=sort only %}
+          {% include "_partials/organisation_table_pagination.html" with page_obj=page_obj pagination=pagination only %}
         {% endif %}
       </div>
     </div>

--- a/templates/_partials/organisation_table.html
+++ b/templates/_partials/organisation_table.html
@@ -8,14 +8,14 @@
           <thead class="border-b-slate-300 bg-slate-100 text-left text-sm font-semibold text-slate-900">
             <tr>
               {% if under_review_codelists %}
-                <th class="px-3 py-3.5 pl-4 whitespace-nowrap sm:pl-6">Name</th>
+                {% include "_partials/organisation_table_sort_header.html" with column_sort=sort_options.name label="Name" th_class="px-3 py-3.5 pl-4 whitespace-nowrap sm:pl-6" only %}
                 <th class="px-3 py-3.5 whitespace-nowrap">Version</th>
-                <th class="px-3 py-3.5 pr-3 whitespace-nowrap sm:pr-6">Created</th>
+                {% include "_partials/organisation_table_sort_header.html" with column_sort=sort_options.created_at label="Created" th_class="px-3 py-3.5 pr-3 whitespace-nowrap sm:pr-6" only %}
               {% else %}
-                <th class="px-3 py-3.5 pl-4 whitespace-nowrap sm:pl-6">Name</th>
+                {% include "_partials/organisation_table_sort_header.html" with column_sort=sort_options.name label="Name" th_class="px-3 py-3.5 pl-4 whitespace-nowrap sm:pl-6" only %}
                 <th class="px-3 py-3.5 whitespace-nowrap">Coding system</th>
                 <th class="px-3 py-3.5 whitespace-nowrap">Description</th>
-                <th class="px-3 py-3.5 pr-3 whitespace-nowrap sm:pr-6">Last updated</th>
+                {% include "_partials/organisation_table_sort_header.html" with column_sort=sort_options.updated_at label="Last updated" th_class="px-3 py-3.5 pr-3 whitespace-nowrap sm:pr-6" only %}
               {% endif %}
             </tr>
           </thead>

--- a/templates/_partials/organisation_table.html
+++ b/templates/_partials/organisation_table.html
@@ -74,7 +74,7 @@
         </table>
 
         {% if page_obj.has_other_pages %}
-          {% include "_partials/organisation_table_pagination.html" with page_obj=page_obj q=q only %}
+          {% include "_partials/organisation_table_pagination.html" with direction=direction page_obj=page_obj q=q sort=sort only %}
         {% endif %}
       </div>
     </div>

--- a/templates/_partials/organisation_table_pagination.html
+++ b/templates/_partials/organisation_table_pagination.html
@@ -2,10 +2,10 @@
   <div class="flex items-center justify-between border-t border-slate-200 bg-white px-4 py-3 sm:px-6 ">
     <div class="flex flex-1 justify-between sm:hidden">
       {% if page_obj.has_previous %}
-        <a href="?page={{ page_obj.previous_page_number }}{% if q %}&q={{ q|urlencode }}{% endif %}" class="relative inline-flex items-center rounded-md border border-slate-300 bg-white px-4 py-2 text-sm font-medium text-slate-700 hover:bg-slate-50">Previous</a>
+        <a href="?page={{ page_obj.previous_page_number }}{% if q %}&q={{ q|urlencode }}{% endif %}{% if sort %}&sort={{ sort|urlencode }}{% endif %}{% if direction %}&direction={{ direction|urlencode }}{% endif %}" class="relative inline-flex items-center rounded-md border border-slate-300 bg-white px-4 py-2 text-sm font-medium text-slate-700 hover:bg-slate-50">Previous</a>
       {% endif %}
       {% if page_obj.has_next %}
-        <a href="?page={{ page_obj.next_page_number }}{% if q %}&q={{ q|urlencode }}{% endif %}" class="relative ml-auto inline-flex items-center rounded-md border border-slate-300 bg-white px-4 py-2 text-sm font-medium text-slate-700 hover:bg-slate-50">Next</a>
+        <a href="?page={{ page_obj.next_page_number }}{% if q %}&q={{ q|urlencode }}{% endif %}{% if sort %}&sort={{ sort|urlencode }}{% endif %}{% if direction %}&direction={{ direction|urlencode }}{% endif %}" class="relative ml-auto inline-flex items-center rounded-md border border-slate-300 bg-white px-4 py-2 text-sm font-medium text-slate-700 hover:bg-slate-50">Next</a>
       {% endif %}
     </div>
     <div class="hidden sm:flex sm:flex-1 sm:items-center sm:justify-between">
@@ -23,7 +23,7 @@
       <div>
         <nav aria-label="Pagination" class="isolate inline-flex -space-x-px rounded-md shadow-xs">
           {% if page_obj.has_previous %}
-            <a href="?page={{ page_obj.previous_page_number }}{% if q %}&q={{ q|urlencode }}{% endif %}" class="relative inline-flex items-center rounded-l-md px-2 py-2 text-slate-400 inset-ring inset-ring-slate-300 hover:bg-slate-50 focus:z-20 focus:outline-offset-0">
+            <a href="?page={{ page_obj.previous_page_number }}{% if q %}&q={{ q|urlencode }}{% endif %}{% if sort %}&sort={{ sort|urlencode }}{% endif %}{% if direction %}&direction={{ direction|urlencode }}{% endif %}" class="relative inline-flex items-center rounded-l-md px-2 py-2 text-slate-400 inset-ring inset-ring-slate-300 hover:bg-slate-50 focus:z-20 focus:outline-offset-0">
               <span class="sr-only">Previous</span>
               <svg viewBox="0 0 20 20" fill="currentColor" data-slot="icon" aria-hidden="true" class="size-5">
                 <path d="M11.78 5.22a.75.75 0 0 1 0 1.06L8.06 10l3.72 3.72a.75.75 0 1 1-1.06 1.06l-4.25-4.25a.75.75 0 0 1 0-1.06l4.25-4.25a.75.75 0 0 1 1.06 0Z" clip-rule="evenodd" fill-rule="evenodd" />
@@ -33,7 +33,7 @@
 
           {% if page_obj.has_previous %}
             {% if current_minus_3 >= 1 %}
-              <a href="?page=1{% if q %}&q={{ q|urlencode }}{% endif %}" class="relative inline-flex items-center px-4 py-2 text-sm font-semibold text-slate-900 inset-ring inset-ring-slate-300 hover:bg-slate-50 focus:z-20 focus:outline-offset-0">1</a>
+              <a href="?page=1{% if q %}&q={{ q|urlencode }}{% endif %}{% if sort %}&sort={{ sort|urlencode }}{% endif %}{% if direction %}&direction={{ direction|urlencode }}{% endif %}" class="relative inline-flex items-center px-4 py-2 text-sm font-semibold text-slate-900 inset-ring inset-ring-slate-300 hover:bg-slate-50 focus:z-20 focus:outline-offset-0">1</a>
             {% endif %}
             {% if current_minus_3 > 1 %}
               <span class="relative inline-flex items-center px-4 py-2 text-sm font-semibold text-slate-700 inset-ring inset-ring-slate-300 focus:outline-offset-0">...</span>
@@ -44,7 +44,7 @@
             {% if page_obj.number == page_number %}
               <span aria-current="page" class="relative z-10 inline-flex items-center bg-blue-700 px-4 py-2 text-sm font-semibold text-white focus:z-20 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-700">{{ page_number }}</span>
             {% elif page_number > page_obj.number|add:'-3' and page_number < page_obj.number|add:'3' %}
-              <a href="?page={{ page_number }}{% if q %}&q={{ q|urlencode }}{% endif %}" class="relative inline-flex items-center px-4 py-2 text-sm font-semibold text-slate-900 inset-ring inset-ring-slate-300 hover:bg-slate-50 focus:z-20 focus:outline-offset-0">{{ page_number }}</a>
+              <a href="?page={{ page_number }}{% if q %}&q={{ q|urlencode }}{% endif %}{% if sort %}&sort={{ sort|urlencode }}{% endif %}{% if direction %}&direction={{ direction|urlencode }}{% endif %}" class="relative inline-flex items-center px-4 py-2 text-sm font-semibold text-slate-900 inset-ring inset-ring-slate-300 hover:bg-slate-50 focus:z-20 focus:outline-offset-0">{{ page_number }}</a>
             {% endif %}
           {% endfor %}
 
@@ -53,9 +53,9 @@
               <span class="relative inline-flex items-center px-4 py-2 text-sm font-semibold text-slate-700 inset-ring inset-ring-slate-300 focus:outline-offset-0">...</span>
             {% endif %}
             {% if current_plus_3 <= page_obj.paginator.num_pages %}
-              <a href="?page={{ page_obj.paginator.num_pages }}{% if q %}&q={{ q|urlencode }}{% endif %}" class="relative inline-flex items-center px-4 py-2 text-sm font-semibold text-slate-900 inset-ring inset-ring-slate-300 hover:bg-slate-50 focus:z-20 focus:outline-offset-0">{{ page_obj.paginator.num_pages }}</a>
+              <a href="?page={{ page_obj.paginator.num_pages }}{% if q %}&q={{ q|urlencode }}{% endif %}{% if sort %}&sort={{ sort|urlencode }}{% endif %}{% if direction %}&direction={{ direction|urlencode }}{% endif %}" class="relative inline-flex items-center px-4 py-2 text-sm font-semibold text-slate-900 inset-ring inset-ring-slate-300 hover:bg-slate-50 focus:z-20 focus:outline-offset-0">{{ page_obj.paginator.num_pages }}</a>
             {% endif %}
-            <a href="?page={{ page_obj.next_page_number }}{% if q %}&q={{ q|urlencode }}{% endif %}" class="relative inline-flex items-center rounded-r-md px-2 py-2 text-slate-400 inset-ring inset-ring-slate-300 hover:bg-slate-50 focus:z-20 focus:outline-offset-0">
+            <a href="?page={{ page_obj.next_page_number }}{% if q %}&q={{ q|urlencode }}{% endif %}{% if sort %}&sort={{ sort|urlencode }}{% endif %}{% if direction %}&direction={{ direction|urlencode }}{% endif %}" class="relative inline-flex items-center rounded-r-md px-2 py-2 text-slate-400 inset-ring inset-ring-slate-300 hover:bg-slate-50 focus:z-20 focus:outline-offset-0">
               <span class="sr-only">Next</span>
               <svg viewBox="0 0 20 20" fill="currentColor" data-slot="icon" aria-hidden="true" class="size-5">
                 <path d="M8.22 5.22a.75.75 0 0 1 1.06 0l4.25 4.25a.75.75 0 0 1 0 1.06l-4.25 4.25a.75.75 0 0 1-1.06-1.06L11.94 10 8.22 6.28a.75.75 0 0 1 0-1.06Z" clip-rule="evenodd" fill-rule="evenodd" />

--- a/templates/_partials/organisation_table_pagination.html
+++ b/templates/_partials/organisation_table_pagination.html
@@ -2,10 +2,10 @@
   <div class="flex items-center justify-between border-t border-slate-200 bg-white px-4 py-3 sm:px-6 ">
     <div class="flex flex-1 justify-between sm:hidden">
       {% if page_obj.has_previous %}
-        <a href="?page={{ page_obj.previous_page_number }}{% if q %}&q={{ q|urlencode }}{% endif %}{% if sort %}&sort={{ sort|urlencode }}{% endif %}{% if direction %}&direction={{ direction|urlencode }}{% endif %}" class="relative inline-flex items-center rounded-md border border-slate-300 bg-white px-4 py-2 text-sm font-medium text-slate-700 hover:bg-slate-50">Previous</a>
+        <a href="{{ pagination.previous_url }}" class="relative inline-flex items-center rounded-md border border-slate-300 bg-white px-4 py-2 text-sm font-medium text-slate-700 hover:bg-slate-50">Previous</a>
       {% endif %}
       {% if page_obj.has_next %}
-        <a href="?page={{ page_obj.next_page_number }}{% if q %}&q={{ q|urlencode }}{% endif %}{% if sort %}&sort={{ sort|urlencode }}{% endif %}{% if direction %}&direction={{ direction|urlencode }}{% endif %}" class="relative ml-auto inline-flex items-center rounded-md border border-slate-300 bg-white px-4 py-2 text-sm font-medium text-slate-700 hover:bg-slate-50">Next</a>
+        <a href="{{ pagination.next_url }}" class="relative ml-auto inline-flex items-center rounded-md border border-slate-300 bg-white px-4 py-2 text-sm font-medium text-slate-700 hover:bg-slate-50">Next</a>
       {% endif %}
     </div>
     <div class="hidden sm:flex sm:flex-1 sm:items-center sm:justify-between">
@@ -23,7 +23,7 @@
       <div>
         <nav aria-label="Pagination" class="isolate inline-flex -space-x-px rounded-md shadow-xs">
           {% if page_obj.has_previous %}
-            <a href="?page={{ page_obj.previous_page_number }}{% if q %}&q={{ q|urlencode }}{% endif %}{% if sort %}&sort={{ sort|urlencode }}{% endif %}{% if direction %}&direction={{ direction|urlencode }}{% endif %}" class="relative inline-flex items-center rounded-l-md px-2 py-2 text-slate-400 inset-ring inset-ring-slate-300 hover:bg-slate-50 focus:z-20 focus:outline-offset-0">
+            <a href="{{ pagination.previous_url }}" class="relative inline-flex items-center rounded-l-md px-2 py-2 text-slate-400 inset-ring inset-ring-slate-300 hover:bg-slate-50 focus:z-20 focus:outline-offset-0">
               <span class="sr-only">Previous</span>
               <svg viewBox="0 0 20 20" fill="currentColor" data-slot="icon" aria-hidden="true" class="size-5">
                 <path d="M11.78 5.22a.75.75 0 0 1 0 1.06L8.06 10l3.72 3.72a.75.75 0 1 1-1.06 1.06l-4.25-4.25a.75.75 0 0 1 0-1.06l4.25-4.25a.75.75 0 0 1 1.06 0Z" clip-rule="evenodd" fill-rule="evenodd" />
@@ -33,18 +33,18 @@
 
           {% if page_obj.has_previous %}
             {% if current_minus_3 >= 1 %}
-              <a href="?page=1{% if q %}&q={{ q|urlencode }}{% endif %}{% if sort %}&sort={{ sort|urlencode }}{% endif %}{% if direction %}&direction={{ direction|urlencode }}{% endif %}" class="relative inline-flex items-center px-4 py-2 text-sm font-semibold text-slate-900 inset-ring inset-ring-slate-300 hover:bg-slate-50 focus:z-20 focus:outline-offset-0">1</a>
+              <a href="{{ pagination.first_url }}" class="relative inline-flex items-center px-4 py-2 text-sm font-semibold text-slate-900 inset-ring inset-ring-slate-300 hover:bg-slate-50 focus:z-20 focus:outline-offset-0">1</a>
             {% endif %}
             {% if current_minus_3 > 1 %}
               <span class="relative inline-flex items-center px-4 py-2 text-sm font-semibold text-slate-700 inset-ring inset-ring-slate-300 focus:outline-offset-0">...</span>
             {% endif %}
           {% endif %}
 
-          {% for page_number in page_obj.paginator.page_range %}
-            {% if page_obj.number == page_number %}
-              <span aria-current="page" class="relative z-10 inline-flex items-center bg-blue-700 px-4 py-2 text-sm font-semibold text-white focus:z-20 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-700">{{ page_number }}</span>
-            {% elif page_number > page_obj.number|add:'-3' and page_number < page_obj.number|add:'3' %}
-              <a href="?page={{ page_number }}{% if q %}&q={{ q|urlencode }}{% endif %}{% if sort %}&sort={{ sort|urlencode }}{% endif %}{% if direction %}&direction={{ direction|urlencode }}{% endif %}" class="relative inline-flex items-center px-4 py-2 text-sm font-semibold text-slate-900 inset-ring inset-ring-slate-300 hover:bg-slate-50 focus:z-20 focus:outline-offset-0">{{ page_number }}</a>
+          {% for link in pagination.page_links %}
+            {% if page_obj.number == link.number %}
+              <span aria-current="page" class="relative z-10 inline-flex items-center bg-blue-700 px-4 py-2 text-sm font-semibold text-white focus:z-20 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-700">{{ link.number }}</span>
+            {% elif link.number > page_obj.number|add:'-3' and link.number < page_obj.number|add:'3' %}
+              <a href="{{ link.url }}" class="relative inline-flex items-center px-4 py-2 text-sm font-semibold text-slate-900 inset-ring inset-ring-slate-300 hover:bg-slate-50 focus:z-20 focus:outline-offset-0">{{ link.number }}</a>
             {% endif %}
           {% endfor %}
 
@@ -53,9 +53,9 @@
               <span class="relative inline-flex items-center px-4 py-2 text-sm font-semibold text-slate-700 inset-ring inset-ring-slate-300 focus:outline-offset-0">...</span>
             {% endif %}
             {% if current_plus_3 <= page_obj.paginator.num_pages %}
-              <a href="?page={{ page_obj.paginator.num_pages }}{% if q %}&q={{ q|urlencode }}{% endif %}{% if sort %}&sort={{ sort|urlencode }}{% endif %}{% if direction %}&direction={{ direction|urlencode }}{% endif %}" class="relative inline-flex items-center px-4 py-2 text-sm font-semibold text-slate-900 inset-ring inset-ring-slate-300 hover:bg-slate-50 focus:z-20 focus:outline-offset-0">{{ page_obj.paginator.num_pages }}</a>
+              <a href="{{ pagination.last_url }}" class="relative inline-flex items-center px-4 py-2 text-sm font-semibold text-slate-900 inset-ring inset-ring-slate-300 hover:bg-slate-50 focus:z-20 focus:outline-offset-0">{{ page_obj.paginator.num_pages }}</a>
             {% endif %}
-            <a href="?page={{ page_obj.next_page_number }}{% if q %}&q={{ q|urlencode }}{% endif %}{% if sort %}&sort={{ sort|urlencode }}{% endif %}{% if direction %}&direction={{ direction|urlencode }}{% endif %}" class="relative inline-flex items-center rounded-r-md px-2 py-2 text-slate-400 inset-ring inset-ring-slate-300 hover:bg-slate-50 focus:z-20 focus:outline-offset-0">
+            <a href="{{ pagination.next_url }}" class="relative inline-flex items-center rounded-r-md px-2 py-2 text-slate-400 inset-ring inset-ring-slate-300 hover:bg-slate-50 focus:z-20 focus:outline-offset-0">
               <span class="sr-only">Next</span>
               <svg viewBox="0 0 20 20" fill="currentColor" data-slot="icon" aria-hidden="true" class="size-5">
                 <path d="M8.22 5.22a.75.75 0 0 1 1.06 0l4.25 4.25a.75.75 0 0 1 0 1.06l-4.25 4.25a.75.75 0 0 1-1.06-1.06L11.94 10 8.22 6.28a.75.75 0 0 1 0-1.06Z" clip-rule="evenodd" fill-rule="evenodd" />

--- a/templates/_partials/organisation_table_sort_header.html
+++ b/templates/_partials/organisation_table_sort_header.html
@@ -1,0 +1,13 @@
+<th class="{{ th_class }}" aria-sort="{{ column_sort.aria }}">
+  <a
+    class="cursor-pointer inline-flex items-center gap-x-1 text-slate-900 transition-colors hover:text-slate-950 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-600"
+    href="{{ column_sort.url }}"
+  >
+    {{ label }}
+    <svg aria-hidden="true" focusable="false" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" class="size-5 border rounded border-slate-300 p-0.5 ml-1 shrink-0 bg-white" width="20" height="20">
+      <path class="{% if column_sort.icon != "asc" %}hidden{% endif %}" clip-rule="evenodd" fill-rule="evenodd" d="M10 17a.75.75 0 0 1-.75-.75V5.612L5.29 9.77a.75.75 0 0 1-1.08-1.04l5.25-5.5a.75.75 0 0 1 1.08 0l5.25 5.5a.75.75 0 1 1-1.08 1.04l-3.96-4.158V16.25A.75.75 0 0 1 10 17Z" />
+      <path class="{% if column_sort.icon != "desc" %}hidden{% endif %}" clip-rule="evenodd" fill-rule="evenodd" d="M10 3a.75.75 0 0 1 .75.75v10.638l3.96-4.158a.75.75 0 1 1 1.08 1.04l-5.25 5.5a.75.75 0 0 1-1.08 0l-5.25-5.5a.75.75 0 1 1 1.08-1.04l3.96 4.158V3.75A.75.75 0 0 1 10 3Z" />
+      <path class="{% if column_sort.icon != "none" %}hidden{% endif %}" clip-rule="evenodd" fill-rule="evenodd" d="M2.24 6.8a.75.75 0 0 0 1.06-.04l1.95-2.1v8.59a.75.75 0 0 0 1.5 0V4.66l1.95 2.1a.75.75 0 1 0 1.1-1.02l-3.25-3.5a.75.75 0 0 0-1.1 0L2.2 5.74a.75.75 0 0 0 .04 1.06Zm8 6.4a.75.75 0 0 0-.04 1.06l3.25 3.5a.75.75 0 0 0 1.1 0l3.25-3.5a.75.75 0 1 0-1.1-1.02l-1.95 2.1V6.75a.75.75 0 0 0-1.5 0v8.59l-1.95-2.1a.75.75 0 0 0-1.06-.04Z" />
+    </svg>
+  </a>
+</th>

--- a/templates/codelists/organisation_published.html
+++ b/templates/codelists/organisation_published.html
@@ -23,7 +23,7 @@
         {% include "_partials/organisation_header.html" with organisation_name=organisation.name request_path=request.path search_query=q description="All of the codelists published by "|add:organisation.name title="Published codelists" sort=sort direction=direction only %}
       </div>
 
-      {% include "_partials/organisation_table.html" with page_obj=page_obj q=q only %}
+      {% include "_partials/organisation_table.html" with direction=direction page_obj=page_obj q=q sort=sort only %}
     </section>
   {% endif %}
 {% endblock full_width_content %}

--- a/templates/codelists/organisation_published.html
+++ b/templates/codelists/organisation_published.html
@@ -20,7 +20,7 @@
   {% if page_obj or q %}
     <section class="pb-24">
       <div class="container">
-        {% include "_partials/organisation_header.html" with organisation_name=organisation.name request_path=request.path search_query=q description="All of the codelists published by "|add:organisation.name title="Published codelists" sort=sort direction=direction only %}
+        {% include "_partials/organisation_header.html" with organisation_name=organisation.name request_path=request.path search_query=q description="All of the codelists published by "|add:organisation.name title="Published codelists" sort_by=sort_by sort_direction=sort_direction only %}
       </div>
 
       {% include "_partials/organisation_table.html" with page_obj=page_obj pagination=pagination q=q sort_options=sort_options only %}

--- a/templates/codelists/organisation_published.html
+++ b/templates/codelists/organisation_published.html
@@ -20,7 +20,7 @@
   {% if page_obj or q %}
     <section class="pb-24">
       <div class="container">
-        {% include "_partials/organisation_header.html" with organisation_name=organisation.name request_path=request.path search_query=q description="All of the codelists published by "|add:organisation.name title="Published codelists" only %}
+        {% include "_partials/organisation_header.html" with organisation_name=organisation.name request_path=request.path search_query=q description="All of the codelists published by "|add:organisation.name title="Published codelists" sort=sort direction=direction only %}
       </div>
 
       {% include "_partials/organisation_table.html" with page_obj=page_obj q=q only %}

--- a/templates/codelists/organisation_published.html
+++ b/templates/codelists/organisation_published.html
@@ -23,7 +23,7 @@
         {% include "_partials/organisation_header.html" with organisation_name=organisation.name request_path=request.path search_query=q description="All of the codelists published by "|add:organisation.name title="Published codelists" sort=sort direction=direction only %}
       </div>
 
-      {% include "_partials/organisation_table.html" with direction=direction page_obj=page_obj pagination=pagination q=q sort=sort only %}
+      {% include "_partials/organisation_table.html" with page_obj=page_obj pagination=pagination q=q sort_options=sort_options only %}
     </section>
   {% endif %}
 {% endblock full_width_content %}

--- a/templates/codelists/organisation_published.html
+++ b/templates/codelists/organisation_published.html
@@ -23,7 +23,7 @@
         {% include "_partials/organisation_header.html" with organisation_name=organisation.name request_path=request.path search_query=q description="All of the codelists published by "|add:organisation.name title="Published codelists" sort=sort direction=direction only %}
       </div>
 
-      {% include "_partials/organisation_table.html" with direction=direction page_obj=page_obj q=q sort=sort only %}
+      {% include "_partials/organisation_table.html" with direction=direction page_obj=page_obj pagination=pagination q=q sort=sort only %}
     </section>
   {% endif %}
 {% endblock full_width_content %}

--- a/templates/codelists/organisation_review.html
+++ b/templates/codelists/organisation_review.html
@@ -20,7 +20,7 @@
   {% if page_obj or q %}
     <section class="pb-24">
       <div class="container">
-        {% include "_partials/organisation_header.html" with organisation_name=organisation.name request_path=request.path search_query=q description="All of the under review codelists by "|add:organisation.name title="Under review codelists" only %}
+        {% include "_partials/organisation_header.html" with organisation_name=organisation.name request_path=request.path search_query=q description="All of the under review codelists by "|add:organisation.name title="Under review codelists" sort=sort direction=direction only %}
       </div>
 
       {% include "_partials/organisation_table.html" with page_obj=page_obj q=q under_review_codelists=True only %}

--- a/templates/codelists/organisation_review.html
+++ b/templates/codelists/organisation_review.html
@@ -23,7 +23,7 @@
         {% include "_partials/organisation_header.html" with organisation_name=organisation.name request_path=request.path search_query=q description="All of the under review codelists by "|add:organisation.name title="Under review codelists" sort=sort direction=direction only %}
       </div>
 
-      {% include "_partials/organisation_table.html" with direction=direction page_obj=page_obj pagination=pagination q=q sort=sort under_review_codelists=True only %}
+      {% include "_partials/organisation_table.html" with page_obj=page_obj pagination=pagination q=q sort_options=sort_options under_review_codelists=True only %}
     </section>
   {% endif %}
 {% endblock full_width_content %}

--- a/templates/codelists/organisation_review.html
+++ b/templates/codelists/organisation_review.html
@@ -20,7 +20,7 @@
   {% if page_obj or q %}
     <section class="pb-24">
       <div class="container">
-        {% include "_partials/organisation_header.html" with organisation_name=organisation.name request_path=request.path search_query=q description="All of the under review codelists by "|add:organisation.name title="Under review codelists" sort=sort direction=direction only %}
+        {% include "_partials/organisation_header.html" with organisation_name=organisation.name request_path=request.path search_query=q description="All of the under review codelists by "|add:organisation.name title="Under review codelists" sort_by=sort_by sort_direction=sort_direction only %}
       </div>
 
       {% include "_partials/organisation_table.html" with page_obj=page_obj pagination=pagination q=q sort_options=sort_options under_review_codelists=True only %}

--- a/templates/codelists/organisation_review.html
+++ b/templates/codelists/organisation_review.html
@@ -23,7 +23,7 @@
         {% include "_partials/organisation_header.html" with organisation_name=organisation.name request_path=request.path search_query=q description="All of the under review codelists by "|add:organisation.name title="Under review codelists" sort=sort direction=direction only %}
       </div>
 
-      {% include "_partials/organisation_table.html" with page_obj=page_obj q=q under_review_codelists=True only %}
+      {% include "_partials/organisation_table.html" with direction=direction page_obj=page_obj q=q sort=sort under_review_codelists=True only %}
     </section>
   {% endif %}
 {% endblock full_width_content %}

--- a/templates/codelists/organisation_review.html
+++ b/templates/codelists/organisation_review.html
@@ -23,7 +23,7 @@
         {% include "_partials/organisation_header.html" with organisation_name=organisation.name request_path=request.path search_query=q description="All of the under review codelists by "|add:organisation.name title="Under review codelists" sort=sort direction=direction only %}
       </div>
 
-      {% include "_partials/organisation_table.html" with direction=direction page_obj=page_obj q=q sort=sort under_review_codelists=True only %}
+      {% include "_partials/organisation_table.html" with direction=direction page_obj=page_obj pagination=pagination q=q sort=sort under_review_codelists=True only %}
     </section>
   {% endif %}
 {% endblock full_width_content %}


### PR DESCRIPTION
Part of #3058 - this PR adds the functionality to sort codelists and stores the state in query params.

Published codelist tests cover:

- `sort=name&direction=asc`
- `sort=name&direction=desc`
- `sort=updated_at&direction=asc`
- `sort=updated_at&direction=desc`

Under-review tests cover:

- `sort=name&direction=asc`
- `sort=name&direction=desc`
- `sort=created_at&direction=asc`
- `sort=created_at&direction=desc`

# Screenshots

## Sorted by name (asc) [default]

<img width="600" alt="" src="https://github.com/user-attachments/assets/7829c351-cba1-4f64-9ff7-da42c671f926" />

## Sorted by name (desc)

<img width="600" alt="" src="https://github.com/user-attachments/assets/2933f069-bf19-4c4a-a1a7-be88f0546362" />

## Sorted by last updated (asc)

<img width="600" alt="" src="https://github.com/user-attachments/assets/bc6ed9ea-592a-4f0b-8112-e4cfcb7ba925" />

## Sorted by last updated (desc)

<img width="600" alt="" src="https://github.com/user-attachments/assets/0bdf61a0-f22f-4b00-8878-e88fbb0629a7" />

## Sorted by name (desc) with search

<img width="600" alt="" src="https://github.com/user-attachments/assets/727827f9-3026-4810-b90e-bdccee2ddcbb" />
