### PR TITLE
Update Auth Token admin views

### DIFF
--- a/opencodelists/admin.py
+++ b/opencodelists/admin.py
@@ -1,4 +1,5 @@
 from django.contrib import admin
+from rest_framework.authtoken.admin import TokenAdmin
 
 from .models import Membership, Organisation, User
 
@@ -32,3 +33,8 @@ class OrganisationAdmin(admin.ModelAdmin):
     @admin.display(description="No. of Users")
     def member_count(self, obj):
         return obj.users.count()
+
+
+TokenAdmin.list_display = ["user", "created"]
+TokenAdmin.fields = ["user", "created"]
+TokenAdmin.readonly_fields = ["created"]


### PR DESCRIPTION
Removes API token values from the Django admin to prevent accidental exposure. The list view now displays only the associated user and creation date, while the detail view allows only the user to be changed.

Closes #3147

## Before

<img width="2462" height="1170" alt="" src="https://github.com/user-attachments/assets/28132013-7521-42ae-843b-088eaad1959d" />

## After

<img width="1219" height="584" alt="" src="https://github.com/user-attachments/assets/f56ee3da-1e39-45f2-b8d6-77fd9352bcf6" />
