### PR TITLE
Allow "create new version" (in builder) for bnf-dmd codelists

### DIFF
--- a/codelists/actions.py
+++ b/codelists/actions.py
@@ -596,7 +596,7 @@ def delete_version(*, version):
 
 
 @transaction.atomic
-def convert_codelist_to_new_style(*, codelist):
+def convert_codelist_to_new_style(*, codelist, status=Status.UNDER_REVIEW):
     """Convert codelist to new style.
     Create a new version with the same codes as the latest version.
     """
@@ -608,7 +608,7 @@ def convert_codelist_to_new_style(*, codelist):
     return _create_version_with_codes(
         codelist=codelist,
         codes=set(prev_clv.codes),
-        status=Status.UNDER_REVIEW,
+        status=status,
         coding_system_release=prev_clv.coding_system_release,
     )
 

--- a/codelists/tests/test_actions.py
+++ b/codelists/tests/test_actions.py
@@ -527,6 +527,18 @@ def test_convert_codelist_to_new_style(old_style_codelist, old_style_version):
     converted_version = old_style_codelist.versions.order_by("id").last()
     assert converted_version.csv_data is None
     assert old_style_version.codes == converted_version.codes
+    assert converted_version.status == Status.UNDER_REVIEW
+
+
+def test_convert_codelist_to_new_style_with_status(old_style_codelist):
+
+    actions.convert_codelist_to_new_style(
+        codelist=old_style_codelist, status=Status.DRAFT
+    )
+
+    converted_version = old_style_codelist.versions.order_by("id").last()
+
+    assert converted_version.status == Status.DRAFT
 
 
 def test_export_to_builder(organisation_user, new_style_version):

--- a/codelists/tests/views/test_version_create.py
+++ b/codelists/tests/views/test_version_create.py
@@ -32,6 +32,28 @@ def test_post_success(client, version):
     assert response.url == draft.get_builder_draft_url()
 
 
+def test_post_success_old_style_codelists(client, old_style_version):
+    force_login(old_style_version, client)
+
+    assert (
+        old_style_version.codelist.versions.filter(status=Status.DRAFT).exists()
+        is False
+    )
+
+    old_style_version_count = old_style_version.codelist.versions.count()
+
+    response = client.post(
+        old_style_version.get_create_url(),
+        {"coding_system_database_alias": most_recent_database_alias("snomedct")},
+    )
+    draft = old_style_version.codelist.versions.get(status=Status.DRAFT)
+
+    assert draft.csv_data is None
+    assert draft.codelist.versions.count() == old_style_version_count + 1
+    assert response.status_code == 302
+    assert response.url == draft.get_builder_draft_url()
+
+
 def test_post_success_no_coding_system_database_alias(client, version):
     force_login(version, client)
 

--- a/codelists/views/version.py
+++ b/codelists/views/version.py
@@ -85,6 +85,13 @@ def version(request, clv):
     else:
         coding_system_release_outdated = False
 
+    is_converted_from_bnf = (
+        clv.codelist.coding_system_id == "dmd"
+        and clv.codelist.slug.endswith("-dmd")
+        and clv.codelist.methodology is not None
+        and "[pseudo-BNF system codelist]" in clv.codelist.methodology
+    )
+
     ctx = {
         "clv": clv,
         "codelist": clv.codelist,
@@ -100,5 +107,6 @@ def version(request, clv):
         "latest_published_version_url": latest_published_version_url,
         "count_codes_included": len(rows),
         "coding_system_release_outdated": coding_system_release_outdated,
+        "is_converted_from_bnf": is_converted_from_bnf,
     }
     return render(request, "codelists/version.html", ctx)

--- a/codelists/views/version_create.py
+++ b/codelists/views/version_create.py
@@ -2,6 +2,8 @@ from django.contrib.auth.decorators import login_required
 from django.shortcuts import redirect
 from django.views.decorators.http import require_POST
 
+from codelists.models import Status
+
 from .. import actions
 from ..coding_systems import most_recent_database_alias
 from .decorators import load_version, require_permission
@@ -19,9 +21,14 @@ def version_create(request, version):
         coding_system_database_alias = most_recent_database_alias(
             version.coding_system.id
         )
-    draft = actions.export_to_builder(
-        version=version,
-        author=request.user,
-        coding_system_database_alias=coding_system_database_alias,
-    )
+    if not version.codelist.is_new_style():
+        draft = actions.convert_codelist_to_new_style(
+            codelist=version.codelist, status=Status.DRAFT
+        )
+    else:
+        draft = actions.export_to_builder(
+            version=version,
+            author=request.user,
+            coding_system_database_alias=coding_system_database_alias,
+        )
     return redirect(draft.get_builder_draft_url())

--- a/templates/codelists/version.html
+++ b/templates/codelists/version.html
@@ -28,7 +28,7 @@
         <form method="POST" action="{{ clv.get_create_url }}" class="version__buttons">
           {% csrf_token %}
 
-          {% if codelist.is_new_style %}
+          {% if codelist.is_new_style or is_converted_from_bnf %}
             {% if can_create_new_version %}
               <input type="hidden" name="coding_system_database_alias" value="" />
               <button
@@ -49,7 +49,8 @@
                 Create new version
               </button>
             {% endif %}
-          {% else %}
+          {% endif %}
+          {% if not codelist.is_new_style %}
             <a
               class="btn btn-outline-primary"
               href="{{ codelist.get_version_upload_url }}"


### PR DESCRIPTION
Fixes #3031 

This adds the "Create New Version" button alongside the existing "Upload New Version" button for BNF to dmd converted codelists.

I chose to leave the Upload New Version button in place because users have previously uploaded new versions of converted codelists. We do not know if they do this only because they could not edit them in the builder. Nonetheless, because of the lack of support for additional columns (in this case the source BNF code), I believe we should retain this functionality in case of a user needing to update the codelist with this column intact. In time we may wish to review this decision.


<img width="1977" height="711" alt="image" src="https://github.com/user-attachments/assets/6fc8351b-ad02-4189-93fe-af5b1769b0f2" />

Original converted version (old-style) with the BNF column
<img width="2005" height="1720" alt="image" src="https://github.com/user-attachments/assets/ea9ff1b6-57cd-46bd-bdcf-8c0c75b3bc0b" />

New draft new-style version in the builder, where the user is redirected to after clicking the "create new version" button
<img width="2005" height="1720" alt="image" src="https://github.com/user-attachments/assets/c82ed084-0cb1-439a-bdc0-497a71752685" />
