### PR TITLE
Add workflow_dispatch to deploy Action

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -9,6 +9,7 @@ env:
     SSH_AUTH_SOCK: /tmp/agent.sock
 
 on:
+  workflow_dispatch:
   push:
     branches: [main]
 


### PR DESCRIPTION
* allows someone to re-deploy directly from Github Actions without having to push a new commit