### PR TITLE
Add dagger/asterisk info to more info modal

### DIFF
--- a/assets/src/scripts/__tests__/builder/codelistbuilder.test.jsx
+++ b/assets/src/scripts/__tests__/builder/codelistbuilder.test.jsx
@@ -36,6 +36,7 @@ const renderCodelistBuilder = (data, hierarchy, visiblePaths) => {
   render(
     <CodelistBuilder
       allCodes={data.all_codes}
+      codeToDaggerAsteriskInfo={data.code_to_dagger_asterisk_info ?? {}}
       codeToStatus={data.code_to_status}
       codeToTerm={data.code_to_term}
       draftURL={data.draft_url}

--- a/assets/src/scripts/__tests__/components/Codelist/MoreInfoModal.spec.tsx
+++ b/assets/src/scripts/__tests__/components/Codelist/MoreInfoModal.spec.tsx
@@ -277,6 +277,102 @@ it("shows clinically different ICD-10 description differences in a red box", asy
   expect(screen.getByText("WHO description")).toBeVisible();
 });
 
+it("shows ICD-10 dagger information in the WHO additional info box", async () => {
+  vi.mocked(readValueFromPage).mockReturnValue({ coding_system_id: "icd10" });
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(() =>
+      Promise.resolve({
+        json: () =>
+          Promise.resolve({
+            rubrics: {
+              "123": {
+                concept_rubrics: {},
+                modifier_rubrics: {},
+              },
+            },
+          }),
+      }),
+    ),
+  );
+
+  const user = userEvent.setup();
+  render(
+    <MoreInfoModal
+      {...props}
+      daggerAsteriskInfo={{
+        usage: "dagger",
+        url: "https://icd.who.int/browse10/2019/en#/A12.3",
+      }}
+    />,
+  );
+
+  await user.click(
+    screen.getByRole("button", {
+      name: /show icd-10 dagger information for 123/i,
+    }),
+  );
+
+  expect(await screen.findByText("WHO ICD-10 Additional Info")).toBeVisible();
+  expect(screen.getByRole("heading", { name: /usage: dagger/i })).toBeVisible();
+  expect(
+    screen.getByText(
+      "Dagger codes identify the underlying condition; asterisk codes identify the manifestation.",
+    ),
+  ).toBeVisible();
+  expect(
+    screen.getByRole("link", {
+      name: /view 123 in the who icd-10 browser/i,
+    }),
+  ).toHaveAttribute("href", "https://icd.who.int/browse10/2019/en#/A12.3");
+  expect(
+    screen.getByRole("link", {
+      name: /read the full dagger\/asterisk guidance \(section 3.1.3 - p20\)/i,
+    }),
+  ).toBeVisible();
+});
+
+it("shows ICD-10 asterisk information without a code-specific browser link", async () => {
+  vi.mocked(readValueFromPage).mockReturnValue({ coding_system_id: "icd10" });
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(() =>
+      Promise.resolve({
+        json: () => Promise.resolve({}),
+      }),
+    ),
+  );
+
+  const user = userEvent.setup();
+  render(
+    <MoreInfoModal
+      {...props}
+      daggerAsteriskInfo={{
+        usage: "asterisk",
+      }}
+    />,
+  );
+
+  const usageButton = screen.getByRole("button", {
+    name: /show icd-10 asterisk information for 123/i,
+  });
+  expect(usageButton).toHaveTextContent("*");
+
+  await user.click(usageButton);
+
+  expect(
+    await screen.findByRole("heading", {
+      name: /usage: asterisk/i,
+    }),
+  ).toBeVisible();
+  expect(screen.queryByRole("link", { name: /view 123/i })).toBeNull();
+  expect(
+    screen.getByRole("link", {
+      name: /read the full dagger\/asterisk guidance \(section 3.1.3 - p20\)/i,
+    }),
+  ).toBeVisible();
+});
+
 it("shows ICD-10 modifier rubric information", async () => {
   vi.mocked(readValueFromPage).mockReturnValue({ coding_system_id: "icd10" });
   vi.stubGlobal(
@@ -310,7 +406,7 @@ it("shows ICD-10 modifier rubric information", async () => {
   expect(screen.getByText("Includes multiple sites")).toBeVisible();
 });
 
-it("uses consistent cards", async () => {
+it("uses consistent cards and renders usage after concept and modifier rubrics", async () => {
   vi.mocked(readValueFromPage).mockReturnValue({ coding_system_id: "icd10" });
   vi.stubGlobal(
     "fetch",
@@ -337,7 +433,7 @@ it("uses consistent cards", async () => {
   );
 
   const user = userEvent.setup();
-  render(<MoreInfoModal {...props} />);
+  render(<MoreInfoModal {...props} daggerAsteriskInfo={{ usage: "dagger" }} />);
   await user.click(screen.getByRole("button", { name: /more info/i }));
 
   const conceptCard = (
@@ -346,18 +442,30 @@ it("uses consistent cards", async () => {
   const modifierCard = screen
     .getByRole("heading", { name: "Modifier: Multiple sites" })
     .closest("section") as HTMLElement;
+  const usageCard = screen
+    .getByRole("heading", { name: /usage: dagger/i })
+    .closest("section") as HTMLElement;
   const codingHint = screen.getByText("Coding hint:");
 
-  for (const card of [conceptCard, modifierCard]) {
+  for (const card of [conceptCard, modifierCard, usageCard]) {
     expect(card).toHaveClass("builder__additional-info-card");
   }
   expect(conceptCard).toHaveClass("builder__additional-info-card--concept");
+  expect(modifierCard).not.toHaveClass(
+    "builder__additional-info-card--concept",
+    "builder__additional-info-card--usage",
+  );
+  expect(usageCard).toHaveClass("builder__additional-info-card--usage");
   expect(
     conceptCard.compareDocumentPosition(codingHint) &
       Node.DOCUMENT_POSITION_FOLLOWING,
   ).toBeTruthy();
   expect(
     codingHint.compareDocumentPosition(modifierCard) &
+      Node.DOCUMENT_POSITION_FOLLOWING,
+  ).toBeTruthy();
+  expect(
+    modifierCard.compareDocumentPosition(usageCard) &
       Node.DOCUMENT_POSITION_FOLLOWING,
   ).toBeTruthy();
 });

--- a/assets/src/scripts/__tests__/fixtures/version_from_scratch.json
+++ b/assets/src/scripts/__tests__/fixtures/version_from_scratch.json
@@ -853,6 +853,7 @@
     "439656005": "+",
     "73583000": "(+)"
   },
+  "code_to_dagger_asterisk_info": {},
   "is_editable": true,
   "update_url": "/builder/71bb8ca2/update/",
   "search_url": "/builder/71bb8ca2/search/",

--- a/assets/src/scripts/__tests__/fixtures/version_with_complete_searches.json
+++ b/assets/src/scripts/__tests__/fixtures/version_with_complete_searches.json
@@ -853,6 +853,7 @@
     "439656005": "+",
     "73583000": "(+)"
   },
+  "code_to_dagger_asterisk_info": {},
   "is_editable": true,
   "update_url": "/builder/71bb8ca2/update/",
   "search_url": "/builder/71bb8ca2/search/",

--- a/assets/src/scripts/__tests__/fixtures/version_with_no_searches.json
+++ b/assets/src/scripts/__tests__/fixtures/version_with_no_searches.json
@@ -460,6 +460,7 @@
     "439656005": "-",
     "73583000": "(+)"
   },
+  "code_to_dagger_asterisk_info": {},
   "is_editable": true,
   "update_url": "/builder/23da730d/update/",
   "search_url": "/builder/23da730d/search/",

--- a/assets/src/scripts/__tests__/fixtures/version_with_some_searches.json
+++ b/assets/src/scripts/__tests__/fixtures/version_with_some_searches.json
@@ -470,6 +470,7 @@
     "439656005": "+",
     "73583000": "(+)"
   },
+  "code_to_dagger_asterisk_info": {},
   "is_editable": true,
   "update_url": "/builder/0acaffd8/update/",
   "search_url": "/builder/0acaffd8/search/",

--- a/assets/src/scripts/builder/index.tsx
+++ b/assets/src/scripts/builder/index.tsx
@@ -32,6 +32,9 @@ if (container) {
         allCodes={readValueFromPage("all-codes")}
         codeToStatus={codeToStatus}
         codeToTerm={codeToTerm}
+        codeToDaggerAsteriskInfo={readValueFromPage(
+          "code-to-dagger-asterisk-info",
+        )}
         draftURL={readValueFromPage("draft-url")}
         hierarchy={hierarchy}
         isEditable={readValueFromPage("is-editable")}

--- a/assets/src/scripts/components/Codelist/Container.tsx
+++ b/assets/src/scripts/components/Codelist/Container.tsx
@@ -5,6 +5,7 @@ import Section from "./Section";
 
 interface ContainerProps {
   allCodes: PageData["allCodes"];
+  codeToDaggerAsteriskInfo: PageData["codeToDaggerAsteriskInfo"];
   codeToStatus: PageData["codeToStatus"];
   codeToTerm: PageData["codeToTerm"];
   hierarchy: Hierarchy;
@@ -16,6 +17,7 @@ interface ContainerProps {
 
 export default function Container({
   allCodes,
+  codeToDaggerAsteriskInfo,
   codeToStatus,
   codeToTerm,
   hierarchy,
@@ -44,6 +46,7 @@ export default function Container({
           key={heading}
           allCodes={allCodes}
           ancestorCodes={ancestorCodes}
+          codeToDaggerAsteriskInfo={codeToDaggerAsteriskInfo}
           codeToStatus={codeToStatus}
           codeToTerm={codeToTerm}
           heading={heading}

--- a/assets/src/scripts/components/Codelist/MoreInfoModal.tsx
+++ b/assets/src/scripts/components/Codelist/MoreInfoModal.tsx
@@ -2,7 +2,14 @@ import React, { useEffect, useState } from "react";
 import { Button, Modal } from "react-bootstrap";
 import type Hierarchy from "../../_hierarchy";
 import { getCookie, readValueFromPage } from "../../_utils";
-import type { Code, PageData, Status, Term } from "../../types";
+import type {
+  Code,
+  DaggerAsteriskInfo,
+  DaggerAsteriskUsage,
+  PageData,
+  Status,
+  Term,
+} from "../../types";
 
 interface CreateModalTextProps {
   allCodes: PageData["allCodes"];
@@ -341,9 +348,21 @@ interface MoreInfoModalProps {
   code: Code;
   codeToStatus: PageData["codeToStatus"];
   codeToTerm: PageData["codeToTerm"];
+  daggerAsteriskInfo?: DaggerAsteriskInfo;
   hierarchy: Hierarchy;
   status: Status;
   term: Term;
+}
+
+const daggerAsteriskGuidanceUrl =
+  "https://icd.who.int/browse10/Content/statichtml/ICD10Volume2_en_2019.pdf#page=29";
+
+function usageLabel(usage: DaggerAsteriskUsage) {
+  return usage === "dagger" ? "Dagger" : "Asterisk";
+}
+
+function usageGlyph(usage: DaggerAsteriskUsage) {
+  return usage === "dagger" ? "†" : "*";
 }
 
 function MoreInfoModal({
@@ -351,6 +370,7 @@ function MoreInfoModal({
   code,
   codeToStatus,
   codeToTerm,
+  daggerAsteriskInfo,
   hierarchy,
   status,
   term,
@@ -430,6 +450,17 @@ function MoreInfoModal({
 
   return (
     <>
+      {daggerAsteriskInfo && (
+        <button
+          className="builder__dagger-asterisk-link"
+          onClick={handleShow}
+          type="button"
+          aria-label={`Show ICD-10 ${daggerAsteriskInfo.usage} information for ${code}`}
+          title={`ICD-10 ${daggerAsteriskInfo.usage} code`}
+        >
+          <span>{usageGlyph(daggerAsteriskInfo.usage)}</span>
+        </button>
+      )}
       <Button
         className="builder__more-info-btn plausible-event-name=More+info+click"
         onClick={handleShow}
@@ -479,7 +510,7 @@ function MoreInfoModal({
               termDifferences={termDifferences}
             />
           )}
-          {hasRubrics(rubrics) && (
+          {(hasRubrics(rubrics) || daggerAsteriskInfo) && (
             <section className="border border-info rounded overflow-hidden mb-4">
               {/* WHO header */}
               <div className="bg-info text-white px-4 py-3">
@@ -496,6 +527,42 @@ function MoreInfoModal({
               <div className="bg-white pt-3 px-4">
                 {rubrics && hasRubrics(rubrics) && (
                   <RubricBlock rubrics={rubrics} term={term} />
+                )}
+                {daggerAsteriskInfo && (
+                  <section className="builder__additional-info-card builder__additional-info-card--usage">
+                    <h3 className="h6 font-weight-bold mb-3 d-flex align-items-center">
+                      Usage: {usageLabel(daggerAsteriskInfo.usage)}
+                      <span className="builder__dagger-asterisk-info__marker ml-2">
+                        {usageGlyph(daggerAsteriskInfo.usage)}
+                      </span>
+                    </h3>
+                    <p>
+                      Dagger codes identify the underlying condition; asterisk
+                      codes identify the manifestation.
+                    </p>
+                    <p className="mb-0 small">
+                      {daggerAsteriskInfo.url && (
+                        <>
+                          <a
+                            href={daggerAsteriskInfo.url}
+                            rel="noreferrer"
+                            target="_blank"
+                          >
+                            View {code} in the WHO ICD-10 browser
+                          </a>
+                          {" · "}
+                        </>
+                      )}
+                      <a
+                        href={daggerAsteriskGuidanceUrl}
+                        rel="noreferrer"
+                        target="_blank"
+                      >
+                        Read the full dagger/asterisk guidance (section 3.1.3 -
+                        p20)
+                      </a>
+                    </p>
+                  </section>
                 )}
               </div>
             </section>

--- a/assets/src/scripts/components/Codelist/Row.tsx
+++ b/assets/src/scripts/components/Codelist/Row.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import type Hierarchy from "../../_hierarchy";
 import type {
   Code,
+  DaggerAsteriskInfo,
   IsExpanded,
   PageData,
   Path,
@@ -19,6 +20,7 @@ import StatusToggle from "./StatusToggle";
 interface RowProps {
   allCodes: PageData["allCodes"];
   code: Code;
+  daggerAsteriskInfo?: DaggerAsteriskInfo;
   codeToStatus: PageData["codeToStatus"];
   codeToTerm: PageData["codeToTerm"];
   hasDescendants: boolean;
@@ -38,6 +40,7 @@ export default function Row({
   code,
   codeToStatus,
   codeToTerm,
+  daggerAsteriskInfo,
   hasDescendants,
   hierarchy,
   isEditable,
@@ -107,6 +110,7 @@ export default function Row({
           code={code}
           codeToStatus={codeToStatus}
           codeToTerm={codeToTerm}
+          daggerAsteriskInfo={daggerAsteriskInfo}
           hierarchy={hierarchy}
           status={status}
           term={term}

--- a/assets/src/scripts/components/Codelist/Section.tsx
+++ b/assets/src/scripts/components/Codelist/Section.tsx
@@ -11,6 +11,7 @@ import Tree from "./Tree";
 interface SectionProps {
   allCodes: PageData["allCodes"];
   ancestorCodes: AncestorCodes;
+  codeToDaggerAsteriskInfo: PageData["codeToDaggerAsteriskInfo"];
   codeToStatus: PageData["codeToStatus"];
   codeToTerm: PageData["codeToTerm"];
   heading: string;
@@ -24,6 +25,7 @@ interface SectionProps {
 export default function Section({
   allCodes,
   ancestorCodes,
+  codeToDaggerAsteriskInfo,
   codeToStatus,
   codeToTerm,
   heading,
@@ -41,6 +43,7 @@ export default function Section({
           <Tree
             allCodes={allCodes}
             ancestorCode={ancestorCode}
+            codeToDaggerAsteriskInfo={codeToDaggerAsteriskInfo}
             codeToStatus={codeToStatus}
             codeToTerm={codeToTerm}
             hierarchy={hierarchy}

--- a/assets/src/scripts/components/Codelist/Tree.tsx
+++ b/assets/src/scripts/components/Codelist/Tree.tsx
@@ -12,6 +12,7 @@ import Row from "./Row";
 interface TreeProps {
   allCodes: PageData["allCodes"];
   ancestorCode: AncestorCode;
+  codeToDaggerAsteriskInfo: PageData["codeToDaggerAsteriskInfo"];
   codeToStatus: PageData["codeToStatus"];
   codeToTerm: PageData["codeToTerm"];
   hierarchy: Hierarchy;
@@ -24,6 +25,7 @@ interface TreeProps {
 export default function Tree({
   allCodes,
   ancestorCode,
+  codeToDaggerAsteriskInfo,
   codeToStatus,
   codeToTerm,
   hierarchy,
@@ -39,6 +41,7 @@ export default function Tree({
       <Row
         allCodes={allCodes}
         code={row.code}
+        daggerAsteriskInfo={codeToDaggerAsteriskInfo[row.code]}
         codeToStatus={codeToStatus}
         codeToTerm={codeToTerm}
         hasDescendants={row.hasDescendants}

--- a/assets/src/scripts/components/CodelistBuilder.tsx
+++ b/assets/src/scripts/components/CodelistBuilder.tsx
@@ -182,6 +182,7 @@ export default class CodelistBuilder extends React.Component<
   render() {
     const {
       allCodes,
+      codeToDaggerAsteriskInfo,
       codeToTerm,
       draftURL,
       hierarchy,
@@ -225,6 +226,7 @@ export default class CodelistBuilder extends React.Component<
                 <Tab eventKey="codelist" title="Codelist">
                   <CodelistTab
                     allCodes={allCodes}
+                    codeToDaggerAsteriskInfo={codeToDaggerAsteriskInfo}
                     codeToStatus={this.state.codeToStatus}
                     codeToTerm={codeToTerm}
                     hierarchy={hierarchy}

--- a/assets/src/scripts/components/Layout/CodelistTab.tsx
+++ b/assets/src/scripts/components/Layout/CodelistTab.tsx
@@ -7,6 +7,7 @@ import EmptySearch from "../Codelist/EmptySearch";
 interface CodelistTabProps {
   allCodes: PageData["allCodes"];
   ancestorCodes?: string[];
+  codeToDaggerAsteriskInfo: PageData["codeToDaggerAsteriskInfo"];
   codeToStatus: PageData["codeToStatus"];
   codeToTerm: PageData["codeToTerm"];
   hierarchy: Hierarchy;
@@ -19,6 +20,7 @@ interface CodelistTabProps {
 
 export default function CodelistTab({
   allCodes,
+  codeToDaggerAsteriskInfo,
   codeToStatus,
   codeToTerm,
   hierarchy,
@@ -35,6 +37,7 @@ export default function CodelistTab({
       {treeTables.length > 0 ? (
         <Container
           allCodes={allCodes}
+          codeToDaggerAsteriskInfo={codeToDaggerAsteriskInfo}
           codeToStatus={codeToStatus}
           codeToTerm={codeToTerm}
           hierarchy={hierarchy}

--- a/assets/src/scripts/types.ts
+++ b/assets/src/scripts/types.ts
@@ -3,6 +3,11 @@ import type { SearchesProps } from "./components/Cards/Searches";
 export type AncestorCode = string;
 export type AncestorCodes = AncestorCode[];
 export type Code = string;
+export type DaggerAsteriskUsage = "dagger" | "asterisk";
+export type DaggerAsteriskInfo = {
+  usage: DaggerAsteriskUsage;
+  url?: string;
+};
 export type IsExpanded = boolean;
 export type Path = string;
 export type Pipe = "└" | "├" | " " | "│";
@@ -16,6 +21,7 @@ type VisiblePaths = Set<string>;
 
 export interface PageData {
   allCodes: AllCodes;
+  codeToDaggerAsteriskInfo: { [key: string]: DaggerAsteriskInfo };
   codeToStatus: { [key: string]: Status };
   codeToTerm: { [key: string]: string };
   draftURL: string;

--- a/assets/src/styles/_builder.css
+++ b/assets/src/styles/_builder.css
@@ -83,6 +83,57 @@ just use the first 3.
   text-decoration-color: currentColor;
 }
 
+.builder__dagger-asterisk-link {
+  appearance: none;
+  cursor: pointer;
+
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  vertical-align: middle;
+
+  width: 1.15rem;
+  height: 1.15rem;
+  padding: 0;
+  margin: 0 0 0 0.25rem;
+
+  border: 1px solid #e3c15f;
+  border-radius: 0.35rem;
+  background: #fff8df;
+  color: #745500;
+
+  font: inherit;
+  font-size: 0.82rem;
+  font-weight: 800;
+  line-height: 1;
+
+  user-select: none;
+  transition:
+    background-color 0.15s ease,
+    border-color 0.15s ease,
+    box-shadow 0.15s ease,
+    transform 0.1s ease;
+}
+
+.builder__dagger-asterisk-link > span {
+  position: relative;
+  top: -0.04rem; /* optical centering */
+}
+
+.builder__dagger-asterisk-link:hover {
+  background: #fff3c2;
+  border-color: #d4b248;
+}
+
+.builder__dagger-asterisk-link:active {
+  transform: translateY(1px);
+}
+
+.builder__dagger-asterisk-link:focus-visible {
+  outline: 2px solid #4d90fe;
+  outline-offset: 2px;
+}
+
 .builder__additional-info-card {
   margin-bottom: 1rem;
   padding: 0.875rem 1rem;
@@ -100,4 +151,31 @@ just use the first 3.
   border-color: #ced4da;
   border-left-color: var(--dark);
   background: #fff;
+}
+
+.builder__additional-info-card--usage {
+  border-color: #e3c15f;
+  border-left-color: #d4b248;
+  background: #fff8df;
+}
+
+.builder__dagger-asterisk-info__marker {
+  display: inline-flex;
+  flex: 0 0 auto;
+  align-items: center;
+  justify-content: center;
+  width: 1.5rem;
+  height: 1.5rem;
+  border: 1px solid #b8dce8;
+  border-radius: 50%;
+  background: #fff;
+  color: #0f6674;
+  font-size: 1rem;
+  font-weight: 800;
+  line-height: 1;
+}
+
+.builder__additional-info-card--usage .builder__dagger-asterisk-info__marker {
+  border-color: #e3c15f;
+  color: #745500;
 }

--- a/builder/management/commands/generate_builder_fixture.py
+++ b/builder/management/commands/generate_builder_fixture.py
@@ -99,6 +99,7 @@ class Command(BaseCommand):
                     "child_map",
                     "code_to_term",
                     "code_to_status",
+                    "code_to_dagger_asterisk_info",
                     "is_editable",
                     "update_url",
                     "search_url",
@@ -120,6 +121,9 @@ class Command(BaseCommand):
             }
             data["code_to_term"] = dict(sorted(data["code_to_term"].items()))
             data["code_to_status"] = dict(sorted(data["code_to_status"].items()))
+            data["code_to_dagger_asterisk_info"] = dict(
+                sorted(data["code_to_dagger_asterisk_info"].items())
+            )
 
             js_fixtures_path = Path(
                 settings.BASE_DIR, "assets", "src", "scripts", "__tests__", "fixtures"

--- a/builder/tests/test_views.py
+++ b/builder/tests/test_views.py
@@ -32,6 +32,8 @@ def test_draft_with_complete_searches(client, draft_with_complete_searches):
 
     assert rsp.status_code == 200
     assert b"New-style Codelist" in rsp.content
+    assert rsp.context["code_to_dagger_asterisk_info"] == {}
+    assert b'id="code-to-dagger-asterisk-info"' in rsp.content
 
 
 def test_version_from_scratch(client, version_from_scratch):

--- a/builder/views.py
+++ b/builder/views.py
@@ -273,6 +273,9 @@ def _draft(request, draft, search_id):
         "child_map": {c: list(pp) for c, pp in hierarchy.child_map.items()},
         "code_to_term": code_to_term,
         "code_to_status": codeset.code_to_status,
+        "code_to_dagger_asterisk_info": coding_system.lookup_dagger_asterisk_usages(
+            codeset.all_codes()
+        ),
         "is_editable": request.user == draft.author,
         "draft_url": draft_url,
         "update_url": update_url,

--- a/coding_systems/base/coding_system_base.py
+++ b/coding_systems/base/coding_system_base.py
@@ -108,6 +108,9 @@ class BaseCodingSystem(ABC):
     def lookup_additional_rubrics(self, codes):  # pragma: no cover
         return {}
 
+    def lookup_dagger_asterisk_usages(self, codes):  # pragma: no cover
+        return {}
+
     def code_to_term(self, codes):  # pragma: no cover
         raise NotImplementedError
 

--- a/coding_systems/icd10/coding_system.py
+++ b/coding_systems/icd10/coding_system.py
@@ -10,6 +10,7 @@ from .models import (
     ConceptEdition,
     ConceptKind,
     ConceptRubric,
+    ConceptUsage,
     Edition,
     ModifierRubric,
 )
@@ -208,6 +209,37 @@ class CodingSystem(BuilderCompatibleCodingSystem):
         return {
             "rubrics": rubrics,
             "term_differences": edition_description_differences,
+        }
+
+    def lookup_dagger_asterisk_usages(self, codes):
+        if not codes:
+            return {}
+
+        def who_2019_browser_url(code):
+            # We return the WHO 2019 URL rather than the NHS 2016 one because:
+            # - the NHS 2016 version made no changes to the underlying WHO 2016 edition
+            # - there are a couple of dagger/asterisk relationships that appear in 2019 but not in 2016, so the 2019 version is more complete
+            return f"https://icd.who.int/browse10/2019/en#/{f'{code[:3]}.{code[3:]}' if len(code) > 3 else code}"
+
+        concept_usages = (
+            ConceptEdition.objects.using(self.database_alias)
+            .filter(
+                edition_id=self.latest_edition.id,
+                concept_id__in=codes,
+                usage__in=[
+                    ConceptUsage.DAGGER,
+                    ConceptUsage.ASTERISK,
+                ],
+            )
+            .values_list("concept_id", "usage")
+        )
+
+        return {
+            concept_code: {
+                "usage": "asterisk" if usage == ConceptUsage.ASTERISK else "dagger",
+                "url": who_2019_browser_url(concept_code),
+            }
+            for concept_code, usage in concept_usages
         }
 
     def codes_by_type(self, codes, hierarchy):

--- a/coding_systems/icd10/tests/test_coding_system.py
+++ b/coding_systems/icd10/tests/test_coding_system.py
@@ -1,7 +1,13 @@
 import pytest
 
 from coding_systems.icd10.coding_system import CodingSystem
-from coding_systems.icd10.models import ConceptRubric, ModifierRubric, RubricKind
+from coding_systems.icd10.models import (
+    ConceptEdition,
+    ConceptRubric,
+    ConceptUsage,
+    ModifierRubric,
+    RubricKind,
+)
 
 
 @pytest.fixture
@@ -181,3 +187,36 @@ def test_term_differences(icd10_data, coding_system):
 
     assert "term_differences" in blank
     assert blank["term_differences"] == {}
+
+
+def test_lookup_dagger_asterisk_usages_with_no_codes(coding_system):
+    assert coding_system.lookup_dagger_asterisk_usages([]) == {}
+
+
+def test_lookup_dagger_asterisk_usages(icd10_data, coding_system):
+    ConceptEdition.objects.using(coding_system.database_alias).filter(id=12).update(
+        usage=ConceptUsage.DAGGER
+    )
+    ConceptEdition.objects.using(coding_system.database_alias).filter(id=13).update(
+        usage=ConceptUsage.DAGGER
+    )
+    ConceptEdition.objects.using(coding_system.database_alias).filter(id=14).update(
+        usage=ConceptUsage.ASTERISK
+    )
+
+    assert coding_system.lookup_dagger_asterisk_usages(
+        ["M77", "M770", "M771", "M772"]
+    ) == {
+        "M77": {
+            "usage": "dagger",
+            "url": "https://icd.who.int/browse10/2019/en#/M77",
+        },
+        "M770": {
+            "usage": "dagger",
+            "url": "https://icd.who.int/browse10/2019/en#/M77.0",
+        },
+        "M771": {
+            "usage": "asterisk",
+            "url": "https://icd.who.int/browse10/2019/en#/M77.1",
+        },
+    }

--- a/templates/builder/draft.html
+++ b/templates/builder/draft.html
@@ -19,6 +19,7 @@
   {{ tree_tables|json_script:"tree-tables" }}
   {{ code_to_term|json_script:"code-to-term" }}
   {{ code_to_status|json_script:"code-to-status" }}
+  {{ code_to_dagger_asterisk_info|json_script:"code-to-dagger-asterisk-info" }}
   {{ all_codes|json_script:"all-codes" }}
   {{ parent_map|json_script:"parent-map" }}
   {{ child_map|json_script:"child-map" }}


### PR DESCRIPTION
Appears in the tree view as:

<img width="569" height="31" alt="image" src="https://github.com/user-attachments/assets/c4103d34-39fe-4149-9de2-343dd9bd486a" />

With a tooltip on hover:

<img width="546" height="81" alt="image" src="https://github.com/user-attachments/assets/29113b12-8ad9-496c-8864-d589a8f13c82" />

Clicking the dagger/asterisk just opens the more info modal, which looks like this:

<img width="827" height="622" alt="image" src="https://github.com/user-attachments/assets/113ba44c-6eff-47d4-8ec7-7f26c5d9b2cc" />

The code links to the WHO ICD 2019 browser (all dagger asterisk codes in 2016 are also in 2019 so this is safe). The guidance link is to this: https://icd.who.int/browse10/Content/statichtml/ICD10Volume2_en_2019.pdf#page=29
