### PR TITLE
Update the Django Admin token interface

### DIFF
--- a/opencodelists/admin.py
+++ b/opencodelists/admin.py
@@ -1,4 +1,11 @@
+from datetime import UTC
+
 from django.contrib import admin
+from django.http import HttpRequest
+from django.utils import timezone
+from django.utils.formats import date_format
+from rest_framework.authtoken.admin import TokenAdmin as DRFTokenAdmin
+from rest_framework.authtoken.models import TokenProxy
 
 from .models import Membership, Organisation, User
 
@@ -32,3 +39,52 @@ class OrganisationAdmin(admin.ModelAdmin):
     @admin.display(description="No. of Users")
     def member_count(self, obj):
         return obj.users.count()
+
+
+# DRF registers TokenProxy with its own admin class. Replace that registration
+# so we can customise the screen while retaining DRF’s behaviour.
+admin.site.unregister(TokenProxy)
+
+
+@admin.register(TokenProxy)
+class TokenAdmin(DRFTokenAdmin):
+    """
+    Custom formatting for the token admin interface allowing tokens to be
+    created, read, and deleted, but not updated.
+    """
+
+    list_display = ("user", "created_at_formatted")
+    fields = ("user", "key", "created_at_formatted")
+    readonly_fields = ("key", "created_at_formatted")
+    list_select_related = ("user",)
+
+    # Key and created are generated when the token is saved, so only show the
+    # user field on the add form.
+    def get_fields(
+        self, request: HttpRequest, obj: TokenProxy | None = None
+    ) -> tuple[str, ...]:
+        if obj is None:
+            return ("user",)
+
+        return self.fields
+
+    # Django handles add and change permissions separately, allowing tokens to be
+    # created while keeping existing tokens read-only.
+    def has_change_permission(
+        self, request: HttpRequest, obj: TokenProxy | None = None
+    ) -> bool:
+        return False
+
+    @admin.display(
+        description="Created at",
+        ordering="created",
+    )
+    def created_at_formatted(self, obj: TokenProxy) -> str:
+        if obj.created is None:
+            return "-"
+
+        # Always show the timestamp in UTC, independently of the active timezone.
+        created_at = timezone.localtime(obj.created, UTC)
+        formatted_date = date_format(created_at, r"j M Y \a\t H:i")
+
+        return f"{formatted_date} UTC"

--- a/opencodelists/tests/test_admin.py
+++ b/opencodelists/tests/test_admin.py
@@ -1,5 +1,6 @@
 import pytest
 from django.contrib.admin import AdminSite
+from django.test import Client
 from django.urls import reverse
 from rest_framework.authtoken.models import TokenProxy
 
@@ -8,7 +9,9 @@ from ..models import Membership, Organisation, User
 
 
 @pytest.fixture
-def token_admin_client(client, organisation_admin):
+def token_admin_client(client: Client, organisation_admin: User) -> Client:
+    """Return a test client authenticated with Django Admin access"""
+
     organisation_admin.is_admin = True
     organisation_admin.save(update_fields=["is_admin"])
     client.force_login(organisation_admin)

--- a/opencodelists/tests/test_admin.py
+++ b/opencodelists/tests/test_admin.py
@@ -1,7 +1,18 @@
+import pytest
 from django.contrib.admin import AdminSite
+from django.urls import reverse
+from rest_framework.authtoken.models import TokenProxy
 
 from ..admin import OrganisationAdmin, UserAdmin
 from ..models import Membership, Organisation, User
+
+
+@pytest.fixture
+def token_admin_client(client, organisation_admin):
+    organisation_admin.is_admin = True
+    organisation_admin.save(update_fields=["is_admin"])
+    client.force_login(organisation_admin)
+    return client
 
 
 def test_user_admin_organisations(organisation_user, user_without_organisation):
@@ -22,3 +33,74 @@ def test_organisation_admin_member_count(organisation):
         org_admin.member_count(organisation)
         == Membership.objects.filter(organisation=organisation).count()
     )
+
+
+def test_token_admin_list_does_not_show_keys(token_admin_client, organisation_user):
+    response = token_admin_client.get(reverse("admin:authtoken_tokenproxy_changelist"))
+    content = response.content.decode()
+
+    assert response.status_code == 200
+    assert organisation_user.username in content
+    assert organisation_user.api_token not in content
+
+
+def test_token_admin_list_allows_adding_tokens(
+    token_admin_client, user_with_no_api_token
+):
+    add_url = reverse("admin:authtoken_tokenproxy_add")
+    response = token_admin_client.get(reverse("admin:authtoken_tokenproxy_changelist"))
+
+    assert response.status_code == 200
+    assert add_url in response.content.decode()
+
+    response = token_admin_client.post(
+        add_url,
+        {"user": user_with_no_api_token.pk, "_save": "Save"},
+    )
+
+    assert response.status_code == 302
+    assert TokenProxy.objects.filter(user=user_with_no_api_token).exists()
+
+
+def test_token_admin_add_form_only_shows_user(
+    token_admin_client,
+):
+    response = token_admin_client.get(reverse("admin:authtoken_tokenproxy_add"))
+
+    assert response.status_code == 200
+    assert tuple(response.context["adminform"].form.fields) == ("user",)
+
+
+def test_token_admin_view_does_not_allow_changes(token_admin_client, organisation_user):
+    response = token_admin_client.get(
+        reverse(
+            "admin:authtoken_tokenproxy_change",
+            args=[organisation_user.pk],
+        )
+    )
+
+    assert response.status_code == 200
+    assert not response.context["has_change_permission"]
+    assert b'name="_save"' not in response.content
+
+
+def test_token_admin_view_allows_deletion(token_admin_client, organisation_user):
+    delete_url = reverse(
+        "admin:authtoken_tokenproxy_delete",
+        args=[organisation_user.pk],
+    )
+    response = token_admin_client.get(
+        reverse(
+            "admin:authtoken_tokenproxy_change",
+            args=[organisation_user.pk],
+        )
+    )
+
+    assert response.status_code == 200
+    assert response.context["has_delete_permission"]
+    assert delete_url in response.content.decode()
+
+    response = token_admin_client.post(delete_url, {"post": "yes"})
+
+    assert response.status_code == 302
+    assert not TokenProxy.objects.filter(user=organisation_user).exists()


### PR DESCRIPTION
This PR creates a custom admin screen for the auth tokens. That means we can make the following changes:

## List view

- Show tokens as a list of username and created at date
- Format the created at date to show in UTC
- Do not show the auth token here

## Token view

- Show the user, key, and formatted created at date
- Do not allow admins to make any changes to the key, only deletion (for rotation)

## Add token

- Allow admins to select the user
- Hide the key and created at fields from being manually set

## Screenshots

<img width="660" alt="Screenshot of the token interface in Django Admin" src="https://github.com/user-attachments/assets/db9f0f4e-4d34-4dea-9421-8bd0ecaaf8c2" />
