### PR TITLE
Add extra rubrics and term differences to more info modal

### DIFF
--- a/assets/src/scripts/__tests__/builder/codelistbuilder.test.jsx
+++ b/assets/src/scripts/__tests__/builder/codelistbuilder.test.jsx
@@ -36,6 +36,7 @@ const renderCodelistBuilder = (data, hierarchy, visiblePaths) => {
   render(
     <CodelistBuilder
       allCodes={data.all_codes}
+      codeToDaggerAsteriskInfo={data.code_to_dagger_asterisk_info ?? {}}
       codeToStatus={data.code_to_status}
       codeToTerm={data.code_to_term}
       draftURL={data.draft_url}

--- a/assets/src/scripts/__tests__/components/Codelist/MoreInfoModal.spec.tsx
+++ b/assets/src/scripts/__tests__/components/Codelist/MoreInfoModal.spec.tsx
@@ -198,6 +198,85 @@ it.each([
   ).toBeVisible();
 });
 
+it("shows clinically equivalent ICD-10 description differences in a green box", async () => {
+  vi.mocked(readValueFromPage).mockReturnValue({ coding_system_id: "icd10" });
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(() =>
+      Promise.resolve({
+        json: () =>
+          Promise.resolve({
+            term_differences: {
+              "123": {
+                combined_2016: "NHS description",
+                who_2019: "WHO description",
+                equivalent: true,
+              },
+            },
+          }),
+      }),
+    ),
+  );
+
+  const user = userEvent.setup();
+  render(<MoreInfoModal {...props} />);
+  await user.click(screen.getByRole("button", { name: /more info/i }));
+
+  const descriptionSection = (
+    await screen.findByText("ICD-10 Edition Descriptions")
+  ).closest("section");
+  expect(descriptionSection).toHaveClass("border-success");
+
+  expect(
+    screen.getByText("The description of 123 differs", { exact: false }),
+  ).toBeVisible();
+  expect(
+    screen.getByText("We consider these terms clinically equivalent", {
+      exact: false,
+    }),
+  ).toBeVisible();
+  expect(screen.getByText("NHS description")).toBeVisible();
+  expect(screen.getByText("WHO description")).toBeVisible();
+});
+
+it("shows clinically different ICD-10 description differences in a red box", async () => {
+  vi.mocked(readValueFromPage).mockReturnValue({ coding_system_id: "icd10" });
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(() =>
+      Promise.resolve({
+        json: () =>
+          Promise.resolve({
+            term_differences: {
+              "123": {
+                combined_2016: "NHS description",
+                who_2019: "WHO description",
+                equivalent: false,
+              },
+            },
+          }),
+      }),
+    ),
+  );
+
+  const user = userEvent.setup();
+  render(<MoreInfoModal {...props} />);
+  await user.click(screen.getByRole("button", { name: /more info/i }));
+
+  const descriptionSection = (
+    await screen.findByText("ICD-10 Edition Descriptions")
+  ).closest("section");
+  expect(descriptionSection).toHaveClass("border-danger");
+  expect(
+    screen.getByText("The description of 123 differs", { exact: false }),
+  ).toBeVisible();
+  expect(
+    screen.getByText("We consider these terms different", { exact: false }),
+  ).toBeVisible();
+  expect(screen.getByText("NHS description")).toBeVisible();
+  expect(screen.getByText("WHO description")).toBeVisible();
+});
+
 it("shows ICD-10 modifier rubric information", async () => {
   vi.mocked(readValueFromPage).mockReturnValue({ coding_system_id: "icd10" });
   vi.stubGlobal(

--- a/assets/src/scripts/__tests__/components/Codelist/MoreInfoModal.spec.tsx
+++ b/assets/src/scripts/__tests__/components/Codelist/MoreInfoModal.spec.tsx
@@ -1,9 +1,10 @@
 import "@testing-library/jest-dom";
-import { act, render, screen, within } from "@testing-library/react";
+import { act, render, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import React from "react";
 import { afterEach, beforeEach, expect, it, vi } from "vitest";
 import Hierarchy from "../../../_hierarchy";
+import { getCookie, readValueFromPage } from "../../../_utils";
 import MoreInfoModal from "../../../components/Codelist/MoreInfoModal";
 import type { Status } from "../../../types";
 import * as versionWithCompleteSearchesData from "../../fixtures/version_with_complete_searches.json";
@@ -11,10 +12,13 @@ import * as versionWithCompleteSearchesData from "../../fixtures/version_with_co
 // Mock dependencies
 vi.mock("../../../_utils", () => ({
   getCookie: vi.fn(() => "test-csrf-token"),
-  readValueFromPage: () => ({ coding_system_id: "snomedct" }),
+  readValueFromPage: vi.fn(() => ({ coding_system_id: "snomedct" })),
 }));
 
 beforeEach(() => {
+  vi.mocked(readValueFromPage).mockReturnValue({
+    coding_system_id: "snomedct",
+  });
   vi.stubGlobal(
     "fetch",
     vi.fn(() =>
@@ -49,6 +53,9 @@ const props = {
 it("renders More info button", () => {
   render(<MoreInfoModal {...props} />);
   expect(screen.getByRole("button", { name: /more info/i })).toBeVisible();
+  expect(
+    screen.queryByRole("button", { name: /icd-10 .* information/i }),
+  ).not.toBeInTheDocument();
 });
 
 it("shows modal and fetches synonyms and references on button click", async () => {
@@ -135,4 +142,412 @@ it("show 'No synonyms' if the only synonym matches the primary term", async () =
   render(<MoreInfoModal {...props} />);
   await user.click(screen.getByRole("button", { name: /more info/i }));
   expect(await screen.findByText(/no synonyms/i)).toBeVisible();
+});
+
+it.each([
+  ["-", { target: "-" }, "Excluded"],
+  ["?", { target: "?" }, "Unresolved"],
+  [
+    "(+)",
+    { includedAncestor: "+", excludedAncestor: "?", target: "(+)" },
+    'Included because you included its ancestor: "Included ancestor [includedAncestor]"',
+  ],
+  [
+    "(-)",
+    { includedAncestor: "?", excludedAncestor: "-", target: "(-)" },
+    'Excluded because you excluded its ancestor: "Excluded ancestor [excludedAncestor]"',
+  ],
+  [
+    "!",
+    { includedAncestor: "+", excludedAncestor: "-", target: "!" },
+    'In conflict!  Included by "Included ancestor [includedAncestor]", and excluded by "Excluded ancestor [excludedAncestor]"',
+  ],
+] as const)("shows status text for %s status", async (status, codeToStatus, expectedText) => {
+  const user = userEvent.setup();
+  const hierarchy = new Hierarchy(
+    {
+      target: ["includedAncestor", "excludedAncestor"],
+    },
+    {
+      includedAncestor: ["target"],
+      excludedAncestor: ["target"],
+    },
+  );
+
+  render(
+    <MoreInfoModal
+      allCodes={["includedAncestor", "excludedAncestor", "target"]}
+      code="target"
+      codeToStatus={codeToStatus}
+      codeToTerm={{
+        includedAncestor: "Included ancestor",
+        excludedAncestor: "Excluded ancestor",
+        target: "Target term",
+      }}
+      hierarchy={hierarchy}
+      status={status}
+      term="Target term"
+    />,
+  );
+  await user.click(screen.getByRole("button", { name: /more info/i }));
+
+  expect(
+    await screen.findByText(
+      (_, element) => element?.textContent === expectedText,
+    ),
+  ).toBeVisible();
+});
+
+it("shows ICD-10 modifier rubric information", async () => {
+  vi.mocked(readValueFromPage).mockReturnValue({ coding_system_id: "icd10" });
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(() =>
+      Promise.resolve({
+        json: () =>
+          Promise.resolve({
+            rubrics: {
+              "123": {
+                concept_rubrics: {},
+                modifier_rubrics: {
+                  "Multiple sites": {
+                    note: ["Includes multiple sites"],
+                  },
+                },
+              },
+            },
+          }),
+      }),
+    ),
+  );
+
+  const user = userEvent.setup();
+  render(<MoreInfoModal {...props} />);
+  await user.click(screen.getByRole("button", { name: /more info/i }));
+
+  expect(
+    await screen.findByRole("heading", { name: "Modifier: Multiple sites" }),
+  ).toBeVisible();
+  expect(screen.getByText("Includes multiple sites")).toBeVisible();
+});
+
+it("uses consistent cards", async () => {
+  vi.mocked(readValueFromPage).mockReturnValue({ coding_system_id: "icd10" });
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(() =>
+      Promise.resolve({
+        json: () =>
+          Promise.resolve({
+            rubrics: {
+              "123": {
+                concept_rubrics: {
+                  inclusion: ["Included condition"],
+                  "coding-hint": ["Use an additional code"],
+                },
+                modifier_rubrics: {
+                  "Multiple sites": {
+                    note: ["Includes multiple sites"],
+                  },
+                },
+              },
+            },
+          }),
+      }),
+    ),
+  );
+
+  const user = userEvent.setup();
+  render(<MoreInfoModal {...props} />);
+  await user.click(screen.getByRole("button", { name: /more info/i }));
+
+  const conceptCard = (
+    await screen.findByRole("heading", { name: "Concept: Test Term" })
+  ).closest("section") as HTMLElement;
+  const modifierCard = screen
+    .getByRole("heading", { name: "Modifier: Multiple sites" })
+    .closest("section") as HTMLElement;
+  const codingHint = screen.getByText("Coding hint:");
+
+  for (const card of [conceptCard, modifierCard]) {
+    expect(card).toHaveClass("builder__additional-info-card");
+  }
+  expect(conceptCard).toHaveClass("builder__additional-info-card--concept");
+  expect(
+    conceptCard.compareDocumentPosition(codingHint) &
+      Node.DOCUMENT_POSITION_FOLLOWING,
+  ).toBeTruthy();
+  expect(
+    codingHint.compareDocumentPosition(modifierCard) &
+      Node.DOCUMENT_POSITION_FOLLOWING,
+  ).toBeTruthy();
+});
+
+it("handles ICD-10 rubrics with omitted optional fields", async () => {
+  vi.mocked(readValueFromPage).mockReturnValue({ coding_system_id: "icd10" });
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(() =>
+      Promise.resolve({
+        json: () =>
+          Promise.resolve({
+            rubrics: {
+              "123": {
+                concept_rubrics: {
+                  inclusion: ["Rubric without optional fields"],
+                },
+              },
+            },
+          }),
+      }),
+    ),
+  );
+
+  const user = userEvent.setup();
+  render(<MoreInfoModal {...props} />);
+  await user.click(screen.getByRole("button", { name: /more info/i }));
+
+  expect(
+    await screen.findByText("Rubric without optional fields"),
+  ).toBeVisible();
+});
+
+it("formats, filters, and orders ICD-10 rubric kinds", async () => {
+  vi.mocked(readValueFromPage).mockReturnValue({ coding_system_id: "icd10" });
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(() =>
+      Promise.resolve({
+        json: () =>
+          Promise.resolve({
+            rubrics: {
+              "123": {
+                concept_rubrics: {
+                  note: ["Ordered note"],
+                  z_kind: ["Generic rubric"],
+                  modifierlink: ["Hidden modifier link"],
+                  "coding-hint": ["Use additional code"],
+                  alpha_kind: ["Alpha rubric"],
+                  definition: ["Ordered definition"],
+                },
+                modifier_rubrics: {},
+              },
+            },
+          }),
+      }),
+    ),
+  );
+
+  const user = userEvent.setup();
+  render(<MoreInfoModal {...props} />);
+  await user.click(screen.getByRole("button", { name: /more info/i }));
+
+  const alphaHeading = await screen.findByRole("heading", {
+    name: "alpha-kind",
+  });
+  const zHeading = screen.getByRole("heading", { name: "z-kind" });
+  const definition = screen.getByText("Ordered definition");
+  const note = screen.getByText("Ordered note");
+  const conceptCard = screen
+    .getByRole("heading", { name: "Concept: Test Term" })
+    .closest("section") as HTMLElement;
+
+  expect(within(conceptCard).getByText("Coding hint:")).toBeVisible();
+  expect(within(conceptCard).getByText("Use additional code")).toBeVisible();
+  expect(within(conceptCard).getByText("Generic rubric")).toBeVisible();
+  expect(within(conceptCard).getByText("Alpha rubric")).toBeVisible();
+  expect(within(conceptCard).queryByText("Ordered definition")).toBeNull();
+  expect(within(conceptCard).queryByText("Ordered note")).toBeNull();
+  expect(screen.queryByText("Hidden modifier link")).toBeNull();
+  expect(
+    definition.compareDocumentPosition(note) & Node.DOCUMENT_POSITION_FOLLOWING,
+  ).toBeTruthy();
+  expect(
+    note.compareDocumentPosition(alphaHeading) &
+      Node.DOCUMENT_POSITION_FOLLOWING,
+  ).toBeTruthy();
+  expect(
+    alphaHeading.compareDocumentPosition(zHeading) &
+      Node.DOCUMENT_POSITION_FOLLOWING,
+  ).toBeTruthy();
+});
+
+it("groups non-italic rubrics in a concept box with inclusion and exclusion first", async () => {
+  vi.mocked(readValueFromPage).mockReturnValue({ coding_system_id: "icd10" });
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(() =>
+      Promise.resolve({
+        json: () =>
+          Promise.resolve({
+            rubrics: {
+              "123": {
+                concept_rubrics: {
+                  exclusion: ["Excluded condition"],
+                  inclusion: ["Included condition"],
+                  note: ["Outside the grouped box"],
+                  "coding-hint": ["Use an additional code"],
+                },
+                modifier_rubrics: {},
+              },
+            },
+          }),
+      }),
+    ),
+  );
+
+  const user = userEvent.setup();
+  render(<MoreInfoModal {...props} term="Test Term : Multiple sites" />);
+  await user.click(screen.getByRole("button", { name: /more info/i }));
+
+  const groupedRubrics = (
+    await screen.findByRole("heading", { name: "Concept: Test Term" })
+  ).closest("section");
+  const note = screen.getByText("Outside the grouped box");
+  const codingHint = screen.getByText("Coding hint:");
+
+  expect(groupedRubrics).toHaveClass("builder__additional-info-card");
+  expect(
+    within(groupedRubrics as HTMLElement).getByText("Includes:"),
+  ).toBeVisible();
+  expect(
+    within(groupedRubrics as HTMLElement).getByText("Included condition"),
+  ).toBeVisible();
+  expect(
+    within(groupedRubrics as HTMLElement).getByText("Excludes:"),
+  ).toBeVisible();
+  expect(
+    within(groupedRubrics as HTMLElement).getByText("Excluded condition"),
+  ).toBeVisible();
+  expect(
+    within(groupedRubrics as HTMLElement).queryByText(
+      "Outside the grouped box",
+    ),
+  ).toBeNull();
+  expect(note).toBeVisible();
+  expect(
+    within(groupedRubrics as HTMLElement).getByText("Use an additional code"),
+  ).toBeVisible();
+  expect(
+    note.compareDocumentPosition(groupedRubrics as HTMLElement) &
+      Node.DOCUMENT_POSITION_FOLLOWING,
+  ).toBeTruthy();
+  expect(
+    within(groupedRubrics as HTMLElement)
+      .getByText("Excluded condition")
+      .compareDocumentPosition(codingHint) & Node.DOCUMENT_POSITION_FOLLOWING,
+  ).toBeTruthy();
+});
+
+it("does not show the ICD-10 rubric section when no rubrics are returned", async () => {
+  vi.mocked(readValueFromPage).mockReturnValue({ coding_system_id: "icd10" });
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(() =>
+      Promise.resolve({
+        json: () =>
+          Promise.resolve({
+            rubrics: {
+              "123": {
+                concept_rubrics: {},
+                modifier_rubrics: {},
+              },
+            },
+          }),
+      }),
+    ),
+  );
+
+  const user = userEvent.setup();
+  render(<MoreInfoModal {...props} />);
+  await user.click(screen.getByRole("button", { name: /more info/i }));
+
+  expect(await screen.findByText("Included")).toBeVisible();
+  expect(screen.queryByText("WHO ICD-10 Additional Info")).toBeNull();
+});
+
+it("does not show the ICD-10 rubric section when rubric fields are omitted", async () => {
+  vi.mocked(readValueFromPage).mockReturnValue({ coding_system_id: "icd10" });
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(() =>
+      Promise.resolve({
+        json: () =>
+          Promise.resolve({
+            rubrics: {
+              "123": {},
+            },
+          }),
+      }),
+    ),
+  );
+
+  const user = userEvent.setup();
+  render(<MoreInfoModal {...props} />);
+  await user.click(screen.getByRole("button", { name: /more info/i }));
+
+  expect(await screen.findByText("Included")).toBeVisible();
+  expect(screen.queryByText("WHO ICD-10 Additional Info")).toBeNull();
+});
+
+it("closes the modal", async () => {
+  const user = userEvent.setup();
+  render(<MoreInfoModal {...props} />);
+  await user.click(screen.getByRole("button", { name: /more info/i }));
+
+  expect(await screen.findByRole("dialog")).toBeVisible();
+  await user.click(screen.getByRole("button", { name: /close/i }));
+
+  await waitFor(() => {
+    expect(screen.queryByRole("dialog")).toBeNull();
+  });
+});
+
+it("does not refetch loaded more-info data when reopened", async () => {
+  const fetch = vi.fn((_: string, __: RequestInit) =>
+    Promise.resolve({
+      json: () =>
+        Promise.resolve({
+          synonyms: { "123": ["Alpha"] },
+          references: { "123": [] },
+        }),
+    }),
+  );
+  vi.stubGlobal("fetch", fetch);
+
+  const user = userEvent.setup();
+  render(<MoreInfoModal {...props} />);
+  await user.click(screen.getByRole("button", { name: /more info/i }));
+  expect(await screen.findByText("Alpha")).toBeVisible();
+  await user.click(screen.getByRole("button", { name: /close/i }));
+  await waitFor(() => {
+    expect(screen.queryByRole("dialog")).toBeNull();
+  });
+
+  await user.click(screen.getByRole("button", { name: /more info/i }));
+
+  expect(await screen.findByText("Alpha")).toBeVisible();
+  expect(fetch).toHaveBeenCalledTimes(1);
+});
+
+it("fetches more-info data without a CSRF header when there is no cookie", async () => {
+  vi.mocked(getCookie).mockReturnValue(undefined);
+  const fetch = vi.fn((_: string, __: RequestInit) =>
+    Promise.resolve({
+      json: () =>
+        Promise.resolve({
+          synonyms: { "123": [] },
+          references: { "123": [] },
+        }),
+    }),
+  );
+  vi.stubGlobal("fetch", fetch);
+
+  const user = userEvent.setup();
+  render(<MoreInfoModal {...props} />);
+  await user.click(screen.getByRole("button", { name: /more info/i }));
+
+  expect(await screen.findByText(/no synonyms/i)).toBeVisible();
+  const headers = fetch.mock.calls[0][1].headers as Headers;
+  expect(headers.has("X-CSRFToken")).toBe(false);
 });

--- a/assets/src/scripts/__tests__/components/Codelist/MoreInfoModal.spec.tsx
+++ b/assets/src/scripts/__tests__/components/Codelist/MoreInfoModal.spec.tsx
@@ -277,6 +277,102 @@ it("shows clinically different ICD-10 description differences in a red box", asy
   expect(screen.getByText("WHO description")).toBeVisible();
 });
 
+it("shows ICD-10 dagger information in the WHO additional info box", async () => {
+  vi.mocked(readValueFromPage).mockReturnValue({ coding_system_id: "icd10" });
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(() =>
+      Promise.resolve({
+        json: () =>
+          Promise.resolve({
+            rubrics: {
+              "123": {
+                concept_rubrics: {},
+                modifier_rubrics: {},
+              },
+            },
+          }),
+      }),
+    ),
+  );
+
+  const user = userEvent.setup();
+  render(
+    <MoreInfoModal
+      {...props}
+      daggerAsteriskInfo={{
+        usage: "dagger",
+        url: "https://icd.who.int/browse10/2019/en#/A12.3",
+      }}
+    />,
+  );
+
+  await user.click(
+    screen.getByRole("button", {
+      name: /show icd-10 dagger information for 123/i,
+    }),
+  );
+
+  expect(await screen.findByText("WHO ICD-10 Additional Info")).toBeVisible();
+  expect(screen.getByRole("heading", { name: /usage: dagger/i })).toBeVisible();
+  expect(
+    screen.getByText(
+      "Dagger codes identify the underlying condition; asterisk codes identify the manifestation.",
+    ),
+  ).toBeVisible();
+  expect(
+    screen.getByRole("link", {
+      name: /view 123 in the who icd-10 browser/i,
+    }),
+  ).toHaveAttribute("href", "https://icd.who.int/browse10/2019/en#/A12.3");
+  expect(
+    screen.getByRole("link", {
+      name: /read the full dagger\/asterisk guidance \(section 3.1.3 - p20\)/i,
+    }),
+  ).toBeVisible();
+});
+
+it("shows ICD-10 asterisk information without a code-specific browser link", async () => {
+  vi.mocked(readValueFromPage).mockReturnValue({ coding_system_id: "icd10" });
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(() =>
+      Promise.resolve({
+        json: () => Promise.resolve({}),
+      }),
+    ),
+  );
+
+  const user = userEvent.setup();
+  render(
+    <MoreInfoModal
+      {...props}
+      daggerAsteriskInfo={{
+        usage: "asterisk",
+      }}
+    />,
+  );
+
+  const usageButton = screen.getByRole("button", {
+    name: /show icd-10 asterisk information for 123/i,
+  });
+  expect(usageButton).toHaveTextContent("*");
+
+  await user.click(usageButton);
+
+  expect(
+    await screen.findByRole("heading", {
+      name: /usage: asterisk/i,
+    }),
+  ).toBeVisible();
+  expect(screen.queryByRole("link", { name: /view 123/i })).toBeNull();
+  expect(
+    screen.getByRole("link", {
+      name: /read the full dagger\/asterisk guidance \(section 3.1.3 - p20\)/i,
+    }),
+  ).toBeVisible();
+});
+
 it("shows ICD-10 modifier rubric information", async () => {
   vi.mocked(readValueFromPage).mockReturnValue({ coding_system_id: "icd10" });
   vi.stubGlobal(
@@ -310,7 +406,7 @@ it("shows ICD-10 modifier rubric information", async () => {
   expect(screen.getByText("Includes multiple sites")).toBeVisible();
 });
 
-it("uses consistent cards", async () => {
+it("uses consistent cards and renders usage after concept and modifier rubrics", async () => {
   vi.mocked(readValueFromPage).mockReturnValue({ coding_system_id: "icd10" });
   vi.stubGlobal(
     "fetch",
@@ -337,7 +433,7 @@ it("uses consistent cards", async () => {
   );
 
   const user = userEvent.setup();
-  render(<MoreInfoModal {...props} />);
+  render(<MoreInfoModal {...props} daggerAsteriskInfo={{ usage: "dagger" }} />);
   await user.click(screen.getByRole("button", { name: /more info/i }));
 
   const conceptCard = (
@@ -346,18 +442,30 @@ it("uses consistent cards", async () => {
   const modifierCard = screen
     .getByRole("heading", { name: "Modifier: Multiple sites" })
     .closest("section") as HTMLElement;
+  const usageCard = screen
+    .getByRole("heading", { name: /usage: dagger/i })
+    .closest("section") as HTMLElement;
   const codingHint = screen.getByText("Coding hint:");
 
-  for (const card of [conceptCard, modifierCard]) {
+  for (const card of [conceptCard, modifierCard, usageCard]) {
     expect(card).toHaveClass("builder__additional-info-card");
   }
   expect(conceptCard).toHaveClass("builder__additional-info-card--concept");
+  expect(modifierCard).not.toHaveClass(
+    "builder__additional-info-card--concept",
+    "builder__additional-info-card--usage",
+  );
+  expect(usageCard).toHaveClass("builder__additional-info-card--usage");
   expect(
     conceptCard.compareDocumentPosition(codingHint) &
       Node.DOCUMENT_POSITION_FOLLOWING,
   ).toBeTruthy();
   expect(
     codingHint.compareDocumentPosition(modifierCard) &
+      Node.DOCUMENT_POSITION_FOLLOWING,
+  ).toBeTruthy();
+  expect(
+    modifierCard.compareDocumentPosition(usageCard) &
       Node.DOCUMENT_POSITION_FOLLOWING,
   ).toBeTruthy();
 });

--- a/assets/src/scripts/__tests__/fixtures/version_from_scratch.json
+++ b/assets/src/scripts/__tests__/fixtures/version_from_scratch.json
@@ -853,6 +853,7 @@
     "439656005": "+",
     "73583000": "(+)"
   },
+  "code_to_dagger_asterisk_info": {},
   "is_editable": true,
   "update_url": "/builder/71bb8ca2/update/",
   "search_url": "/builder/71bb8ca2/search/",

--- a/assets/src/scripts/__tests__/fixtures/version_with_complete_searches.json
+++ b/assets/src/scripts/__tests__/fixtures/version_with_complete_searches.json
@@ -853,6 +853,7 @@
     "439656005": "+",
     "73583000": "(+)"
   },
+  "code_to_dagger_asterisk_info": {},
   "is_editable": true,
   "update_url": "/builder/71bb8ca2/update/",
   "search_url": "/builder/71bb8ca2/search/",

--- a/assets/src/scripts/__tests__/fixtures/version_with_no_searches.json
+++ b/assets/src/scripts/__tests__/fixtures/version_with_no_searches.json
@@ -460,6 +460,7 @@
     "439656005": "-",
     "73583000": "(+)"
   },
+  "code_to_dagger_asterisk_info": {},
   "is_editable": true,
   "update_url": "/builder/23da730d/update/",
   "search_url": "/builder/23da730d/search/",

--- a/assets/src/scripts/__tests__/fixtures/version_with_some_searches.json
+++ b/assets/src/scripts/__tests__/fixtures/version_with_some_searches.json
@@ -470,6 +470,7 @@
     "439656005": "+",
     "73583000": "(+)"
   },
+  "code_to_dagger_asterisk_info": {},
   "is_editable": true,
   "update_url": "/builder/0acaffd8/update/",
   "search_url": "/builder/0acaffd8/search/",

--- a/assets/src/scripts/builder/index.tsx
+++ b/assets/src/scripts/builder/index.tsx
@@ -32,6 +32,9 @@ if (container) {
         allCodes={readValueFromPage("all-codes")}
         codeToStatus={codeToStatus}
         codeToTerm={codeToTerm}
+        codeToDaggerAsteriskInfo={readValueFromPage(
+          "code-to-dagger-asterisk-info",
+        )}
         draftURL={readValueFromPage("draft-url")}
         hierarchy={hierarchy}
         icd10TermDifferences={readValueFromPage("icd10-term-differences")}

--- a/assets/src/scripts/components/Codelist/Container.tsx
+++ b/assets/src/scripts/components/Codelist/Container.tsx
@@ -6,6 +6,7 @@ import Section from "./Section";
 
 interface ContainerProps {
   allCodes: PageData["allCodes"];
+  codeToDaggerAsteriskInfo: PageData["codeToDaggerAsteriskInfo"];
   codeToStatus: PageData["codeToStatus"];
   codeToTerm: PageData["codeToTerm"];
   hierarchy: Hierarchy;
@@ -18,6 +19,7 @@ interface ContainerProps {
 
 export default function Container({
   allCodes,
+  codeToDaggerAsteriskInfo,
   codeToStatus,
   codeToTerm,
   hierarchy,
@@ -47,6 +49,7 @@ export default function Container({
           key={heading}
           allCodes={allCodes}
           ancestorCodes={ancestorCodes}
+          codeToDaggerAsteriskInfo={codeToDaggerAsteriskInfo}
           codeToStatus={codeToStatus}
           codeToTerm={codeToTerm}
           heading={heading}

--- a/assets/src/scripts/components/Codelist/MoreInfoModal.tsx
+++ b/assets/src/scripts/components/Codelist/MoreInfoModal.tsx
@@ -2,7 +2,14 @@ import React, { useEffect, useState } from "react";
 import { Button, Modal } from "react-bootstrap";
 import type Hierarchy from "../../_hierarchy";
 import { getCookie, readValueFromPage } from "../../_utils";
-import type { Code, PageData, Status, Term } from "../../types";
+import type {
+  Code,
+  DaggerAsteriskInfo,
+  DaggerAsteriskUsage,
+  PageData,
+  Status,
+  Term,
+} from "../../types";
 
 interface CreateModalTextProps {
   allCodes: PageData["allCodes"];
@@ -341,9 +348,21 @@ interface MoreInfoModalProps {
   code: Code;
   codeToStatus: PageData["codeToStatus"];
   codeToTerm: PageData["codeToTerm"];
+  daggerAsteriskInfo?: DaggerAsteriskInfo;
   hierarchy: Hierarchy;
   status: Status;
   term: Term;
+}
+
+const daggerAsteriskGuidanceUrl =
+  "https://icd.who.int/browse10/Content/statichtml/ICD10Volume2_en_2019.pdf#page=29";
+
+function usageLabel(usage: DaggerAsteriskUsage) {
+  return usage === "dagger" ? "Dagger" : "Asterisk";
+}
+
+function usageGlyph(usage: DaggerAsteriskUsage) {
+  return usage === "dagger" ? "†" : "*";
 }
 
 function MoreInfoModal({
@@ -351,6 +370,7 @@ function MoreInfoModal({
   code,
   codeToStatus,
   codeToTerm,
+  daggerAsteriskInfo,
   hierarchy,
   status,
   term,
@@ -430,6 +450,17 @@ function MoreInfoModal({
 
   return (
     <>
+      {daggerAsteriskInfo && (
+        <button
+          className="builder__dagger-asterisk-link"
+          onClick={handleShow}
+          type="button"
+          aria-label={`Show ICD-10 ${daggerAsteriskInfo.usage} information for ${code}`}
+          title={`ICD-10 ${daggerAsteriskInfo.usage} code`}
+        >
+          <span>{usageGlyph(daggerAsteriskInfo.usage)}</span>
+        </button>
+      )}
       <Button
         className="builder__more-info-btn plausible-event-name=More+info+click"
         onClick={handleShow}
@@ -479,7 +510,7 @@ function MoreInfoModal({
               termDifferences={termDifferences}
             />
           )}
-          {hasRubrics(rubrics) && (
+          {(hasRubrics(rubrics) || daggerAsteriskInfo) && (
             <section className="border border-info rounded overflow-hidden mb-4">
               {/* WHO header */}
               <div className="bg-info text-white px-4 py-3">
@@ -496,6 +527,42 @@ function MoreInfoModal({
               <div className="bg-white pt-3 px-4">
                 {rubrics && hasRubrics(rubrics) && (
                   <RubricBlock rubrics={rubrics} term={term} />
+                )}
+                {daggerAsteriskInfo && (
+                  <section className="builder__additional-info-card builder__additional-info-card--usage">
+                    <h3 className="h6 font-weight-bold mb-3 d-flex align-items-center">
+                      Usage: {usageLabel(daggerAsteriskInfo.usage)}
+                      <span className="builder__dagger-asterisk-info__marker ml-2">
+                        {usageGlyph(daggerAsteriskInfo.usage)}
+                      </span>
+                    </h3>
+                    <p>
+                      Dagger codes identify the underlying condition; asterisk
+                      codes identify the manifestation.
+                    </p>
+                    <p className="mb-0 small">
+                      {daggerAsteriskInfo.url && (
+                        <>
+                          <a
+                            href={daggerAsteriskInfo.url}
+                            rel="noreferrer"
+                            target="_blank"
+                          >
+                            View {code} in the WHO ICD-10 browser
+                          </a>
+                          {" · "}
+                        </>
+                      )}
+                      <a
+                        href={daggerAsteriskGuidanceUrl}
+                        rel="noreferrer"
+                        target="_blank"
+                      >
+                        Read the full dagger/asterisk guidance (section 3.1.3 -
+                        p20)
+                      </a>
+                    </p>
+                  </section>
                 )}
               </div>
             </section>

--- a/assets/src/scripts/components/Codelist/MoreInfoModal.tsx
+++ b/assets/src/scripts/components/Codelist/MoreInfoModal.tsx
@@ -13,6 +13,187 @@ interface CreateModalTextProps {
   status: Status;
 }
 
+type RubricValues = Record<string, string[]>;
+
+interface CodeRubrics {
+  concept_rubrics?: RubricValues;
+  modifier_rubrics?: Record<string, RubricValues>;
+}
+
+const rubricDisplayNames: Record<string, string> = {
+  exclusion: "Excludes:",
+  inclusion: "Includes:",
+  "coding-hint": "Coding hint:",
+};
+
+const rubricOrder = [
+  "definition",
+  "text",
+  "note",
+  "inclusion",
+  "exclusion",
+  "coding-hint",
+];
+const italicRubricKinds = ["footnote", "text", "note", "definition"];
+const inlineHeaderRubricKinds = ["coding-hint"];
+const groupedConceptRubricKinds = ["inclusion", "exclusion"];
+
+function emptyRubrics(): CodeRubrics {
+  return {
+    concept_rubrics: {},
+    modifier_rubrics: {},
+  };
+}
+
+function formatRubricKind(kind: string) {
+  return rubricDisplayNames[kind] || kind.replaceAll("_", "-");
+}
+
+function sortAndFilterRubricEntries(rubrics: RubricValues) {
+  return Object.entries(rubrics)
+    .filter(([kind]) => kind !== "modifierlink")
+    .sort(([left], [right]) => {
+      const leftIndex = rubricOrder.indexOf(left);
+      const rightIndex = rubricOrder.indexOf(right);
+
+      if (leftIndex !== -1 || rightIndex !== -1) {
+        return (
+          (leftIndex === -1 ? rubricOrder.length : leftIndex) -
+          (rightIndex === -1 ? rubricOrder.length : rightIndex)
+        );
+      }
+
+      return left.localeCompare(right);
+    });
+}
+
+function hasRubricValues(rubricValues?: RubricValues) {
+  return Object.values(rubricValues || {}).some((values) => values.length > 0);
+}
+
+function hasRubrics(rubrics: CodeRubrics | null) {
+  if (!rubrics) {
+    return false;
+  }
+
+  return (
+    hasRubricValues(rubrics.concept_rubrics) ||
+    Object.values(rubrics.modifier_rubrics || {}).some(hasRubricValues)
+  );
+}
+
+function rubricMultipleWithHeader(kind: string, values: string[]) {
+  return (
+    <>
+      <h3 className="h6 font-weight-bold">{formatRubricKind(kind)}</h3>
+      <ul>
+        {values.map((value, idx) => (
+          // biome-ignore lint/suspicious/noArrayIndexKey: item won't be re-rendered based on key
+          <li key={idx}>{value}</li>
+        ))}
+      </ul>
+    </>
+  );
+}
+
+function rubricWithHeaderInline(kind: string, values: string[]) {
+  return (
+    <p>
+      <span className="h6 font-weight-bold">{formatRubricKind(kind)} </span>
+      {values.join(" ")}
+    </p>
+  );
+}
+
+function rubricItalicWithoutHeader(value: string) {
+  return <p className="font-italic">{value}</p>;
+}
+
+function rubricFormat(kind: string, values: string[]) {
+  if (italicRubricKinds.includes(kind)) {
+    return rubricItalicWithoutHeader(values.join(" "));
+  } else if (inlineHeaderRubricKinds.includes(kind)) {
+    return rubricWithHeaderInline(kind, values);
+  } else {
+    return rubricMultipleWithHeader(kind, values);
+  }
+}
+
+function RubricList({ rubrics }: { rubrics: RubricValues }) {
+  return sortAndFilterRubricEntries(rubrics).map(([kind, values]) => (
+    <React.Fragment key={kind}>{rubricFormat(kind, values)}</React.Fragment>
+  ));
+}
+
+function mainTerm(term: Term) {
+  return term.split(" : ", 1)[0];
+}
+
+function ConceptRubrics({
+  rubrics,
+  term,
+}: {
+  rubrics: RubricValues;
+  term: Term;
+}) {
+  const boxedRubrics: RubricValues = {};
+  const rubricsBeforeGroup: RubricValues = {};
+  const rubricsAfterGroup: RubricValues = {};
+  const firstGroupedRubricIndex = rubricOrder.indexOf(
+    groupedConceptRubricKinds[0],
+  );
+
+  for (const [kind, values] of Object.entries(rubrics)) {
+    const rubricIndex = rubricOrder.indexOf(kind);
+    let collection = rubricsAfterGroup;
+
+    if (kind !== "modifierlink" && !italicRubricKinds.includes(kind)) {
+      collection = boxedRubrics;
+    } else if (rubricIndex !== -1 && rubricIndex < firstGroupedRubricIndex) {
+      collection = rubricsBeforeGroup;
+    }
+
+    collection[kind] = values;
+  }
+
+  return (
+    <>
+      <RubricList rubrics={rubricsBeforeGroup} />
+      {hasRubricValues(boxedRubrics) && (
+        <section className="builder__additional-info-card builder__additional-info-card--concept">
+          <h3 className="h6 font-weight-bold mb-3">
+            Concept: {mainTerm(term)}
+          </h3>
+          <RubricList rubrics={boxedRubrics} />
+        </section>
+      )}
+      <RubricList rubrics={rubricsAfterGroup} />
+    </>
+  );
+}
+
+function RubricBlock({ rubrics, term }: { rubrics: CodeRubrics; term: Term }) {
+  return (
+    <>
+      {rubrics.concept_rubrics && (
+        <ConceptRubrics rubrics={rubrics.concept_rubrics} term={term} />
+      )}
+
+      {Object.entries(rubrics.modifier_rubrics || {}).map(
+        ([termModifier, modifierRubrics]) => (
+          <section key={termModifier} className="builder__additional-info-card">
+            <h3 className="h6 font-weight-bold mb-3">
+              Modifier: {termModifier}
+            </h3>
+
+            <RubricList rubrics={modifierRubrics} />
+          </section>
+        ),
+      )}
+    </>
+  );
+}
+
 function createModalText({
   allCodes,
   code,
@@ -83,16 +264,20 @@ function MoreInfoModal({
   term,
 }: MoreInfoModalProps) {
   const codingSystemId = readValueFromPage("metadata")?.coding_system_id;
+  const showSynonymsAndReferences = codingSystemId !== "icd10";
 
   const [showMoreInfoModal, setShowMoreInfoModal] = useState(false);
-  const [references, setReferences] = useState<string[] | null>(null);
+  const [references, setReferences] = useState<Array<[string, string]> | null>(
+    null,
+  );
+  const [rubrics, setRubrics] = useState<CodeRubrics | null>(null);
   const [synonyms, setSynonyms] = useState<string[] | null>(null);
   const [modalText, setModalText] = useState("");
   const [loading, setLoading] = useState(false);
 
   const handleShow = () => {
     setShowMoreInfoModal(true);
-    if (synonyms === null || references === null) {
+    if (synonyms === null || references === null || rubrics === null) {
       setLoading(true);
       const requestHeaders = new Headers();
       requestHeaders.append("Accept", "application/json");
@@ -121,10 +306,12 @@ function MoreInfoModal({
             ) || [],
           );
           setReferences(data.references?.[code] || []);
+          setRubrics(data.rubrics?.[code] || emptyRubrics());
         })
         .catch(() => {
           setSynonyms([]);
           setReferences([]);
+          setRubrics(emptyRubrics());
         })
         .finally(() => setLoading(false));
     }
@@ -167,35 +354,64 @@ function MoreInfoModal({
           </Modal.Title>
         </Modal.Header>
         <Modal.Body>
-          <h2 className="h6 font-weight-bold">Synonyms</h2>
-          {loading ? (
-            <p>Loading synonyms...</p>
-          ) : (
-            <ul>
-              {!synonyms || synonyms?.length === 0 ? (
-                <li>No synonyms</li>
+          {showSynonymsAndReferences && (
+            <>
+              <h2 className="h6 font-weight-bold">Synonyms</h2>
+              {loading ? (
+                <p>Loading synonyms...</p>
               ) : (
-                // biome-ignore lint/suspicious/noArrayIndexKey: item won't be re-rendered based on key
-                synonyms.map((synonym, idx) => <li key={idx}>{synonym}</li>)
+                <ul>
+                  {!synonyms || synonyms?.length === 0 ? (
+                    <li>No synonyms</li>
+                  ) : (
+                    // biome-ignore lint/suspicious/noArrayIndexKey: item won't be re-rendered based on key
+                    synonyms.map((synonym, idx) => <li key={idx}>{synonym}</li>)
+                  )}
+                </ul>
               )}
-            </ul>
+            </>
           )}
-          <h2 className="h6 font-weight-bold">References</h2>
-          {loading ? (
-            <p>Loading references...</p>
-          ) : (
-            <ul>
-              {!references?.length ? (
-                <li>No references</li>
+          {hasRubrics(rubrics) && (
+            <section className="border border-info rounded overflow-hidden mb-4">
+              {/* WHO header */}
+              <div className="bg-info text-white px-4 py-3">
+                <div className="font-weight-bold">
+                  WHO ICD-10 Additional Info
+                </div>
+                <small className="opacity-75">
+                  This information is primarily targeted at clinical coders, but
+                  may be useful and so included for completeness.
+                </small>
+              </div>
+
+              {/* WHO body */}
+              <div className="bg-white pt-3 px-4">
+                {rubrics && hasRubrics(rubrics) && (
+                  <RubricBlock rubrics={rubrics} term={term} />
+                )}
+              </div>
+            </section>
+          )}
+          {showSynonymsAndReferences && (
+            <>
+              <h2 className="h6 font-weight-bold">References</h2>
+              {loading ? (
+                <p>Loading references...</p>
               ) : (
-                references.map((reference, idx) => (
-                  // biome-ignore lint/suspicious/noArrayIndexKey: item won't be re-rendered based on key
-                  <li key={idx}>
-                    <a href={reference[1]}>{reference[0]}</a>
-                  </li>
-                ))
+                <ul>
+                  {!references?.length ? (
+                    <li>No references</li>
+                  ) : (
+                    references.map((reference, idx) => (
+                      // biome-ignore lint/suspicious/noArrayIndexKey: item won't be re-rendered based on key
+                      <li key={idx}>
+                        <a href={reference[1]}>{reference[0]}</a>
+                      </li>
+                    ))
+                  )}
+                </ul>
               )}
-            </ul>
+            </>
           )}
           <h2 className="h6 font-weight-bold">Status</h2>
           <p>{modalText}</p>

--- a/assets/src/scripts/components/Codelist/MoreInfoModal.tsx
+++ b/assets/src/scripts/components/Codelist/MoreInfoModal.tsx
@@ -20,6 +20,12 @@ interface CodeRubrics {
   modifier_rubrics?: Record<string, RubricValues>;
 }
 
+interface TermDifferences {
+  combined_2016: string;
+  who_2019: string;
+  equivalent?: boolean | null;
+}
+
 const rubricDisplayNames: Record<string, string> = {
   exclusion: "Excludes:",
   inclusion: "Includes:",
@@ -194,6 +200,92 @@ function RubricBlock({ rubrics, term }: { rubrics: CodeRubrics; term: Term }) {
   );
 }
 
+function TermDifferenceSection({
+  code,
+  termDifferences,
+}: {
+  code: Code;
+  termDifferences: TermDifferences;
+}) {
+  const descriptionMessage = termDifferences.equivalent
+    ? "We consider these terms clinically equivalent, so this code can be used irrespective of the ICD-10 edition used in the data."
+    : "We consider these terms different. Check which dataset you are querying before deciding whether to use this code.";
+  const variant = termDifferences.equivalent ? "success" : "danger";
+
+  return (
+    <section
+      className={`border border-${variant} rounded overflow-hidden mb-4`}
+    >
+      <div className={`bg-${variant} text-white px-4 py-3`}>
+        <div className="font-weight-bold">ICD-10 Edition Descriptions</div>
+        <small className="opacity-75">
+          The description of {code} differs between the{" "}
+          <a
+            href="https://classbrowser.nhs.uk/#/book/ICD-10-5TH-Edition"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="font-weight-bold builder__more-info-modal__link"
+          >
+            NHS 2016 ICD-10 edition
+          </a>{" "}
+          used in{" "}
+          <a
+            href="https://docs.opensafely.org/ehrql/reference/schemas/tpp/#apcs"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="font-weight-bold builder__more-info-modal__link"
+          >
+            APCS admissions data
+          </a>{" "}
+          and the{" "}
+          <a
+            href="https://icd.who.int/browse10/2019/en"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="font-weight-bold builder__more-info-modal__link"
+          >
+            WHO 2019 edition
+          </a>{" "}
+          used in{" "}
+          <a
+            href="https://docs.opensafely.org/ehrql/reference/schemas/tpp/#ons_deaths"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="font-weight-bold builder__more-info-modal__link"
+          >
+            ONS death data
+          </a>
+          . {descriptionMessage}
+        </small>
+      </div>
+
+      <div className="bg-white p-4">
+        <table className="table table-sm mb-0">
+          <thead>
+            <tr>
+              <th>Edition</th>
+              <th>Used in</th>
+              <th>Description</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td className="font-weight-bold">NHS 2016</td>
+              <td className="text-nowrap">APCS (hospital admissions)</td>
+              <td>{termDifferences.combined_2016}</td>
+            </tr>
+            <tr>
+              <td className="font-weight-bold text-nowrap">WHO 2019</td>
+              <td>ONS deaths</td>
+              <td>{termDifferences.who_2019}</td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+    </section>
+  );
+}
+
 function createModalText({
   allCodes,
   code,
@@ -271,6 +363,8 @@ function MoreInfoModal({
     null,
   );
   const [rubrics, setRubrics] = useState<CodeRubrics | null>(null);
+  const [termDifferences, setTermDifferences] =
+    useState<TermDifferences | null>(null);
   const [synonyms, setSynonyms] = useState<string[] | null>(null);
   const [modalText, setModalText] = useState("");
   const [loading, setLoading] = useState(false);
@@ -307,11 +401,13 @@ function MoreInfoModal({
           );
           setReferences(data.references?.[code] || []);
           setRubrics(data.rubrics?.[code] || emptyRubrics());
+          setTermDifferences(data.term_differences?.[code] || null);
         })
         .catch(() => {
           setSynonyms([]);
           setReferences([]);
           setRubrics(emptyRubrics());
+          setTermDifferences(null);
         })
         .finally(() => setLoading(false));
     }
@@ -350,7 +446,13 @@ function MoreInfoModal({
       >
         <Modal.Header closeButton>
           <Modal.Title>
-            {term} ({code})
+            {codingSystemId === "icd10" && termDifferences ? (
+              code
+            ) : (
+              <>
+                {term} ({code})
+              </>
+            )}
           </Modal.Title>
         </Modal.Header>
         <Modal.Body>
@@ -370,6 +472,12 @@ function MoreInfoModal({
                 </ul>
               )}
             </>
+          )}
+          {codingSystemId === "icd10" && termDifferences && (
+            <TermDifferenceSection
+              code={code}
+              termDifferences={termDifferences}
+            />
           )}
           {hasRubrics(rubrics) && (
             <section className="border border-info rounded overflow-hidden mb-4">

--- a/assets/src/scripts/components/Codelist/Row.tsx
+++ b/assets/src/scripts/components/Codelist/Row.tsx
@@ -3,6 +3,7 @@ import type Hierarchy from "../../_hierarchy";
 import type { ICD10WarningIndicator } from "../../icd10-warning-indicators";
 import type {
   Code,
+  DaggerAsteriskInfo,
   IsExpanded,
   PageData,
   Path,
@@ -20,6 +21,7 @@ import StatusToggle from "./StatusToggle";
 interface RowProps {
   allCodes: PageData["allCodes"];
   code: Code;
+  daggerAsteriskInfo?: DaggerAsteriskInfo;
   codeToStatus: PageData["codeToStatus"];
   codeToTerm: PageData["codeToTerm"];
   hasDescendants: boolean;
@@ -40,6 +42,7 @@ export default function Row({
   code,
   codeToStatus,
   codeToTerm,
+  daggerAsteriskInfo,
   hasDescendants,
   hierarchy,
   icd10WarningIndicator,
@@ -119,6 +122,7 @@ export default function Row({
             code={code}
             codeToStatus={codeToStatus}
             codeToTerm={codeToTerm}
+            daggerAsteriskInfo={daggerAsteriskInfo}
             hierarchy={hierarchy}
             status={status}
             term={term}

--- a/assets/src/scripts/components/Codelist/Section.tsx
+++ b/assets/src/scripts/components/Codelist/Section.tsx
@@ -12,6 +12,7 @@ import Tree from "./Tree";
 interface SectionProps {
   allCodes: PageData["allCodes"];
   ancestorCodes: AncestorCodes;
+  codeToDaggerAsteriskInfo: PageData["codeToDaggerAsteriskInfo"];
   codeToStatus: PageData["codeToStatus"];
   codeToTerm: PageData["codeToTerm"];
   heading: string;
@@ -26,6 +27,7 @@ interface SectionProps {
 export default function Section({
   allCodes,
   ancestorCodes,
+  codeToDaggerAsteriskInfo,
   codeToStatus,
   codeToTerm,
   heading,
@@ -44,6 +46,7 @@ export default function Section({
           <Tree
             allCodes={allCodes}
             ancestorCode={ancestorCode}
+            codeToDaggerAsteriskInfo={codeToDaggerAsteriskInfo}
             codeToStatus={codeToStatus}
             codeToTerm={codeToTerm}
             hierarchy={hierarchy}

--- a/assets/src/scripts/components/Codelist/Tree.tsx
+++ b/assets/src/scripts/components/Codelist/Tree.tsx
@@ -13,6 +13,7 @@ import Row from "./Row";
 interface TreeProps {
   allCodes: PageData["allCodes"];
   ancestorCode: AncestorCode;
+  codeToDaggerAsteriskInfo: PageData["codeToDaggerAsteriskInfo"];
   codeToStatus: PageData["codeToStatus"];
   codeToTerm: PageData["codeToTerm"];
   hierarchy: Hierarchy;
@@ -26,6 +27,7 @@ interface TreeProps {
 export default function Tree({
   allCodes,
   ancestorCode,
+  codeToDaggerAsteriskInfo,
   codeToStatus,
   codeToTerm,
   hierarchy,
@@ -42,6 +44,7 @@ export default function Tree({
       <Row
         allCodes={allCodes}
         code={row.code}
+        daggerAsteriskInfo={codeToDaggerAsteriskInfo[row.code]}
         codeToStatus={codeToStatus}
         codeToTerm={codeToTerm}
         hasDescendants={row.hasDescendants}

--- a/assets/src/scripts/components/CodelistBuilder.tsx
+++ b/assets/src/scripts/components/CodelistBuilder.tsx
@@ -184,6 +184,7 @@ export default class CodelistBuilder extends React.Component<
   render() {
     const {
       allCodes,
+      codeToDaggerAsteriskInfo,
       codeToTerm,
       draftURL,
       hierarchy,
@@ -244,6 +245,7 @@ export default class CodelistBuilder extends React.Component<
                 <Tab eventKey="codelist" title="Codelist">
                   <CodelistTab
                     allCodes={allCodes}
+                    codeToDaggerAsteriskInfo={codeToDaggerAsteriskInfo}
                     codeToStatus={this.state.codeToStatus}
                     codeToTerm={codeToTerm}
                     hierarchy={hierarchy}

--- a/assets/src/scripts/components/Layout/CodelistTab.tsx
+++ b/assets/src/scripts/components/Layout/CodelistTab.tsx
@@ -8,6 +8,7 @@ import EmptySearch from "../Codelist/EmptySearch";
 interface CodelistTabProps {
   allCodes: PageData["allCodes"];
   ancestorCodes?: string[];
+  codeToDaggerAsteriskInfo: PageData["codeToDaggerAsteriskInfo"];
   codeToStatus: PageData["codeToStatus"];
   codeToTerm: PageData["codeToTerm"];
   hierarchy: Hierarchy;
@@ -21,6 +22,7 @@ interface CodelistTabProps {
 
 export default function CodelistTab({
   allCodes,
+  codeToDaggerAsteriskInfo,
   codeToStatus,
   codeToTerm,
   hierarchy,
@@ -38,6 +40,7 @@ export default function CodelistTab({
       {treeTables.length > 0 ? (
         <Container
           allCodes={allCodes}
+          codeToDaggerAsteriskInfo={codeToDaggerAsteriskInfo}
           codeToStatus={codeToStatus}
           codeToTerm={codeToTerm}
           hierarchy={hierarchy}

--- a/assets/src/scripts/types.ts
+++ b/assets/src/scripts/types.ts
@@ -14,6 +14,11 @@ export type ICD10MovedCode = {
   nhs2016: string[];
   who2019: string[];
 };
+export type DaggerAsteriskUsage = "dagger" | "asterisk";
+export type DaggerAsteriskInfo = {
+  usage: DaggerAsteriskUsage;
+  url?: string;
+};
 export type IsExpanded = boolean;
 export type Path = string;
 export type Pipe = "└" | "├" | " " | "│";
@@ -27,6 +32,7 @@ type VisiblePaths = Set<string>;
 
 export interface PageData {
   allCodes: AllCodes;
+  codeToDaggerAsteriskInfo: { [key: string]: DaggerAsteriskInfo };
   codeToStatus: { [key: string]: Status };
   codeToTerm: { [key: string]: string };
   draftURL: string;

--- a/assets/src/styles/_builder.css
+++ b/assets/src/styles/_builder.css
@@ -90,3 +90,22 @@ just use the first 3.
   margin-block-end: 1rem;
   row-gap: 1rem;
 }
+
+.builder__additional-info-card {
+  margin-bottom: 1rem;
+  padding: 0.875rem 1rem;
+  border: 1px solid #d4ecf4;
+  border-left: 0.25rem solid var(--info);
+  border-radius: 0.25rem;
+  background: #f6fbfd;
+}
+
+.builder__additional-info-card > :last-child {
+  margin-bottom: 0;
+}
+
+.builder__additional-info-card--concept {
+  border-color: #ced4da;
+  border-left-color: var(--dark);
+  background: #fff;
+}

--- a/assets/src/styles/_builder.css
+++ b/assets/src/styles/_builder.css
@@ -103,6 +103,57 @@ just use the first 3.
   text-decoration-color: currentColor;
 }
 
+.builder__dagger-asterisk-link {
+  appearance: none;
+  cursor: pointer;
+
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  vertical-align: middle;
+
+  width: 1.15rem;
+  height: 1.15rem;
+  padding: 0;
+  margin: 0 0 0 0.25rem;
+
+  border: 1px solid #e3c15f;
+  border-radius: 0.35rem;
+  background: #fff8df;
+  color: #745500;
+
+  font: inherit;
+  font-size: 0.82rem;
+  font-weight: 800;
+  line-height: 1;
+
+  user-select: none;
+  transition:
+    background-color 0.15s ease,
+    border-color 0.15s ease,
+    box-shadow 0.15s ease,
+    transform 0.1s ease;
+}
+
+.builder__dagger-asterisk-link > span {
+  position: relative;
+  top: -0.04rem; /* optical centering */
+}
+
+.builder__dagger-asterisk-link:hover {
+  background: #fff3c2;
+  border-color: #d4b248;
+}
+
+.builder__dagger-asterisk-link:active {
+  transform: translateY(1px);
+}
+
+.builder__dagger-asterisk-link:focus-visible {
+  outline: 2px solid #4d90fe;
+  outline-offset: 2px;
+}
+
 .builder__additional-info-card {
   margin-bottom: 1rem;
   padding: 0.875rem 1rem;
@@ -120,4 +171,31 @@ just use the first 3.
   border-color: #ced4da;
   border-left-color: var(--dark);
   background: #fff;
+}
+
+.builder__additional-info-card--usage {
+  border-color: #e3c15f;
+  border-left-color: #d4b248;
+  background: #fff8df;
+}
+
+.builder__dagger-asterisk-info__marker {
+  display: inline-flex;
+  flex: 0 0 auto;
+  align-items: center;
+  justify-content: center;
+  width: 1.5rem;
+  height: 1.5rem;
+  border: 1px solid #b8dce8;
+  border-radius: 50%;
+  background: #fff;
+  color: #0f6674;
+  font-size: 1rem;
+  font-weight: 800;
+  line-height: 1;
+}
+
+.builder__additional-info-card--usage .builder__dagger-asterisk-info__marker {
+  border-color: #e3c15f;
+  color: #745500;
 }

--- a/assets/src/styles/_builder.css
+++ b/assets/src/styles/_builder.css
@@ -91,6 +91,18 @@ just use the first 3.
   row-gap: 1rem;
 }
 
+.builder__more-info-modal__link {
+  color: #fff;
+  text-decoration: underline;
+  text-decoration-color: #fff;
+}
+
+.builder__more-info-modal__link:hover,
+.builder__more-info-modal__link:focus {
+  color: var(--primary); /* or your normal link color */
+  text-decoration-color: currentColor;
+}
+
 .builder__additional-info-card {
   margin-bottom: 1rem;
   padding: 0.875rem 1rem;

--- a/builder/management/commands/generate_builder_fixture.py
+++ b/builder/management/commands/generate_builder_fixture.py
@@ -99,6 +99,7 @@ class Command(BaseCommand):
                     "child_map",
                     "code_to_term",
                     "code_to_status",
+                    "code_to_dagger_asterisk_info",
                     "is_editable",
                     "update_url",
                     "search_url",
@@ -120,6 +121,9 @@ class Command(BaseCommand):
             }
             data["code_to_term"] = dict(sorted(data["code_to_term"].items()))
             data["code_to_status"] = dict(sorted(data["code_to_status"].items()))
+            data["code_to_dagger_asterisk_info"] = dict(
+                sorted(data["code_to_dagger_asterisk_info"].items())
+            )
 
             js_fixtures_path = Path(
                 settings.BASE_DIR, "assets", "src", "scripts", "__tests__", "fixtures"

--- a/builder/tests/test_views.py
+++ b/builder/tests/test_views.py
@@ -36,6 +36,8 @@ def test_draft_with_complete_searches(client, draft_with_complete_searches):
 
     assert rsp.status_code == 200
     assert b"New-style Codelist" in rsp.content
+    assert rsp.context["code_to_dagger_asterisk_info"] == {}
+    assert b'id="code-to-dagger-asterisk-info"' in rsp.content
 
 
 def test_version_from_scratch(client, version_from_scratch):

--- a/builder/views.py
+++ b/builder/views.py
@@ -274,6 +274,9 @@ def _draft(request, draft, search_id):
         "child_map": {c: list(pp) for c, pp in hierarchy.child_map.items()},
         "code_to_term": code_to_term,
         "code_to_status": codeset.code_to_status,
+        "code_to_dagger_asterisk_info": coding_system.lookup_dagger_asterisk_usages(
+            codeset.all_codes()
+        ),
         "is_editable": request.user == draft.author,
         "draft_url": draft_url,
         "update_url": update_url,

--- a/builder/views.py
+++ b/builder/views.py
@@ -258,6 +258,15 @@ def _draft(request, draft, search_id):
         ],
     }
 
+    # Dagger asterisk info will only ever appear for icd10. So instead of a
+    # generic interface for all coding systems, we just check if the coding system
+    # has the method and call it if it does.
+    dagger_asterisk_info = (
+        coding_system.lookup_dagger_asterisk_usages(codeset.all_codes())
+        if hasattr(coding_system, "lookup_dagger_asterisk_usages")
+        else {}
+    )
+
     ctx = {
         "user": draft.author,
         "draft": draft,
@@ -274,9 +283,7 @@ def _draft(request, draft, search_id):
         "child_map": {c: list(pp) for c, pp in hierarchy.child_map.items()},
         "code_to_term": code_to_term,
         "code_to_status": codeset.code_to_status,
-        "code_to_dagger_asterisk_info": coding_system.lookup_dagger_asterisk_usages(
-            codeset.all_codes()
-        ),
+        "code_to_dagger_asterisk_info": dagger_asterisk_info,
         "is_editable": request.user == draft.author,
         "draft_url": draft_url,
         "update_url": update_url,

--- a/coding_systems/base/coding_system_base.py
+++ b/coding_systems/base/coding_system_base.py
@@ -108,6 +108,9 @@ class BaseCodingSystem(ABC):
     def lookup_additional_rubrics(self, codes):  # pragma: no cover
         return {}
 
+    def lookup_dagger_asterisk_usages(self, codes):  # pragma: no cover
+        return {}
+
     def code_to_term(self, codes):  # pragma: no cover
         raise NotImplementedError
 

--- a/coding_systems/base/coding_system_base.py
+++ b/coding_systems/base/coding_system_base.py
@@ -105,6 +105,9 @@ class BaseCodingSystem(ABC):
     def lookup_references(self, codes):  # pragma: no cover
         return {}
 
+    def lookup_additional_rubrics(self, codes):  # pragma: no cover
+        return {}
+
     def code_to_term(self, codes):  # pragma: no cover
         raise NotImplementedError
 

--- a/coding_systems/base/coding_system_base.py
+++ b/coding_systems/base/coding_system_base.py
@@ -99,13 +99,7 @@ class BaseCodingSystem(ABC):
     def lookup_names(self, codes):  # pragma: no cover
         raise NotImplementedError
 
-    def lookup_synonyms(self, codes):  # pragma: no cover
-        return {}
-
-    def lookup_references(self, codes):  # pragma: no cover
-        return {}
-
-    def lookup_additional_rubrics(self, codes):  # pragma: no cover
+    def lookup_more_info(self, codes):  # pragma: no cover
         return {}
 
     def code_to_term(self, codes):  # pragma: no cover

--- a/coding_systems/base/coding_system_base.py
+++ b/coding_systems/base/coding_system_base.py
@@ -108,9 +108,6 @@ class BaseCodingSystem(ABC):
     def lookup_additional_rubrics(self, codes):  # pragma: no cover
         return {}
 
-    def lookup_dagger_asterisk_usages(self, codes):  # pragma: no cover
-        return {}
-
     def code_to_term(self, codes):  # pragma: no cover
         raise NotImplementedError
 

--- a/coding_systems/dmd/coding_system.py
+++ b/coding_systems/dmd/coding_system.py
@@ -70,7 +70,7 @@ class CodingSystem(BuilderCompatibleCodingSystem):
                 break
         return lookup
 
-    def lookup_synonyms(self, codes):
+    def _lookup_synonyms(self, codes):
         descriptions = (
             AMP.objects.using(self.database_alias)
             .filter(id__in=codes)
@@ -82,7 +82,7 @@ class CodingSystem(BuilderCompatibleCodingSystem):
             result[d["id"]].append(d["nm"])
         return dict(result)
 
-    def lookup_references(self, codes):
+    def _lookup_references(self, codes):
         # OpenPrescribing's dm+d browser supports VTMs, VMPs, AMPs, VMPPs, and AMPPs
         # We need to know the type of the code to correctly form the URL for this.
         codes = set(codes)
@@ -105,6 +105,12 @@ class CodingSystem(BuilderCompatibleCodingSystem):
                 )
             ]
             for code, codetype in codes_and_types
+        }
+
+    def lookup_more_info(self, codes):
+        return {
+            "references": self._lookup_references(codes),
+            "synonyms": self._lookup_synonyms(codes),
         }
 
     def code_to_term(self, codes):

--- a/coding_systems/dmd/tests/test_coding_system.py
+++ b/coding_systems/dmd/tests/test_coding_system.py
@@ -218,8 +218,25 @@ def test_search_by_code(dmd_data, coding_system, code, expected_response):
     assert coding_system.search_by_code(code) == expected_response
 
 
-def test_lookup_synonyms(dmd_data, coding_system):
-    assert coding_system.lookup_synonyms(["3293111000001105", "22503111000001109"]) == {
+def test_lookup_more_info(dmd_data, coding_system):
+    more_info = coding_system.lookup_more_info(
+        ["3293111000001105", "22503111000001109"]
+    )
+    assert more_info["synonyms"] == {
         "3293111000001105": ["Aerolin 100micrograms/dose Autohaler"],
         "22503111000001109": ["AirSalb 100micrograms/dose inhaler CFC free"],
+    }
+    assert more_info["references"] == {
+        "3293111000001105": [
+            (
+                "OpenPrescribing dm+d browser",
+                "https://openprescribing.net/dmd/amp/3293111000001105/",
+            )
+        ],
+        "22503111000001109": [
+            (
+                "OpenPrescribing dm+d browser",
+                "https://openprescribing.net/dmd/amp/22503111000001109/",
+            )
+        ],
     }

--- a/coding_systems/icd10/coding_system.py
+++ b/coding_systems/icd10/coding_system.py
@@ -137,8 +137,8 @@ class CodingSystem(BuilderCompatibleCodingSystem):
             ConceptRubric.objects.using(self.database_alias)
             .filter(
                 concept_edition__concept_id__in=codes,
-                concept_edition__edition_id=self.latest_edition.id,
             )
+            .prioritise_by_edition()
             .values_list("concept_edition__concept_id", "kind", "text")
         )
 

--- a/coding_systems/icd10/coding_system.py
+++ b/coding_systems/icd10/coding_system.py
@@ -127,10 +127,10 @@ class CodingSystem(BuilderCompatibleCodingSystem):
         unknown = set(codes) - set(lookup)
         return {**lookup, **{code: "Unknown" for code in unknown}}
 
-    def lookup_additional_rubrics(self, codes):
+    def _lookup_rubrics(self, codes):
         codes = list(codes)
         if not codes:
-            return {"rubrics": {}, "term_differences": {}}
+            return {}
 
         # First we get the rubrics for the concept code itself
         direct_concept_rubrics = (
@@ -226,11 +226,15 @@ class CodingSystem(BuilderCompatibleCodingSystem):
                 rubrics_by_kind[kind] = []
             rubrics_by_kind[kind].append(text)
 
-        edition_description_differences = codes_with_different_descriptions(codes)
+        return rubrics
 
+    def _lookup_term_differences(self, codes):
+        return codes_with_different_descriptions(codes)
+
+    def lookup_more_info(self, codes):
         return {
-            "rubrics": rubrics,
-            "term_differences": edition_description_differences,
+            "rubrics": self._lookup_rubrics(codes),
+            "term_differences": self._lookup_term_differences(codes),
         }
 
     def lookup_dagger_asterisk_usages(self, codes):

--- a/coding_systems/icd10/coding_system.py
+++ b/coding_systems/icd10/coding_system.py
@@ -132,25 +132,8 @@ class CodingSystem(BuilderCompatibleCodingSystem):
         if not codes:
             return {"rubrics": {}, "term_differences": {}}
 
-        def empty_rubrics():
-            return {"concept_rubrics": {}, "modifier_rubrics": {}}
-
-        def code_rubrics_for(collection, code):
-            return collection.setdefault(code, empty_rubrics())
-
-        def add_concept_rubric(collection, code, kind, text):
-            code_rubrics = code_rubrics_for(collection, code)
-            code_rubrics["concept_rubrics"].setdefault(kind, []).append(text)
-
-        def add_modifier_rubric(collection, code, term_modifier, kind, text):
-            code_rubrics = code_rubrics_for(collection, code)
-            modifier_key = term_modifier or "Modifier"
-            modifier_rubrics = code_rubrics["modifier_rubrics"].setdefault(
-                modifier_key, {}
-            )
-            modifier_rubrics.setdefault(kind, []).append(text)
-
-        concept_rubrics = (
+        # First we get the rubrics for the concept code itself
+        direct_concept_rubrics = (
             ConceptRubric.objects.using(self.database_alias)
             .filter(
                 concept_edition__concept_id__in=codes,
@@ -159,26 +142,29 @@ class CodingSystem(BuilderCompatibleCodingSystem):
             .values_list("concept_edition__concept_id", "kind", "text")
         )
 
-        # Modifier codes should show their own modifier rubrics plus the
-        # concept rubrics from the parent code they modify.
-        modifier_parent_codes = dict(
-            ConceptEdition.objects.using(self.database_alias)
-            .filter(
-                concept_id__in=codes,
-                edition_id=self.latest_edition.id,
-                term_modifier__isnull=False,
-            )
-            .values_list("concept_id", "concept__parent_id")
-        )
-        modifier_concept_rubrics = (
+        # Then we get the concept rubrics for any modifier codes. These are the
+        # rubrics for the parent code that the modifier code modifies.
+        inherited_concept_rubrics = (
             ConceptRubric.objects.using(self.database_alias)
             .filter(
-                concept_edition__concept_id__in=modifier_parent_codes.values(),
+                # The rubric belongs to the requested modifier code's parent.
                 concept_edition__edition_id=self.latest_edition.id,
+                concept_edition__concept__children__code__in=codes,
+                concept_edition__concept__children__concept_editions__edition_id=(
+                    self.latest_edition.id
+                ),
+                concept_edition__concept__children__concept_editions__term_modifier__isnull=(
+                    False
+                ),
             )
-            .values_list("concept_edition__concept_id", "kind", "text")
+            .values_list(
+                "concept_edition__concept__children__code",
+                "kind",
+                "text",
+            )
         )
 
+        # Now we get the modifier rubrics for any modifier codes
         modifier_rubrics = (
             ModifierRubric.objects.using(self.database_alias)
             .filter(
@@ -193,20 +179,52 @@ class CodingSystem(BuilderCompatibleCodingSystem):
             )
         )
 
+        # Construct a rubrics object that looks like this:
+        # {
+        #   "code_1": {
+        #     "concept_rubrics": {
+        #       "rubric_kind_1": ["text", "text", ...],
+        #       "rubric_kind_2": ["text", "text", ...],
+        #     },
+        #     "modifier_rubrics": {
+        #       "modifier_term_1": {
+        #         "rubric_kind_1": ["text", "text", ...],
+        #       },
+        #     },
+        #   },
+        #  "code_2": {
+        #    ...
+        #  },
+        # },
         rubrics = {}
+
+        concept_rubrics = direct_concept_rubrics.union(inherited_concept_rubrics)
         for code, kind, text in concept_rubrics:
-            add_concept_rubric(rubrics, code, kind, text)
+            if code not in rubrics:
+                rubrics[code] = {
+                    "concept_rubrics": {},
+                    "modifier_rubrics": {},
+                }
 
-        parent_concept_rubrics = defaultdict(list)
-        for parent_code, kind, text in modifier_concept_rubrics:
-            parent_concept_rubrics[parent_code].append((kind, text))
-
-        for code, parent_code in modifier_parent_codes.items():
-            for kind, text in parent_concept_rubrics[parent_code]:
-                add_concept_rubric(rubrics, code, kind, text)
+            rubrics_by_kind = rubrics[code]["concept_rubrics"]
+            if kind not in rubrics_by_kind:
+                rubrics_by_kind[kind] = []
+            rubrics_by_kind[kind].append(text)
 
         for code, term_modifier, kind, text in modifier_rubrics:
-            add_modifier_rubric(rubrics, code, term_modifier, kind, text)
+            if code not in rubrics:
+                rubrics[code] = {
+                    "concept_rubrics": {},
+                    "modifier_rubrics": {},
+                }
+
+            if term_modifier not in rubrics[code]["modifier_rubrics"]:
+                rubrics[code]["modifier_rubrics"][term_modifier] = {}
+
+            rubrics_by_kind = rubrics[code]["modifier_rubrics"][term_modifier]
+            if kind not in rubrics_by_kind:
+                rubrics_by_kind[kind] = []
+            rubrics_by_kind[kind].append(text)
 
         edition_description_differences = codes_with_different_descriptions(codes)
 

--- a/coding_systems/icd10/coding_system.py
+++ b/coding_systems/icd10/coding_system.py
@@ -12,6 +12,7 @@ from .models import (
     ConceptEdition,
     ConceptKind,
     ConceptRubric,
+    ConceptUsage,
     Edition,
     ModifierRubric,
     RubricKind,
@@ -212,6 +213,37 @@ class CodingSystem(BuilderCompatibleCodingSystem):
         return {
             "rubrics": rubrics,
             "term_differences": edition_description_differences,
+        }
+
+    def lookup_dagger_asterisk_usages(self, codes):
+        if not codes:
+            return {}
+
+        def who_2019_browser_url(code):
+            # We return the WHO 2019 URL rather than the NHS 2016 one because:
+            # - the NHS 2016 version made no changes to the underlying WHO 2016 edition
+            # - there are a couple of dagger/asterisk relationships that appear in 2019 but not in 2016, so the 2019 version is more complete
+            return f"https://icd.who.int/browse10/2019/en#/{f'{code[:3]}.{code[3:]}' if len(code) > 3 else code}"
+
+        concept_usages = (
+            ConceptEdition.objects.using(self.database_alias)
+            .filter(
+                edition_id=self.latest_edition.id,
+                concept_id__in=codes,
+                usage__in=[
+                    ConceptUsage.DAGGER,
+                    ConceptUsage.ASTERISK,
+                ],
+            )
+            .values_list("concept_id", "usage")
+        )
+
+        return {
+            concept_code: {
+                "usage": "asterisk" if usage == ConceptUsage.ASTERISK else "dagger",
+                "url": who_2019_browser_url(concept_code),
+            }
+            for concept_code, usage in concept_usages
         }
 
     def codes_by_type(self, codes, hierarchy):

--- a/coding_systems/icd10/coding_system.py
+++ b/coding_systems/icd10/coding_system.py
@@ -10,7 +10,9 @@ from .models import (
     Concept,
     ConceptEdition,
     ConceptKind,
+    ConceptRubric,
     Edition,
+    ModifierRubric,
     RubricKind,
 )
 
@@ -122,6 +124,91 @@ class CodingSystem(BuilderCompatibleCodingSystem):
         lookup = self.lookup_names(codes)
         unknown = set(codes) - set(lookup)
         return {**lookup, **{code: "Unknown" for code in unknown}}
+
+    def lookup_additional_rubrics(self, codes):
+        codes = list(codes)
+        if not codes:
+            return {"rubrics": {}}
+
+        def empty_rubrics():
+            return {"concept_rubrics": {}, "modifier_rubrics": {}}
+
+        def code_rubrics_for(collection, code):
+            return collection.setdefault(code, empty_rubrics())
+
+        def add_concept_rubric(collection, code, kind, text):
+            code_rubrics = code_rubrics_for(collection, code)
+            code_rubrics["concept_rubrics"].setdefault(kind, []).append(text)
+
+        def add_modifier_rubric(collection, code, term_modifier, kind, text):
+            code_rubrics = code_rubrics_for(collection, code)
+            modifier_key = term_modifier or "Modifier"
+            modifier_rubrics = code_rubrics["modifier_rubrics"].setdefault(
+                modifier_key, {}
+            )
+            modifier_rubrics.setdefault(kind, []).append(text)
+
+        concept_rubrics = (
+            ConceptRubric.objects.using(self.database_alias)
+            .filter(
+                concept_edition__concept_id__in=codes,
+                concept_edition__edition_id=self.latest_edition.id,
+            )
+            .values_list("concept_edition__concept_id", "kind", "text")
+        )
+
+        # Modifier codes should show their own modifier rubrics plus the
+        # concept rubrics from the parent code they modify.
+        modifier_parent_codes = dict(
+            ConceptEdition.objects.using(self.database_alias)
+            .filter(
+                concept_id__in=codes,
+                edition_id=self.latest_edition.id,
+                term_modifier__isnull=False,
+            )
+            .values_list("concept_id", "concept__parent_id")
+        )
+        modifier_concept_rubrics = (
+            ConceptRubric.objects.using(self.database_alias)
+            .filter(
+                concept_edition__concept_id__in=modifier_parent_codes.values(),
+                concept_edition__edition_id=self.latest_edition.id,
+            )
+            .values_list("concept_edition__concept_id", "kind", "text")
+        )
+
+        modifier_rubrics = (
+            ModifierRubric.objects.using(self.database_alias)
+            .filter(
+                concept_edition__concept_id__in=codes,
+                concept_edition__edition_id=self.latest_edition.id,
+            )
+            .values_list(
+                "concept_edition__concept_id",
+                "concept_edition__term_modifier",
+                "kind",
+                "text",
+            )
+        )
+
+        rubrics = {}
+        for code, kind, text in concept_rubrics:
+            add_concept_rubric(rubrics, code, kind, text)
+
+        parent_concept_rubrics = defaultdict(list)
+        for parent_code, kind, text in modifier_concept_rubrics:
+            parent_concept_rubrics[parent_code].append((kind, text))
+
+        for code, parent_code in modifier_parent_codes.items():
+            for kind, text in parent_concept_rubrics[parent_code]:
+                add_concept_rubric(rubrics, code, kind, text)
+
+        for code, term_modifier, kind, text in modifier_rubrics:
+            add_modifier_rubric(rubrics, code, term_modifier, kind, text)
+
+        return {
+            "rubrics": rubrics,
+        }
 
     def codes_by_type(self, codes, hierarchy):
         """Return mapping from chapter name to codes in that chapter."""

--- a/coding_systems/icd10/coding_system.py
+++ b/coding_systems/icd10/coding_system.py
@@ -6,7 +6,7 @@ from django.db.models import Q
 from opencodelists.db_utils import query
 
 from ..base.coding_system_base import BuilderCompatibleCodingSystem
-from .known_diffs import different_codes
+from .known_diffs import codes_with_different_descriptions
 from .models import (
     Concept,
     ConceptEdition,
@@ -208,7 +208,7 @@ class CodingSystem(BuilderCompatibleCodingSystem):
         for code, term_modifier, kind, text in modifier_rubrics:
             add_modifier_rubric(rubrics, code, term_modifier, kind, text)
 
-        edition_description_differences = different_codes(codes)
+        edition_description_differences = codes_with_different_descriptions(codes)
 
         return {
             "rubrics": rubrics,

--- a/coding_systems/icd10/coding_system.py
+++ b/coding_systems/icd10/coding_system.py
@@ -6,6 +6,7 @@ from django.db.models import Q
 from opencodelists.db_utils import query
 
 from ..base.coding_system_base import BuilderCompatibleCodingSystem
+from .known_diffs import different_codes
 from .models import (
     Concept,
     ConceptEdition,
@@ -128,7 +129,7 @@ class CodingSystem(BuilderCompatibleCodingSystem):
     def lookup_additional_rubrics(self, codes):
         codes = list(codes)
         if not codes:
-            return {"rubrics": {}}
+            return {"rubrics": {}, "term_differences": {}}
 
         def empty_rubrics():
             return {"concept_rubrics": {}, "modifier_rubrics": {}}
@@ -206,8 +207,11 @@ class CodingSystem(BuilderCompatibleCodingSystem):
         for code, term_modifier, kind, text in modifier_rubrics:
             add_modifier_rubric(rubrics, code, term_modifier, kind, text)
 
+        edition_description_differences = different_codes(codes)
+
         return {
             "rubrics": rubrics,
+            "term_differences": edition_description_differences,
         }
 
     def codes_by_type(self, codes, hierarchy):

--- a/coding_systems/icd10/known_diffs.py
+++ b/coding_systems/icd10/known_diffs.py
@@ -902,6 +902,25 @@ def clinically_different_codes(codes: list[str]) -> dict[str, dict[str, str]]:
     return differences
 
 
+def different_codes(codes: list[str]) -> dict[str, dict[str, str | bool]]:
+    """
+    Given a list of codes, return a dict containing the codes
+    that have different descriptions between the 2016 and 2019
+    releases, along with their descriptions in both releases.
+    """
+    differences = {}
+    normalised_codes = set(code.upper() for code in codes)
+    for code in normalised_codes:
+        difference = COMBINED_2016_VS_2019_DIFFERENCES.get(code)
+        if difference:
+            differences[code] = {
+                "combined_2016": difference.combined_2016,
+                "who_2019": difference.who_2019,
+                "equivalent": difference.clinically_equivalent,
+            }
+    return differences
+
+
 # Moved code sets. We flag codelists that contain only part of one of these sets,
 # because the same clinical concept is represented by different codes across releases.
 # These moved codes were derived from this report (https://github.com/bennettoxford/icd-browser-scraper/blob/main/claml/2016-vs-2019.md)

--- a/coding_systems/icd10/known_diffs.py
+++ b/coding_systems/icd10/known_diffs.py
@@ -902,7 +902,9 @@ def clinically_different_codes(codes: list[str]) -> dict[str, dict[str, str]]:
     return differences
 
 
-def different_codes(codes: list[str]) -> dict[str, dict[str, str | bool]]:
+def codes_with_different_descriptions(
+    codes: list[str],
+) -> dict[str, dict[str, str | bool]]:
     """
     Given a list of codes, return a dict containing the codes
     that have different descriptions between the 2016 and 2019

--- a/coding_systems/icd10/models.py
+++ b/coding_systems/icd10/models.py
@@ -1,7 +1,7 @@
 from django.core.exceptions import ValidationError
 from django.db import models
-from django.db.models import F, Window
-from django.db.models.functions import RowNumber
+from django.db.models import Window
+from django.db.models.functions import DenseRank, RowNumber
 from django.db.models.manager import BaseManager
 from django.db.models.query import QuerySet
 
@@ -108,10 +108,17 @@ class ConceptEdition(models.Model):
 
 class ConceptRubricQuerySet(QuerySet):
     def prioritise_by_edition(self):
+        # Give each ConceptRubric a rank based on the edition from which it came,
+        # and only select those with rank==1.
+        # This relies on the current state of the edition with id "2016"
+        # being the preferred source of rubrics over the one with id "2019"
+        # As we use dense_rank, all rubrics (there may be multiple of the same
+        # type, e.g. a bulleted list of inclusions) from the same edition will
+        # get the same ranking.
         return self.annotate(
             edition_priority=Window(
-                expression=RowNumber(),
-                partition_by=[F("concept_edition__concept_id"), F("kind")],
+                expression=DenseRank(),
+                partition_by="concept_edition__concept_id",
                 order_by="concept_edition__edition_id",
             )
         ).filter(edition_priority=1)

--- a/coding_systems/icd10/models.py
+++ b/coding_systems/icd10/models.py
@@ -1,6 +1,6 @@
 from django.core.exceptions import ValidationError
 from django.db import models
-from django.db.models import Window
+from django.db.models import F, Window
 from django.db.models.functions import RowNumber
 from django.db.models.manager import BaseManager
 from django.db.models.query import QuerySet
@@ -106,12 +106,28 @@ class ConceptEdition(models.Model):
         ]
 
 
+class ConceptRubricQuerySet(QuerySet):
+    def prioritise_by_edition(self):
+        return self.annotate(
+            edition_priority=Window(
+                expression=RowNumber(),
+                partition_by=[F("concept_edition__concept_id"), F("kind")],
+                order_by="concept_edition__edition_id",
+            )
+        ).filter(edition_priority=1)
+
+
+class ConceptRubricManager(BaseManager.from_queryset(ConceptRubricQuerySet)):
+    pass
+
+
 class ConceptRubric(models.Model):
     kind = get_char_choices_field(RubricKind)
     text = models.TextField()
     concept_edition = models.ForeignKey(
         ConceptEdition, on_delete=models.CASCADE, related_name="rubrics"
     )
+    objects = ConceptRubricManager()
 
 
 class ModifierRubric(models.Model):

--- a/coding_systems/icd10/tests/test_coding_system.py
+++ b/coding_systems/icd10/tests/test_coding_system.py
@@ -219,6 +219,46 @@ def test_lookup_additional_rubrics_for_concept_code(icd10_data, coding_system):
     }
 
 
+def test_lookup_additional_rubrics_for_concept_prioritises_2016(
+    icd10_data, coding_system
+):
+    ConceptRubric.objects.using(coding_system.database_alias).create(
+        concept_edition_id=13,
+        kind=RubricKind.INCLUSION,
+        text="Golfer's elbow",
+    )
+
+    edition = Edition.objects.using(coding_system.database_alias).create(
+        id="zzz", version=999, year=2000, source_description="a later edition"
+    )
+
+    concept_edition = ConceptEdition.objects.using(coding_system.database_alias).create(
+        concept_id="M770", edition=edition, term="Medial Epicondylitis"
+    )
+
+    ConceptRubric.objects.using(coding_system.database_alias).create(
+        concept_edition=concept_edition,
+        kind=RubricKind.INCLUSION,
+        text="Golfers elbow",
+    )
+
+    ConceptRubric.objects.using(coding_system.database_alias).create(
+        concept_edition=concept_edition,
+        kind=RubricKind.EXCLUSION,
+        text="Curler's elbow",
+    )
+
+    assert coding_system.lookup_additional_rubrics(["M770"])["rubrics"] == {
+        "M770": {
+            "concept_rubrics": {
+                RubricKind.INCLUSION: ["Golfer's elbow"],
+                RubricKind.EXCLUSION: ["Curler's elbow"],
+            },
+            "modifier_rubrics": {},
+        }
+    }
+
+
 def test_lookup_additional_rubrics_with_no_codes(coding_system):
     assert coding_system.lookup_additional_rubrics([])["rubrics"] == {}
 

--- a/coding_systems/icd10/tests/test_coding_system.py
+++ b/coding_systems/icd10/tests/test_coding_system.py
@@ -227,6 +227,11 @@ def test_lookup_additional_rubrics_for_concept_prioritises_2016(
         kind=RubricKind.INCLUSION,
         text="Golfer's elbow",
     )
+    ConceptRubric.objects.using(coding_system.database_alias).create(
+        concept_edition_id=13,
+        kind=RubricKind.INCLUSION,
+        text="Disc Golfer's elbow",
+    )
 
     edition = Edition.objects.using(coding_system.database_alias).create(
         id="zzz", version=999, year=2000, source_description="a later edition"
@@ -251,8 +256,7 @@ def test_lookup_additional_rubrics_for_concept_prioritises_2016(
     assert coding_system.lookup_additional_rubrics(["M770"])["rubrics"] == {
         "M770": {
             "concept_rubrics": {
-                RubricKind.INCLUSION: ["Golfer's elbow"],
-                RubricKind.EXCLUSION: ["Curler's elbow"],
+                RubricKind.INCLUSION: ["Disc Golfer's elbow", "Golfer's elbow"],
             },
             "modifier_rubrics": {},
         }

--- a/coding_systems/icd10/tests/test_coding_system.py
+++ b/coding_systems/icd10/tests/test_coding_system.py
@@ -211,18 +211,16 @@ def test_lookup_additional_rubrics_for_concept_code(icd10_data, coding_system):
         text="Golfer's elbow",
     )
 
-    assert coding_system.lookup_additional_rubrics(["M770"]) == {
-        "rubrics": {
-            "M770": {
-                "concept_rubrics": {RubricKind.INCLUSION: ["Golfer's elbow"]},
-                "modifier_rubrics": {},
-            }
+    assert coding_system.lookup_additional_rubrics(["M770"])["rubrics"] == {
+        "M770": {
+            "concept_rubrics": {RubricKind.INCLUSION: ["Golfer's elbow"]},
+            "modifier_rubrics": {},
         }
     }
 
 
 def test_lookup_additional_rubrics_with_no_codes(coding_system):
-    assert coding_system.lookup_additional_rubrics([]) == {"rubrics": {}}
+    assert coding_system.lookup_additional_rubrics([])["rubrics"] == {}
 
 
 def test_lookup_additional_rubrics_for_modifier_code_includes_parent_concept_rubrics(
@@ -239,13 +237,28 @@ def test_lookup_additional_rubrics_for_modifier_code_includes_parent_concept_rub
         text="Includes multiple sites",
     )
 
-    assert coding_system.lookup_additional_rubrics(["M7700"]) == {
-        "rubrics": {
-            "M7700": {
-                "concept_rubrics": {RubricKind.INCLUSION: ["Golfer's elbow"]},
-                "modifier_rubrics": {
-                    "Multiple sites": {RubricKind.NOTE: ["Includes multiple sites"]}
-                },
-            }
+    assert coding_system.lookup_additional_rubrics(["M7700"])["rubrics"] == {
+        "M7700": {
+            "concept_rubrics": {RubricKind.INCLUSION: ["Golfer's elbow"]},
+            "modifier_rubrics": {
+                "Multiple sites": {RubricKind.NOTE: ["Includes multiple sites"]}
+            },
         }
     }
+
+
+def test_term_differences(icd10_data, coding_system):
+
+    x590 = coding_system.lookup_additional_rubrics(["X590"])
+    xxxx = coding_system.lookup_additional_rubrics(["XXXX"])
+    blank = coding_system.lookup_additional_rubrics([])
+
+    assert "term_differences" in x590
+    assert "X590" in x590["term_differences"]
+    assert not x590["term_differences"]["X590"]["equivalent"]
+
+    assert "term_differences" in xxxx
+    assert xxxx["term_differences"] == {}
+
+    assert "term_differences" in blank
+    assert blank["term_differences"] == {}

--- a/coding_systems/icd10/tests/test_coding_system.py
+++ b/coding_systems/icd10/tests/test_coding_system.py
@@ -211,7 +211,7 @@ def test_lookup_additional_rubrics_for_concept_code(icd10_data, coding_system):
         text="Golfer's elbow",
     )
 
-    assert coding_system.lookup_additional_rubrics(["M770"])["rubrics"] == {
+    assert coding_system.lookup_more_info(["M770"])["rubrics"] == {
         "M770": {
             "concept_rubrics": {RubricKind.INCLUSION: ["Golfer's elbow"]},
             "modifier_rubrics": {},
@@ -253,7 +253,7 @@ def test_lookup_additional_rubrics_for_concept_prioritises_2016(
         text="Curler's elbow",
     )
 
-    assert coding_system.lookup_additional_rubrics(["M770"])["rubrics"] == {
+    assert coding_system.lookup_more_info(["M770"])["rubrics"] == {
         "M770": {
             "concept_rubrics": {
                 RubricKind.INCLUSION: ["Disc Golfer's elbow", "Golfer's elbow"],
@@ -264,7 +264,7 @@ def test_lookup_additional_rubrics_for_concept_prioritises_2016(
 
 
 def test_lookup_additional_rubrics_with_no_codes(coding_system):
-    assert coding_system.lookup_additional_rubrics([])["rubrics"] == {}
+    assert coding_system.lookup_more_info([])["rubrics"] == {}
 
 
 def test_lookup_additional_rubrics_for_modifier_code_includes_parent_concept_rubrics(
@@ -281,7 +281,7 @@ def test_lookup_additional_rubrics_for_modifier_code_includes_parent_concept_rub
         text="Includes multiple sites",
     )
 
-    assert coding_system.lookup_additional_rubrics(["M7700"])["rubrics"] == {
+    assert coding_system.lookup_more_info(["M7700"])["rubrics"] == {
         "M7700": {
             "concept_rubrics": {RubricKind.INCLUSION: ["Golfer's elbow"]},
             "modifier_rubrics": {
@@ -293,9 +293,9 @@ def test_lookup_additional_rubrics_for_modifier_code_includes_parent_concept_rub
 
 def test_term_differences(icd10_data, coding_system):
 
-    x590 = coding_system.lookup_additional_rubrics(["X590"])
-    xxxx = coding_system.lookup_additional_rubrics(["XXXX"])
-    blank = coding_system.lookup_additional_rubrics([])
+    x590 = coding_system.lookup_more_info(["X590"])
+    xxxx = coding_system.lookup_more_info(["XXXX"])
+    blank = coding_system.lookup_more_info([])
 
     assert "term_differences" in x590
     assert "X590" in x590["term_differences"]

--- a/coding_systems/icd10/tests/test_coding_system.py
+++ b/coding_systems/icd10/tests/test_coding_system.py
@@ -262,3 +262,36 @@ def test_term_differences(icd10_data, coding_system):
 
     assert "term_differences" in blank
     assert blank["term_differences"] == {}
+
+
+def test_lookup_dagger_asterisk_usages_with_no_codes(coding_system):
+    assert coding_system.lookup_dagger_asterisk_usages([]) == {}
+
+
+def test_lookup_dagger_asterisk_usages(icd10_data, coding_system):
+    ConceptEdition.objects.using(coding_system.database_alias).filter(id=12).update(
+        usage=ConceptUsage.DAGGER
+    )
+    ConceptEdition.objects.using(coding_system.database_alias).filter(id=13).update(
+        usage=ConceptUsage.DAGGER
+    )
+    ConceptEdition.objects.using(coding_system.database_alias).filter(id=14).update(
+        usage=ConceptUsage.ASTERISK
+    )
+
+    assert coding_system.lookup_dagger_asterisk_usages(
+        ["M77", "M770", "M771", "M772"]
+    ) == {
+        "M77": {
+            "usage": "dagger",
+            "url": "https://icd.who.int/browse10/2019/en#/M77",
+        },
+        "M770": {
+            "usage": "dagger",
+            "url": "https://icd.who.int/browse10/2019/en#/M77.0",
+        },
+        "M771": {
+            "usage": "asterisk",
+            "url": "https://icd.who.int/browse10/2019/en#/M77.1",
+        },
+    }

--- a/coding_systems/icd10/tests/test_coding_system.py
+++ b/coding_systems/icd10/tests/test_coding_system.py
@@ -8,6 +8,7 @@ from coding_systems.icd10.models import (
     ConceptRubric,
     ConceptUsage,
     Edition,
+    ModifierRubric,
     RubricKind,
 )
 
@@ -201,3 +202,50 @@ def test_descendant_relationships(icd10_data, coding_system):
         ("A77", "A778"),
         ("A77", "A779"),
     ]
+
+
+def test_lookup_additional_rubrics_for_concept_code(icd10_data, coding_system):
+    ConceptRubric.objects.using(coding_system.database_alias).create(
+        concept_edition_id=13,
+        kind=RubricKind.INCLUSION,
+        text="Golfer's elbow",
+    )
+
+    assert coding_system.lookup_additional_rubrics(["M770"]) == {
+        "rubrics": {
+            "M770": {
+                "concept_rubrics": {RubricKind.INCLUSION: ["Golfer's elbow"]},
+                "modifier_rubrics": {},
+            }
+        }
+    }
+
+
+def test_lookup_additional_rubrics_with_no_codes(coding_system):
+    assert coding_system.lookup_additional_rubrics([]) == {"rubrics": {}}
+
+
+def test_lookup_additional_rubrics_for_modifier_code_includes_parent_concept_rubrics(
+    icd10_data, coding_system
+):
+    ConceptRubric.objects.using(coding_system.database_alias).create(
+        concept_edition_id=13,
+        kind=RubricKind.INCLUSION,
+        text="Golfer's elbow",
+    )
+    ModifierRubric.objects.using(coding_system.database_alias).create(
+        concept_edition_id=22,
+        kind=RubricKind.NOTE,
+        text="Includes multiple sites",
+    )
+
+    assert coding_system.lookup_additional_rubrics(["M7700"]) == {
+        "rubrics": {
+            "M7700": {
+                "concept_rubrics": {RubricKind.INCLUSION: ["Golfer's elbow"]},
+                "modifier_rubrics": {
+                    "Multiple sites": {RubricKind.NOTE: ["Includes multiple sites"]}
+                },
+            }
+        }
+    }

--- a/coding_systems/icd10/tests/test_known_diffs.py
+++ b/coding_systems/icd10/tests/test_known_diffs.py
@@ -5,7 +5,7 @@ from coding_systems.icd10.known_diffs import (
     RubricChange,
     TermDifference,
     clinically_different_codes,
-    different_codes,
+    codes_with_different_descriptions,
     expand_who_2016_place_of_occurrence,
     get_2016_2019_description_difference,
     is_2016_claml_only,
@@ -256,9 +256,9 @@ def test_moved_codes():
     ]
 
 
-def test_different_codes():
+def test_codes_with_different_descriptions():
     codes = ["P710", "P710", "P711", "ZZZZ", "X590"]
-    differences = different_codes(codes)
+    differences = codes_with_different_descriptions(codes)
 
     assert differences == {
         "P710": {

--- a/coding_systems/icd10/tests/test_known_diffs.py
+++ b/coding_systems/icd10/tests/test_known_diffs.py
@@ -5,6 +5,7 @@ from coding_systems.icd10.known_diffs import (
     RubricChange,
     TermDifference,
     clinically_different_codes,
+    different_codes,
     expand_who_2016_place_of_occurrence,
     get_2016_2019_description_difference,
     is_2016_claml_only,
@@ -253,3 +254,21 @@ def test_moved_codes():
             "comment": "This is U076 in 2016, but U11/U119 in 2019.",
         },
     ]
+
+
+def test_different_codes():
+    codes = ["P710", "P710", "P711", "ZZZZ", "X590"]
+    differences = different_codes(codes)
+
+    assert differences == {
+        "P710": {
+            "combined_2016": "Cow's milk hypocalcaemia in newborn",
+            "who_2019": "Cow milk hypocalcaemia in newborn",
+            "equivalent": True,
+        },
+        "X590": {
+            "combined_2016": "Exposure to unspecified factor (Home)",
+            "who_2019": "Exposure to unspecified factor causing fracture",
+            "equivalent": False,
+        },
+    }

--- a/coding_systems/snomedct/coding_system.py
+++ b/coding_systems/snomedct/coding_system.py
@@ -29,7 +29,7 @@ class CodingSystem(BuilderCompatibleCodingSystem):
             )
         }
 
-    def lookup_synonyms(self, codes):
+    def _lookup_synonyms(self, codes):
         descriptions = Description.objects.using(self.database_alias).filter(
             concept__in=codes, type=SYNONYM, active=True
         )
@@ -38,6 +38,9 @@ class CodingSystem(BuilderCompatibleCodingSystem):
         for d in descriptions:
             result[d.concept_id].append(d.term)
         return dict(result)
+
+    def lookup_more_info(self, codes):
+        return {"synonyms": self._lookup_synonyms(codes)}
 
     def search_by_term(self, term):
         return set(

--- a/coding_systems/snomedct/tests/test_coding_system.py
+++ b/coding_systems/snomedct/tests/test_coding_system.py
@@ -26,10 +26,12 @@ def test_lookup_names(snomedct_data, coding_system):
     }
 
 
-def test_lookup_synonyms(snomedct_data, coding_system):
-    assert coding_system.lookup_synonyms(["705115006", "239964003", "99999"]) == {
-        "239964003": ["Soft tissue lesion of elbow region"],
-        "705115006": ["Technology Preview module"],
+def test_lookup_more_info(snomedct_data, coding_system):
+    assert coding_system.lookup_more_info(["705115006", "239964003", "99999"]) == {
+        "synonyms": {
+            "239964003": ["Soft tissue lesion of elbow region"],
+            "705115006": ["Technology Preview module"],
+        }
     }
 
 

--- a/coding_systems/versioning/tests/test_views.py
+++ b/coding_systems/versioning/tests/test_views.py
@@ -76,13 +76,11 @@ def test_more_info_returns_additional_rubrics(client, setup_coding_systems, icd1
     )
 
     assert response.status_code == 200
-    assert response.json() == {
-        "synonyms": {},
-        "references": {},
-        "rubrics": {
-            "M770": {
-                "concept_rubrics": {RubricKind.INCLUSION: ["Golfer's elbow"]},
-                "modifier_rubrics": {},
-            }
-        },
+    json_data = response.json()
+    assert "rubrics" in json_data
+    assert "M770" in json_data["rubrics"]
+    assert json_data["rubrics"]["M770"]["concept_rubrics"] == {
+        RubricKind.INCLUSION: ["Golfer's elbow"]
     }
+    assert json_data["rubrics"]["M770"]["modifier_rubrics"] == {}
+    assert "term_differences" in json_data

--- a/coding_systems/versioning/tests/test_views.py
+++ b/coding_systems/versioning/tests/test_views.py
@@ -1,5 +1,7 @@
 from django.urls import reverse
 
+from coding_systems.icd10.models import ConceptRubric, RubricKind
+
 
 def test_latest_releases(client, setup_coding_systems):
     response = client.get(reverse("versioning:latest_releases"))
@@ -58,3 +60,29 @@ def test_latest_releases_json_with_pcd_refset(
     }
     assert data["pcd_refsets"]["release"] == pcd_refset_version.release
     assert data["nhs_drug_refsets"]["release"] == nhs_drug_refset_version.release
+
+
+def test_more_info_returns_additional_rubrics(client, setup_coding_systems, icd10_data):
+    ConceptRubric.objects.using("icd10_test_20200101").create(
+        concept_edition_id=13,
+        kind=RubricKind.INCLUSION,
+        text="Golfer's elbow",
+    )
+
+    response = client.post(
+        "/coding-systems/more-info/icd10",
+        {"codes": ["M770"]},
+        content_type="application/json",
+    )
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "synonyms": {},
+        "references": {},
+        "rubrics": {
+            "M770": {
+                "concept_rubrics": {RubricKind.INCLUSION: ["Golfer's elbow"]},
+                "modifier_rubrics": {},
+            }
+        },
+    }

--- a/coding_systems/versioning/views.py
+++ b/coding_systems/versioning/views.py
@@ -77,7 +77,8 @@ def more_info(request, coding_system):
     cs = CODING_SYSTEMS[coding_system].get_by_release_or_most_recent()
     synonyms = {"synonyms": cs.lookup_synonyms(codes)}
     references = {"references": cs.lookup_references(codes)}
-    return JsonResponse(synonyms | references)
+    additional_rubrics = cs.lookup_additional_rubrics(codes)
+    return JsonResponse(synonyms | references | additional_rubrics)
 
 
 @csrf_exempt

--- a/coding_systems/versioning/views.py
+++ b/coding_systems/versioning/views.py
@@ -75,10 +75,7 @@ def more_info(request, coding_system):
         return JsonResponse({"error": "Badly formatted JSON request"})
 
     cs = CODING_SYSTEMS[coding_system].get_by_release_or_most_recent()
-    synonyms = {"synonyms": cs.lookup_synonyms(codes)}
-    references = {"references": cs.lookup_references(codes)}
-    additional_rubrics = cs.lookup_additional_rubrics(codes)
-    return JsonResponse(synonyms | references | additional_rubrics)
+    return JsonResponse(cs.lookup_more_info(codes))
 
 
 @csrf_exempt

--- a/templates/builder/draft.html
+++ b/templates/builder/draft.html
@@ -19,6 +19,7 @@
   {{ tree_tables|json_script:"tree-tables" }}
   {{ code_to_term|json_script:"code-to-term" }}
   {{ code_to_status|json_script:"code-to-status" }}
+  {{ code_to_dagger_asterisk_info|json_script:"code-to-dagger-asterisk-info" }}
   {{ all_codes|json_script:"all-codes" }}
   {{ parent_map|json_script:"parent-map" }}
   {{ child_map|json_script:"child-map" }}


### PR DESCRIPTION
Fixes #3126 . Fixes #3128 .

**Extra rubrics**

- An example with a note and inclusion/exclusion rubrics

<img width="822" height="891" alt="image" src="https://github.com/user-attachments/assets/fe69a1d3-2514-4115-a089-7fcbaca6d373" />

- If a concept has modifier rubrics and concept rubrics they are visually distinct:

<img width="814" height="682" alt="image" src="https://github.com/user-attachments/assets/9dca2fe3-ceef-4925-91ef-caeb37b05abe" />

**Term differences**

- Typos are shown in a green box with both definitions

<img width="815" height="506" alt="image" src="https://github.com/user-attachments/assets/df684896-4665-4fcb-ba07-4f1d66d30bf8" />

- Clinically different definitions in a red box (NB the main thing users will see is a warning banner at the top of the page, this info in the more info modal is on top of that)

<img width="815" height="506" alt="image" src="https://github.com/user-attachments/assets/0afab842-f607-41d2-a4fa-9cceb070397c" />
