### PR TITLE
Spike: convert BNF codelists to dm+d as new-style

### DIFF
--- a/codelists/actions.py
+++ b/codelists/actions.py
@@ -15,7 +15,7 @@ from coding_systems.snomedct import ecl_parser
 from opencodelists.models import User
 
 from .codeset import Codeset
-from .coding_systems import most_recent_database_alias
+from .coding_systems import CODING_SYSTEMS
 from .hierarchy import Hierarchy
 from .models import CachedHierarchy, Codelist, CodeObj, Handle, Status
 from .search import do_search
@@ -750,7 +750,12 @@ def convert_bnf_codelist_version_to_dmd(version, published=False):
     dmd_methodology = (
         f"Converted from [pseudo-BNF system codelist]({version.get_absolute_url()})"
     )
-    dmd_alias = most_recent_database_alias("dmd")
+    most_recent_dmd = CODING_SYSTEMS["dmd"].get_by_release_or_most_recent()
+    codes = most_recent_dmd.codes_from_csv(
+        csv_data=dmd_csv_data, csv_has_header=True, lookup_code_column=True
+    )
+    most_recent_dmd.validate_csv_data_codes(codes)
+    dmd_alias = most_recent_dmd.database_alias
     dmd_references = [
         {"text": ref.text, "url": ref.url} for ref in version.codelist.references.all()
     ]
@@ -764,14 +769,16 @@ def convert_bnf_codelist_version_to_dmd(version, published=False):
 
     if existing_handle:
         for existing_version in existing_handle.codelist.versions.all():
-            if existing_version.csv_data == dmd_csv_data.replace("\r", ""):
+            if set(existing_version.codes) == set(codes):
                 raise IntegrityError("Version with identical csv_data exists")
-        converted_codelist = create_old_style_version(
-            codelist=existing_handle.codelist,
-            csv_data=dmd_csv_data,
+        converted_codelist = existing_handle.codelist
+        create_version_with_codes(
+            codelist=converted_codelist,
+            codes=codes,
             coding_system_database_alias=dmd_alias,
             author=version.author,
-        ).codelist
+            status=Status.UNDER_REVIEW,
+        )
 
         update_codelist(
             codelist=converted_codelist,
@@ -787,7 +794,7 @@ def convert_bnf_codelist_version_to_dmd(version, published=False):
             ],
         )
     else:
-        converted_codelist = create_old_style_codelist(
+        converted_codelist = create_codelist_with_codes(
             owner=owner,
             name=dmd_name,
             slug=dmd_slug,
@@ -795,9 +802,10 @@ def convert_bnf_codelist_version_to_dmd(version, published=False):
             coding_system_database_alias=dmd_alias,
             methodology=dmd_methodology,
             description=dmd_description,
-            csv_data=dmd_csv_data,
+            codes=codes,
             references=dmd_references,
             author=version.author,
+            status=Status.UNDER_REVIEW,
         )
     if published:
         publish_version(version=converted_codelist.versions.last())

--- a/codelists/forms.py
+++ b/codelists/forms.py
@@ -5,7 +5,7 @@ from crispy_forms.helper import FormHelper
 from crispy_forms.layout import Submit
 from django import forms
 
-from opencodelists.forms import form_field_from_model, validate_csv_data_codes
+from opencodelists.forms import form_field_from_model
 from opencodelists.models import Organisation, User
 
 from .coding_systems import CODING_SYSTEMS
@@ -140,7 +140,10 @@ class CSVValidationMixin:
                 ]
             )
 
-        validate_csv_data_codes(coding_system, codes)
+        try:
+            coding_system.validate_csv_data_codes(codes)
+        except ValueError as e:
+            raise forms.ValidationError(str(e))
         return data
 
 

--- a/codelists/tests/test_actions.py
+++ b/codelists/tests/test_actions.py
@@ -595,11 +595,7 @@ def test_convert_bnf_codelist_version_to_dmd(bnf_version_asthma, dmd_bnf_mapping
 
     # status is under review by default
     assert dmd_version.status == "under review"
-    assert dmd_version.csv_data == (
-        "dmd_type,dmd_id,dmd_name,bnf_code\n"
-        "VMP,10514511000001106,Adrenaline (base) 220micrograms/dose inhaler,0301012A0AAABAB\n"
-        "VMP,10525011000001107,Adrenaline (base) 220micrograms/dose inhaler refill,0301012A0AAACAC\n"
-    )
+    assert set(dmd_version.codes) == {"10514511000001106", "10525011000001107"}
 
 
 def test_cannot_convert_non_bnf_codelist_to_dmd(version):
@@ -632,12 +628,11 @@ def test_can_update_converted_dmd_codelist(bnf_version_asthma, dmd_bnf_mapping_d
 
     # status is under review by default
     assert dmd_version.status == "under review"
-    assert dmd_version.csv_data == (
-        "dmd_type,dmd_id,dmd_name,bnf_code\n"
-        "VMP,35936411000001109,Salbutamol 100micrograms/dose breath actuated inhaler,0301011R0AAADAD\n"
-        "VMP,10514511000001106,Adrenaline (base) 220micrograms/dose inhaler,0301012A0AAABAB\n"
-        "VMP,10525011000001107,Adrenaline (base) 220micrograms/dose inhaler refill,0301012A0AAACAC\n"
-    )
+    assert set(dmd_version.codes) == {
+        "35936411000001109",
+        "10514511000001106",
+        "10525011000001107",
+    }
 
 
 def test_converting_bnf_to_dmd_preserves_author(

--- a/coding_systems/base/coding_system_base.py
+++ b/coding_systems/base/coding_system_base.py
@@ -1,5 +1,7 @@
+import csv
 import operator
 from abc import ABC
+from io import StringIO
 
 from django.utils.functional import cached_property
 
@@ -133,6 +135,17 @@ class BaseCodingSystem(ABC):
                 msg = f"CSV file contains {num} unknown code{suffix} -- the first ({code}) is on line {line}"
             msg += f" ({self.short_name} release {self.release_name}, valid from {self.release.valid_from})"
             raise ValueError(msg)
+
+    def codes_from_csv_file(self, csv_file, csv_has_header):
+        data = csv_file.read().decode("utf-8-sig")
+        return self.codes_from_csv(data, csv_has_header)
+
+    def codes_from_csv(self, csv_data, csv_has_header):
+        csv_reader = csv.reader(StringIO(csv_data))
+        if csv_has_header:
+            next(csv_reader, None)
+
+        return [row[0] for row in csv_reader if row]
 
 
 class DummyCodingSystem(BaseCodingSystem):

--- a/coding_systems/base/coding_system_base.py
+++ b/coding_systems/base/coding_system_base.py
@@ -140,12 +140,22 @@ class BaseCodingSystem(ABC):
         data = csv_file.read().decode("utf-8-sig")
         return self.codes_from_csv(data, csv_has_header)
 
-    def codes_from_csv(self, csv_data, csv_has_header):
+    def codes_from_csv(self, csv_data, csv_has_header, lookup_code_column=False):
+        if lookup_code_column:
+            assert csv_has_header, (
+                "Can only lookup code column in header if header provided"
+            )
         csv_reader = csv.reader(StringIO(csv_data))
+        code_column_ix = 0
         if csv_has_header:
-            next(csv_reader, None)
+            header = next(csv_reader, None)
+            if lookup_code_column:
+                for i, header_value in enumerate(header):
+                    if header_value in self.csv_headers["code"]:
+                        code_column_ix = i
+                        break
 
-        return [row[0] for row in csv_reader if row]
+        return [row[code_column_ix] for row in csv_reader if row]
 
 
 class DummyCodingSystem(BaseCodingSystem):

--- a/coding_systems/base/coding_system_base.py
+++ b/coding_systems/base/coding_system_base.py
@@ -1,3 +1,4 @@
+import operator
 from abc import ABC
 
 from django.utils.functional import cached_property
@@ -107,6 +108,31 @@ class BaseCodingSystem(ABC):
 
     def code_to_term(self, codes):  # pragma: no cover
         raise NotImplementedError
+
+    def validate_csv_data_codes(self, codes):
+        # Fully implemented codings systems have a `lookup_names` method that is used to
+        # validate the codes in the CSV upload.  However, we also support uploads for some
+        # coding systems that we don't maintain data for (e.g. OPCS4, ReadV2).  Skip code
+        # validation for these systems, and just allow upload of the CSV data as it is.
+        if not self.has_database:
+            return
+        unknown_codes = set(codes) - set(self.lookup_names(codes))
+        unknown_codes_and_ixs = sorted(
+            [(codes.index(code), code) for code in unknown_codes],
+            key=operator.itemgetter(0),
+        )
+
+        if unknown_codes_and_ixs:
+            line = unknown_codes_and_ixs[0][0] + 1
+            code = unknown_codes_and_ixs[0][1]
+            if len(unknown_codes_and_ixs) == 1:
+                msg = f"CSV file contains 1 unknown code ({code}) on line {line}"
+            else:
+                num = len(unknown_codes_and_ixs)
+                suffix = "" if num == 1 else "s"
+                msg = f"CSV file contains {num} unknown code{suffix} -- the first ({code}) is on line {line}"
+            msg += f" ({self.short_name} release {self.release_name}, valid from {self.release.valid_from})"
+            raise ValueError(msg)
 
 
 class DummyCodingSystem(BaseCodingSystem):

--- a/opencodelists/forms.py
+++ b/opencodelists/forms.py
@@ -1,6 +1,3 @@
-import csv
-from io import StringIO
-
 from django import forms
 from django.contrib.auth import password_validation
 from django.core.validators import RegexValidator
@@ -117,26 +114,20 @@ class CodelistCreateForm(forms.Form):
 
         csv_has_header = self.cleaned_data["csv_has_header"]
 
-        try:
-            data = f.read().decode("utf-8-sig")
-        except UnicodeDecodeError as exception:
-            raise forms.ValidationError(
-                "File could not be read. Please ensure the file contains CSV "
-                "data (not Excel, for example). It should be a text file encoded "
-                f"in the UTF-8 format. Error details: {exception}."
-            )
-
         # Eventually coding system version may be a selectable field, but for now it
         # just defaults to using the most recent one.
         coding_system = CODING_SYSTEMS[
             self.cleaned_data["coding_system_id"]
         ].get_by_release_or_most_recent()
 
-        csv_reader = csv.reader(StringIO(data))
-        if csv_has_header:
-            next(csv_reader, None)
-
-        codes = [row[0] for row in csv_reader if row]
+        try:
+            codes = coding_system.codes_from_csv_file(f, csv_has_header)
+        except UnicodeDecodeError as exception:
+            raise forms.ValidationError(
+                "File could not be read. Please ensure the file contains CSV "
+                "data (not Excel, for example). It should be a text file encoded "
+                f"in the UTF-8 format. Error details: {exception}."
+            )
 
         try:
             coding_system.validate_csv_data_codes(codes)

--- a/opencodelists/forms.py
+++ b/opencodelists/forms.py
@@ -1,5 +1,4 @@
 import csv
-import operator
 from io import StringIO
 
 from django import forms
@@ -139,34 +138,11 @@ class CodelistCreateForm(forms.Form):
 
         codes = [row[0] for row in csv_reader if row]
 
-        validate_csv_data_codes(coding_system, codes)
+        try:
+            coding_system.validate_csv_data_codes(codes)
+        except ValueError as e:
+            raise forms.ValidationError(str(e))
         return codes
-
-
-def validate_csv_data_codes(coding_system, codes):
-    # Fully implemented codings systems have a `lookup_names` method that is used to
-    # validate the codes in the CSV upload.  However, we also support uploads for some
-    # coding systems that we don't maintain data for (e.g. OPCS4, ReadV2).  Skip code
-    # validation for these systems, and just allow upload of the CSV data as it is.
-    if not coding_system.has_database:
-        return
-    unknown_codes = set(codes) - set(coding_system.lookup_names(codes))
-    unknown_codes_and_ixs = sorted(
-        [(codes.index(code), code) for code in unknown_codes],
-        key=operator.itemgetter(0),
-    )
-
-    if unknown_codes_and_ixs:
-        line = unknown_codes_and_ixs[0][0] + 1
-        code = unknown_codes_and_ixs[0][1]
-        if len(unknown_codes_and_ixs) == 1:
-            msg = f"CSV file contains 1 unknown code ({code}) on line {line}"
-        else:
-            num = len(unknown_codes_and_ixs)
-            suffix = "" if num == 1 else "s"
-            msg = f"CSV file contains {num} unknown code{suffix} -- the first ({code}) is on line {line}"
-        msg += f" ({coding_system.short_name} release {coding_system.release_name}, valid from {coding_system.release.valid_from})"
-        raise forms.ValidationError(msg)
 
 
 class RegisterForm(forms.ModelForm):


### PR DESCRIPTION
re: #3031 

Advantages:
* converted codelists can be edited in the builder
Disadvantages:
* converted codelists lose the source BNF code column
* existing converted codelists will need to be converted to new-style to become editable
  * we can do this en masse with an existing script
  * we can do this manually on request
  * or users can delete their old converted codelists and convert a fresh one