### PR TITLE
Enable importing of BNF data releases using the new ODP CSV format

### DIFF
--- a/coding_systems/bnf/README.md
+++ b/coding_systems/bnf/README.md
@@ -5,45 +5,40 @@ BNF codes are used to identify anything that is prescribed in England (and maybe
 
 For more details, see [our most popular blog post][0].
 
-We obtain the data from the BSA.
-New releases are published annually, sometimes with unannounced mid-year updates.
-[The release page][1] displays the date and number of each release.
-For example, in "01-01-2024 : 86", "01-01-2024" is the date and "86" is the number.
-The release page displays mid-year updates using the same dates and numbers as their associated releases.
-The date of a mid-year update is contained in the name of the associated zipfile.
-For example, in `20240502_1714657404842_BNF_Code_Information.zip`, the date of the mid-year update is "20240502".
-The number of a mid-year update is the same as that of the associated release.
+We obtain the data from the NHSBSA Open Data Portal (ODP). New releases are published monthly.
+[The release page][1] displays each release for the current calendar year in the Data and Resources section.
+The name of each release contains the date and version for that release, for example, "BNF Code Information - Current - June 2026 Version 90".
+Each monthly release is published as a CSV file whose name includes the year, month and release version. For example, `bnf_code_current_202606_version_90.csv` corresponds to the June 2026 release of version 90.
 
-Download and copy the latest release's zipfile to the BNF data folder on dokku3,
+Download the latest BNF release CSV and copy it to the BNF data folder on dokku3,
 at `/var/lib/dokku/data/storage/opencodelists/data/bnf/`.
 
 To import the data, run:
 
 ```sh
 ./manage.py import_coding_system_data bnf
-/storage/data/bnf/<zipfile>
+/storage/data/bnf/<csvfile>
 --release <release_name>
 --valid-from <valid_from>
 --import-ref <import_ref>
 ```
 
-- `release_name` is the name of the release in `<number> (<date>)` format.
-  `<number>` is the number of the release.
-  (Remember that the number of a mid-year update is the same as that of the associated release.)
-  `<date>` is the date of the release/mid-year update in `YYYY-MM-DD` format.
-- `valid_from` is the date of the release/mid-year update in `YYYY-MM-DD` format.
+- `release_name` is the name of the release in `<version> (<date>)` format.
+  - `<version>` is the release version number.
+  - `<date>` is the release date in `YYYY-MM-DD` format. As the ODP filenames only include the year and month, use the first day of the month (for example, `2026-06-01`).
+- `valid_from` is the date of the release in `YYYY-MM-DD` format.
   (It is *not* the date the data are imported into OpenCodelists.)
-- `import_ref` is an optional reference for any other information. Include the name of the zipfile.
+- `import_ref` is an optional reference for any other information. Include the name of the csv file.
 
-For the example above (`20240502_1714657404842_BNF_Code_Information.zip`),
+For the example above (`bnf_code_current_202606_version_90.csv`),
 the data should be imported with:
 
 ```sh
 dokku run opencodelists python manage.py import_coding_system_data bnf
-/storage/data/bnf/20240502_1714657404842_BNF_Code_Information.zip
---release '86 (2024-05-02)'
---valid-from 2024-05-02
---import-ref 20240502_1714657404842_BNF_Code_Information.zip
+/storage/data/bnf/bnf_code_current_202606_version_90.csv
+--release '90 (2026-06-01)'
+--valid-from 2026-06-01
+--import-ref bnf_code_current_202606_version_90.csv
 ```
 
 After importing, restart the opencodelists app with:
@@ -53,4 +48,4 @@ dokku ps:restart opencodelists
 ```
 
 [0]: https://www.bennett.ox.ac.uk/blog/2017/04/prescribing-data-bnf-codes/
-[1]: https://applications.nhsbsa.nhs.uk/infosystems/data/showDataSelector.do?reportId=126
+[1]: https://opendata.nhsbsa.net/dataset/bnf-code-information-current-year

--- a/coding_systems/bnf/import_data.py
+++ b/coding_systems/bnf/import_data.py
@@ -1,4 +1,5 @@
 import csv
+from pathlib import Path
 
 import structlog
 
@@ -18,10 +19,11 @@ def normalise(name: str) -> str:
 def import_data(
     release_csv, release_name, valid_from, import_ref=None, check_compatibility=True
 ):
-    if not release_csv.lower().endswith(".csv"):
-        raise ValueError(f"Expected file path str ending '.csv', got '{release_csv}'.")
+    release_path = Path(release_csv)
+    if release_path.suffix.lower() != ".csv":
+        raise ValueError(f"Expected file path str ending '.csv', got '{release_path}'.")
     records = {type: set() for type in TYPES}
-    with open(release_csv, newline="") as f:
+    with release_path.open(mode="r", newline="") as f:
         csv_reader = csv.DictReader(f)
         for r in csv_reader:
             parent_code = None

--- a/coding_systems/bnf/import_data.py
+++ b/coding_systems/bnf/import_data.py
@@ -19,12 +19,12 @@ def import_data(
     records = {concept_type: set() for concept_type in TYPES}
     with release_path.open(mode="r", newline="") as f:
         csv_reader = csv.DictReader(f)
-        for r in csv_reader:
+        for row in csv_reader:
             parent_code = None
             for concept_type in TYPES:
                 conecpt_type_column_header = concept_type.upper().replace(" ", "_")
-                name = r[f"BNF_{conecpt_type_column_header}"]
-                code = r[f"BNF_{conecpt_type_column_header}_CODE"]
+                name = row[f"BNF_{conecpt_type_column_header}"]
+                code = row[f"BNF_{conecpt_type_column_header}_CODE"]
                 if "DUMMY" not in name:
                     records[concept_type].add((code, name, parent_code))
                     parent_code = code

--- a/coding_systems/bnf/import_data.py
+++ b/coding_systems/bnf/import_data.py
@@ -1,7 +1,4 @@
 import csv
-from pathlib import Path
-from tempfile import TemporaryDirectory
-from zipfile import ZipFile
 
 import structlog
 
@@ -12,29 +9,28 @@ from coding_systems.bnf.models import TYPES, Concept
 logger = structlog.get_logger()
 
 
-def import_data(
-    release_zipfile, release_name, valid_from, import_ref=None, check_compatibility=True
-):
-    with TemporaryDirectory() as tempdir:
-        release_zip = ZipFile(release_zipfile)
-        logger.info("Extracting", release_zip=release_zip.filename)
-        release_zip.extractall(path=tempdir)
-        paths = list(Path(tempdir).glob("*.csv"))
-        assert len(paths) == 1, (
-            f"Expected 1 and only one .csv file (found {len(paths)})"
-        )
-        path = paths[0]
+# Normalise ODP header names (for example, BNF_CHAPTER_CODE) so they match the
+# BNF field names used by the importer.
+def normalise(name: str) -> str:
+    return name.upper().replace(" ", "_")
 
-        records = {type: set() for type in TYPES}
-        with open(path) as f:
-            for r in csv.DictReader(f):
-                parent_code = None
-                for type in TYPES:
-                    name = r[f"BNF {type}"]
-                    code = r[f"BNF {type} Code"]
-                    if "DUMMY" not in name:
-                        records[type].add((code, name, parent_code))
-                        parent_code = code
+
+def import_data(
+    release_csv, release_name, valid_from, import_ref=None, check_compatibility=True
+):
+    if not release_csv.lower().endswith(".csv"):
+        raise ValueError(f"Expected one .csv file, got '{release_csv}'.")
+    records = {type: set() for type in TYPES}
+    with open(release_csv, newline="") as f:
+        csv_reader = csv.DictReader(f)
+        for r in csv_reader:
+            parent_code = None
+            for type in TYPES:
+                name = r[normalise(f"BNF {type}")]
+                code = r[normalise(f"BNF {type} Code")]
+                if "DUMMY" not in name:
+                    records[type].add((code, name, parent_code))
+                    parent_code = code
 
     with CodingSystemImporter(
         "bnf", release_name, valid_from, import_ref, check_compatibility

--- a/coding_systems/bnf/import_data.py
+++ b/coding_systems/bnf/import_data.py
@@ -22,9 +22,9 @@ def import_data(
         for row in csv_reader:
             parent_code = None
             for concept_type in TYPES:
-                conecpt_type_column_header = concept_type.upper().replace(" ", "_")
-                name = row[f"BNF_{conecpt_type_column_header}"]
-                code = row[f"BNF_{conecpt_type_column_header}_CODE"]
+                concept_type_column_header = concept_type.upper().replace(" ", "_")
+                name = row[f"BNF_{concept_type_column_header}"]
+                code = row[f"BNF_{concept_type_column_header}_CODE"]
 
                 records[concept_type].add((code, name, parent_code))
                 parent_code = code

--- a/coding_systems/bnf/import_data.py
+++ b/coding_systems/bnf/import_data.py
@@ -25,9 +25,9 @@ def import_data(
                 conecpt_type_column_header = concept_type.upper().replace(" ", "_")
                 name = row[f"BNF_{conecpt_type_column_header}"]
                 code = row[f"BNF_{conecpt_type_column_header}_CODE"]
-                if "DUMMY" not in name:
-                    records[concept_type].add((code, name, parent_code))
-                    parent_code = code
+
+                records[concept_type].add((code, name, parent_code))
+                parent_code = code
 
     with CodingSystemImporter(
         "bnf", release_name, valid_from, import_ref, check_compatibility

--- a/coding_systems/bnf/import_data.py
+++ b/coding_systems/bnf/import_data.py
@@ -19,7 +19,7 @@ def import_data(
     release_csv, release_name, valid_from, import_ref=None, check_compatibility=True
 ):
     if not release_csv.lower().endswith(".csv"):
-        raise ValueError(f"Expected one .csv file, got '{release_csv}'.")
+        raise ValueError(f"Expected file path str ending '.csv', got '{release_csv}'.")
     records = {type: set() for type in TYPES}
     with open(release_csv, newline="") as f:
         csv_reader = csv.DictReader(f)

--- a/coding_systems/bnf/import_data.py
+++ b/coding_systems/bnf/import_data.py
@@ -10,37 +10,36 @@ from coding_systems.bnf.models import TYPES, Concept
 logger = structlog.get_logger()
 
 
-# Normalise ODP header names (for example, BNF_CHAPTER_CODE) so they match the
-# BNF field names used by the importer.
-def normalise(name: str) -> str:
-    return name.upper().replace(" ", "_")
-
-
 def import_data(
     release_csv, release_name, valid_from, import_ref=None, check_compatibility=True
 ):
     release_path = Path(release_csv)
     if release_path.suffix.lower() != ".csv":
         raise ValueError(f"Expected file path str ending '.csv', got '{release_path}'.")
-    records = {type: set() for type in TYPES}
+    records = {concept_type: set() for concept_type in TYPES}
     with release_path.open(mode="r", newline="") as f:
         csv_reader = csv.DictReader(f)
         for r in csv_reader:
             parent_code = None
-            for type in TYPES:
-                name = r[normalise(f"BNF {type}")]
-                code = r[normalise(f"BNF {type} Code")]
+            for concept_type in TYPES:
+                conecpt_type_column_header = concept_type.upper().replace(" ", "_")
+                name = r[f"BNF_{conecpt_type_column_header}"]
+                code = r[f"BNF_{conecpt_type_column_header}_CODE"]
                 if "DUMMY" not in name:
-                    records[type].add((code, name, parent_code))
+                    records[concept_type].add((code, name, parent_code))
                     parent_code = code
 
     with CodingSystemImporter(
         "bnf", release_name, valid_from, import_ref, check_compatibility
     ) as database_alias:
-        for type in TYPES:
-            logger.info("Loading BNF type", type=type)
-            for code, name, parent_code in sorted(records[type]):
+        for concept_type in TYPES:
+            logger.info("Loading BNF type", type=concept_type)
+            for code, name, parent_code in sorted(records[concept_type]):
                 Concept.objects.using(database_alias).get_or_create(
                     code=code,
-                    defaults={"name": name, "type": type, "parent_id": parent_code},
+                    defaults={
+                        "name": name,
+                        "type": concept_type,
+                        "parent_id": parent_code,
+                    },
                 )

--- a/coding_systems/bnf/tests/test_import_data.py
+++ b/coding_systems/bnf/tests/test_import_data.py
@@ -46,7 +46,6 @@ def mock_bnf_data_csv_path(tmp_path):
     1. Header row using the NHSBSA ODP column name format.
     2. 7 new concepts.
     3. 3 new concepts and 4 concepts shared with row 2.
-    4. 3 new concepts and 4 DUMMY concepts that should be ignored by the importer.
 
     Returns the path to the directory containing the CSV.
     """
@@ -101,23 +100,6 @@ def mock_bnf_data_csv_path(tmp_path):
             "0101010A0AA",
             "Alexitol sodium 360mg tablets",
             "0101010A0AAAAAA",
-        ],
-        [
-            "2025-09",
-            "Dressings",
-            "20",
-            "Absorbent Cottons",
-            "2001",
-            "DUMMY PARAGRAPH 200100",
-            "200100",
-            "DUMMY SUB-PARAGRAPH 2001000",
-            "2001000",
-            "DUMMY CHEMICAL SUBSTANCE 200100001",
-            "200100001",
-            "DUMMY PRODUCT 20010000101",
-            "20010000101",
-            "Absorbent cotton BP 1988",
-            "20010000101",
         ],
     ]
     csv_dir = tmp_path / "data"
@@ -192,7 +174,7 @@ class TestImportData(BNFDynamicDatabaseTestCaseWithTmpPath):
         assert cs_release.database_alias in settings.DATABASES
 
         # Verify imported concepts.
-        assert Concept.objects.using("bnf_release-1-a_20221001").count() == 13
+        assert Concept.objects.using("bnf_release-1-a_20221001").count() == 10
 
 
 class TestImportDataExisting(BNFDynamicDatabaseTestCaseWithTmpPath):
@@ -230,7 +212,7 @@ class TestImportDataExisting(BNFDynamicDatabaseTestCaseWithTmpPath):
         assert cs_release.import_timestamp > initial_timestamp
 
         # Verify imported concepts.
-        assert Concept.objects.using("bnf_v1-1_20221001").count() == 13
+        assert Concept.objects.using("bnf_v1-1_20221001").count() == 10
 
         # Backup file (created from the existing db file during setup) has been removed.
         assert not self.expected_db_path.with_suffix(".bu").exists()

--- a/coding_systems/bnf/tests/test_import_data.py
+++ b/coding_systems/bnf/tests/test_import_data.py
@@ -137,7 +137,8 @@ def test_import_data_no_csv_files(tmp_path):
     other_file.touch()
 
     with pytest.raises(
-        ValueError, match=re.escape(f"Expected one .csv file, got '{other_file}'")
+        ValueError,
+        match=re.escape(f"Expected file path str ending '.csv', got '{other_file}'"),
     ):
         import_data(str(other_file), release_name="v1", valid_from=date(2022, 10, 1))
 

--- a/coding_systems/bnf/tests/test_import_data.py
+++ b/coding_systems/bnf/tests/test_import_data.py
@@ -2,7 +2,6 @@ import csv
 import re
 from datetime import date
 from unittest.mock import patch
-from zipfile import ZipFile
 
 import pytest
 from django.conf import settings
@@ -40,25 +39,37 @@ def mock_migrate_coding_system_with_error(*args, **kwargs):
 
 
 @pytest.fixture
-def mock_bnf_import_data_path(tmp_path):
-    MOCK_BNF_IMPORT_DATA = [
+def mock_bnf_data_csv_path(tmp_path):
+    """Create a temporary directory containing a mock CSV that includes BNF data in the format available from the NHSBSA ODP API.
+
+    The CSV contains 4 rows and includes 13 concepts:
+    1. Header row using the NHSBSA ODP column name format.
+    2. 7 new concepts.
+    3. 3 new concepts and 4 concepts shared with row 2.
+    4. 3 new concepts and 4 DUMMY concepts that should be ignored by the importer.
+
+    Returns the path to the directory containing the CSV.
+    """
+    mock_bnf_import_data = [
         [
-            "BNF Chapter",
-            "BNF Chapter Code",
-            "BNF Section",
-            "BNF Section Code",
-            "BNF Paragraph",
-            "BNF Paragraph Code",
-            "BNF Subparagraph",
-            "BNF Subparagraph Code",
-            "BNF Chemical Substance",
-            "BNF Chemical Substance Code",
-            "BNF Product",
-            "BNF Product Code",
-            "BNF Presentation",
-            "BNF Presentation Code",
+            "MONTH_YEAR",
+            "BNF_CHAPTER",
+            "BNF_CHAPTER_CODE",
+            "BNF_SECTION",
+            "BNF_SECTION_CODE",
+            "BNF_PARAGRAPH",
+            "BNF_PARAGRAPH_CODE",
+            "BNF_SUBPARAGRAPH",
+            "BNF_SUBPARAGRAPH_CODE",
+            "BNF_CHEMICAL_SUBSTANCE",
+            "BNF_CHEMICAL_SUBSTANCE_CODE",
+            "BNF_PRODUCT",
+            "BNF_PRODUCT_CODE",
+            "BNF_PRESENTATION",
+            "BNF_PRESENTATION_CODE",
         ],
         [
+            "2025-09",
             "Gastro-Intestinal System",
             "01",
             "Dyspepsia and gastro-oesophageal reflux disease",
@@ -75,6 +86,7 @@ def mock_bnf_import_data_path(tmp_path):
             "010101000BBAJA0",
         ],
         [
+            "2025-09",
             "Gastro-Intestinal System",
             "01",
             "Dyspepsia and gastro-oesophageal reflux disease",
@@ -91,6 +103,7 @@ def mock_bnf_import_data_path(tmp_path):
             "0101010A0AAAAAA",
         ],
         [
+            "2025-09",
             "Dressings",
             "20",
             "Absorbent Cottons",
@@ -107,58 +120,26 @@ def mock_bnf_import_data_path(tmp_path):
             "20010000101",
         ],
     ]
-    # write some mock CSV data to be imported
-    # This consists of 4 rows, 13 concepts to be imported:
-    # 1) headers
-    # 2) 7 new concepts
-    # 3) 3 new concepts, 4 concepts shared with (2)
-    # 4) 3 new concepts, 4 DUMMY concepts that are not imported
     csv_dir = tmp_path / "data"
-    csv_dir.mkdir(parents=True)
-    with open(csv_dir / "data.csv", "w") as csv_file:
+    csv_dir.mkdir()
+    with open(
+        csv_dir / "data.csv",
+        "w",
+        newline="",
+    ) as csv_file:
         writer = csv.writer(csv_file)
-        writer.writerows(MOCK_BNF_IMPORT_DATA)
-    zip_path = tmp_path / "archive.zip"
-    with ZipFile(tmp_path / "archive.zip", mode="w") as archive:
-        archive.write(csv_dir / "data.csv", arcname="data.csv")
-    yield str(zip_path)
+        writer.writerows(mock_bnf_import_data)
+    return str(csv_dir / "data.csv")
 
 
 def test_import_data_no_csv_files(tmp_path):
     other_file = tmp_path / "test.txt"
     other_file.touch()
-    with ZipFile(tmp_path / "test.zip", "w") as zip_file:
-        zip_file.write(other_file, arcname=other_file.name)
 
     with pytest.raises(
-        AssertionError, match=re.escape("Expected 1 and only one .csv file (found 0)")
+        ValueError, match=re.escape(f"Expected one .csv file, got '{other_file}'")
     ):
-        import_data(
-            str(tmp_path / "test.zip"), release_name="v1", valid_from=date(2022, 10, 1)
-        )
-
-
-def test_import_data_too_many_csv_files(tmp_path):
-    # 2 csv files in the resource dir
-    subdir = tmp_path / "subdir"
-    subdir.mkdir(parents=True)
-    for filename in ["test.csv", "test1.csv"]:
-        (tmp_path / subdir / filename).touch()
-    # csvs in subdirs are ignored
-    (subdir / tmp_path / "testsubdir").mkdir(parents=True)
-    (subdir / tmp_path / "testsubdir" / "test1.csv").touch()
-    with ZipFile(tmp_path / "archive.zip", mode="w") as archive:
-        for file_path in subdir.iterdir():
-            archive.write(file_path, arcname=file_path.name)
-
-    with pytest.raises(
-        AssertionError, match=re.escape("Expected 1 and only one .csv file (found 2)")
-    ):
-        import_data(
-            str(tmp_path / "archive.zip"),
-            release_name="v1",
-            valid_from=date(2022, 10, 1),
-        )
+        import_data(str(other_file), release_name="v1", valid_from=date(2022, 10, 1))
 
 
 class BNFDynamicDatabaseTestCaseWithTmpPath(DynamicDatabaseTestCaseWithTmpPath):
@@ -172,8 +153,8 @@ class BNFDynamicDatabaseTestCaseWithTmpPath(DynamicDatabaseTestCaseWithTmpPath):
     # Set this fixture as `autouse`:
     # all the tests currently using this class use this import data fixture.
     @pytest.fixture(autouse=True)
-    def _set_import_data_from_fixture(self, mock_bnf_import_data_path):
-        self.import_data_path = mock_bnf_import_data_path
+    def _set_import_data_from_fixture(self, mock_bnf_data_csv_path):
+        self.import_data_path = mock_bnf_data_csv_path
 
 
 class TestImportData(BNFDynamicDatabaseTestCaseWithTmpPath):
@@ -254,7 +235,7 @@ class TestImportDataExisting(BNFDynamicDatabaseTestCaseWithTmpPath):
         assert not self.expected_db_path.with_suffix(".bu").exists()
 
 
-def test_import_error(coding_systems_tmp_path, mock_bnf_import_data_path):
+def test_import_error(coding_systems_tmp_path, mock_bnf_data_csv_path):
     cs_release_count = CodingSystemRelease.objects.count()
 
     # raise an exception after the migrate command; i.e after the setup that
@@ -262,7 +243,7 @@ def test_import_error(coding_systems_tmp_path, mock_bnf_import_data_path):
     with patch("coding_systems.bnf.import_data.csv.DictReader", side_effect=Exception):
         with pytest.raises(Exception):
             import_data(
-                mock_bnf_import_data_path,
+                mock_bnf_data_csv_path,
                 release_name="release 2",
                 valid_from=date(2022, 10, 1),
                 import_ref="Ref",
@@ -276,7 +257,7 @@ def test_import_error(coding_systems_tmp_path, mock_bnf_import_data_path):
     ).exists()
 
 
-def test_import_setup_error(coding_systems_tmp_path, mock_bnf_import_data_path):
+def test_import_setup_error(coding_systems_tmp_path, mock_bnf_data_csv_path):
     cs_release_count = CodingSystemRelease.objects.count()
 
     # raise an exception during the setup that creates the CodingSystemRelease and the new db file
@@ -286,7 +267,7 @@ def test_import_setup_error(coding_systems_tmp_path, mock_bnf_import_data_path):
     ):
         with pytest.raises(Exception, match="expected exception"):
             import_data(
-                mock_bnf_import_data_path,
+                mock_bnf_data_csv_path,
                 release_name="release 3",
                 valid_from=date(2022, 10, 1),
                 import_ref="Ref",
@@ -305,7 +286,7 @@ def test_import_setup_error(coding_systems_tmp_path, mock_bnf_import_data_path):
 
 
 def test_import_setup_error_existing_release(
-    coding_systems_tmp_path, mock_bnf_import_data_path
+    coding_systems_tmp_path, mock_bnf_data_csv_path
 ):
     # set up an existing CodingSystemRelease and db file
     cs_release = CodingSystemRelease.objects.create(
@@ -330,7 +311,7 @@ def test_import_setup_error_existing_release(
     ):
         with pytest.raises(Exception, match="expected exception"):
             import_data(
-                mock_bnf_import_data_path,
+                mock_bnf_data_csv_path,
                 release_name="v_error_setup",
                 valid_from=date(2022, 10, 1),
                 import_ref="Ref",


### PR DESCRIPTION
Addresses steps 1 and 2 listed in #3167

Previously, we imported BNF data from ZIP archives downloaded from the NHSBSA Information Services Portal (ISP).
The ISP is no longer available, and BNF releases are now published as CSV files via the [NHSBSA Open Data Portal (ODP)](https://opendata.nhsbsa.net/dataset/bnf-code-information-current-year).

Due to this change, our existing BNF data import process no longer works, and we cannot update the BNF data in production. This is blocking a user’s research work ([Slack thread](https://bennettoxford.slack.com/archives/C07AA91BZD4/p1775145012702679?thread_ts=1764597164.852979&cid=C07AA91BZD4)).

This PR makes the minimum updates required to support importing the latest BNF releases from the ODP
while preserving the existing import workflow described in `coding_systems/bnf/README.md`.

Importer updates

- import BNF releases directly from CSV files
- normalise CSV headers to support the new ODP column naming convention
- remove ZIP extraction from the BNF import path

Test updates

- update the BNF import fixture to match the test CSV data to the new ODP CSV format
- update the import tests to use the new CSV fixture

#### Local testing
<details>
  <summary>**Expand this**</summary>

Assess current local state of BNF data:

What does the most current release look like:
`just manage shell`
```
>>> from coding_systems.versioning.models import CodingSystemRelease
>>> 
>>> latest = (
...     CodingSystemRelease.objects
...     .filter(coding_system="bnf")
...     .latest("valid_from")
... )
>>> print(latest)
86 (2024-09-02) (valid from 2024-09-02)
>>> print(latest.release_name)
86 (2024-09-02)
>>> print(latest.valid_from)
2024-09-02
>>> print(latest.import_ref)
20240902_1725264234995_BNF_Code_Information.zip
>>> print(latest.state)
ready
>>> print(latest.database_alias)
bnf_86-2024-09-02_20240902

Which BNF releases do I have available locally?
>>> for release in (
...     CodingSystemRelease.objects
...     .filter(coding_system="bnf")
...     .order_by("-valid_from")
... ):
...     print(
...         release.release_name,
...         release.valid_from,
...         release.state,
...         release.database_alias,
...     )
... 

86 (2024-09-02) 2024-09-02 ready bnf_86-2024-09-02_20240902
86 (2024-05-02) 2024-05-02 ready bnf_86-2024-05-02_20240502
86 (2024-01-01) 2024-01-01 ready bnf_86-2024-01-01_20240101
84 (2023-11-01) 2023-11-01 ready bnf_84-2023-11-01_20231101
84 (2023-09-01) 2023-09-01 ready bnf_84-2023-09-01_20230901
84 (2023-05-02) 2023-05-02 ready bnf_84-2023-05-02_20230502
84 (2023-02-01) 2023-02-01 ready bnf_84-2023-02-01_20230201
82 (2022-11-01) 2022-11-01 ready bnf_82-2022-11-01_20221101
unknown 1900-01-01 ready bnf_unknown_19000101
```

Run local dev server: `just run`

Check what we can see for MontyTest3 BNF codelist in the browser:
<img width="1620" height="796" alt="Screenshot from 2026-07-23 08-18-19" src="https://github.com/user-attachments/assets/7999de7b-6ce3-471f-ad86-ebcda7dbcd01" />

Locally run the import:
`python manage.py import_coding_system_data   bnf   /home/katie/opencodelists-bnf-data/bnf_code_current_202503_version_88.csv   --release "88 (2025-03-01)"   --valid-from 2025-03-01   --import-ref bnf_code_current_202503_version_88.csv`
```
Setting up database...
Operations to perform:
  Apply all migrations: bnf
Running migrations:
  Applying bnf.0001_squashed_0002_20250425... OK
Importing bnf data...
2026-07-29T11:27:42.601251Z [info     ] Loading BNF type               [coding_systems.bnf.import_data] type=Chapter
2026-07-29T11:27:42.673715Z [info     ] Loading BNF type               [coding_systems.bnf.import_data] type=Section
2026-07-29T11:27:43.234549Z [info     ] Loading BNF type               [coding_systems.bnf.import_data] type=Paragraph
2026-07-29T11:27:44.285959Z [info     ] Loading BNF type               [coding_systems.bnf.import_data] type=Subparagraph
2026-07-29T11:27:45.594722Z [info     ] Loading BNF type               [coding_systems.bnf.import_data] type='Chemical Substance'
2026-07-29T11:27:52.766660Z [info     ] Loading BNF type               [coding_systems.bnf.import_data] type=Product
2026-07-29T11:29:55.178517Z [info     ] Loading BNF type               [coding_systems.bnf.import_data] type=Presentation
Found 348 versions compatible with previous release 'bnf_86-2024-09-02_20240902'.
100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 348/348 [00:07<00:00, 44.31it/s]
348 checked; 69 identified as compatible

*** APP RESTART REQUIRED ***
Import complete; run `dokku ps:restart opencodelists` to restart the app
```

Post-import checks:
`just manage shell`
```
>>> from coding_systems.versioning.models import CodingSystemRelease
>>> 
>>> release = (
...     CodingSystemRelease.objects
...     .filter(coding_system="bnf")
...     .latest("valid_from")
... )
>>> print(release.release_name)
88 (2025-03-01)
>>> print(release.valid_from)
2025-03-01
>>> print(release.state)
ready
>>> print(release.database_alias)
bnf_88-2025-03-01_20250301

>>> for release in (
...     CodingSystemRelease.objects
...     .filter(coding_system="bnf")
...     .order_by("-valid_from")
... ):
...     print(
...         release.release_name,
...         release.valid_from,
...         release.state,
...         release.database_alias,
...     )
... 
88 (2025-03-01) 2025-03-01 ready bnf_88-2025-03-01_20250301
86 (2024-09-02) 2024-09-02 ready bnf_86-2024-09-02_20240902
86 (2024-05-02) 2024-05-02 ready bnf_86-2024-05-02_20240502
86 (2024-01-01) 2024-01-01 ready bnf_86-2024-01-01_20240101
84 (2023-11-01) 2023-11-01 ready bnf_84-2023-11-01_20231101
84 (2023-09-01) 2023-09-01 ready bnf_84-2023-09-01_20230901
84 (2023-05-02) 2023-05-02 ready bnf_84-2023-05-02_20230502
84 (2023-02-01) 2023-02-01 ready bnf_84-2023-02-01_20230201
82 (2022-11-01) 2022-11-01 ready bnf_82-2022-11-01_20221101
unknown 1900-01-01 ready bnf_unknown_19000101
```

Try and create a codelist in the browser and check its made with the newly imported BNF **Coding system release**:
<img width="1681" height="812" alt="Screenshot from 2026-07-29 12-38-37" src="https://github.com/user-attachments/assets/08721d41-618c-4bd9-a941-f2999bfb75b2" />

We can check for a **Latest compatible release** for the MontyTest3 codelist, which is showing as the newly imported BNF **Coding system release**:
<img width="1681" height="812" alt="Screenshot from 2026-07-29 12-43-46" src="https://github.com/user-attachments/assets/45b3aed4-ba93-4295-b239-ffc30935fd49" />

To note, I have subsequently tested this more comprehensively (locally) by importing all available monthly releases from the ODP API:

- fresh downloads of all the BNF coding system databases 
- a sanitised core database backup 
- Checked a few pre-existing BNF codelists, e.g. these prod codelists with old release: http://localhost:7000/codelist/bristol/multimorbidity_prescription_analgesics_opiods_exc_migraine_bnf/26bf845e/ 
- http://localhost:7000/codelist/bristol/multimorbidity_prescription_epilepsy_bnf/14a2f833/#full-list 
Then, for each release imported I have:
- done a BNF-to-dmd conversion, 
- checked we get latest compatible releases from BNF codelists made with previous release versions
- cloned a BNF codelist
- uploaded a csv to create a BNF codelist
- created a BNF codelist via the builder
- saved for review and published BNF codelists created via draft and csv

I was able to complete all of the above successfully. 

This is my local state for BNF data coding system releases:
```
>>> from coding_systems.versioning.models import CodingSystemRelease
>>> for release in (CodingSystemRelease.objects.filter(coding_system="bnf").order_by("-valid_from")):
...     print(release.release_name, release.state, release.database_alias)
... 
90 (2026-07-01) ready bnf_90-2026-07-01_20260701
90 (2026-06-01) ready bnf_90-2026-06-01_20260601
90 (2026-05-01) ready bnf_90-2026-05-01_20260501
90 (2026-04-01) ready bnf_90-2026-04-01_20260401
90 (2026-03-01) ready bnf_90-2026-03-01_20260301
90 (2026-02-01) ready bnf_90-2026-02-01_20260201
90 (2026-01-01) ready bnf_90-2026-01-01_20260101
88 (2025-12-01) ready bnf_88-2025-12-01_20251201
88 (2025-11-01) ready bnf_88-2025-11-01_20251101
88 (2025-10-01) ready bnf_88-2025-10-01_20251001
88 (2025-09-01) ready bnf_88-2025-09-01_20250901
88 (2025-08-01) ready bnf_88-2025-08-01_20250801
88 (2025-07-01) ready bnf_88-2025-07-01_20250701
88 (2025-06-01) ready bnf_88-2025-06-01_20250601
88 (2025-05-01) ready bnf_88-2025-05-01_20250501
88 (2025-04-01) ready bnf_88-2025-04-01_20250401
88 (2025-03-01) ready bnf_88-2025-03-01_20250301
86 (2024-09-02) ready bnf_86-2024-09-02_20240902
86 (2024-05-02) ready bnf_86-2024-05-02_20240502
86 (2024-01-01) ready bnf_86-2024-01-01_20240101
84 (2023-11-01) ready bnf_84-2023-11-01_20231101
84 (2023-09-01) ready bnf_84-2023-09-01_20230901
84 (2023-05-02) ready bnf_84-2023-05-02_20230502
84 (2023-02-01) ready bnf_84-2023-02-01_20230201
82 (2022-11-01) ready bnf_82-2022-11-01_20221101
unknown ready bnf_unknown_19000101
```

</details>

#### To note

- Future work is planned to improve and potentially automate our BNF data importing process (#3168).
- The [team are aware](https://bennettoxford.slack.com/archives/C069SADHP1Q/p1785756807111759?thread_ts=1785225233.886609&cid=C069SADHP1Q) of the date duplication in the display of the Coding system release and Lastest compatible version in the UI; fixing this is out-of-scope for the current PR (#3191 ).