### PR TITLE
Harden repository configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -25,3 +25,13 @@ updates:
       timezone: "Europe/London"
     cooldown:
       default-days: 7
+
+  - package-ecosystem: "pre-commit"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "08:00"
+      timezone: "Europe/London"
+    cooldown:
+      default-days: 7

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,7 +15,6 @@ updates:
         dependency-type: "production"
       development-dependencies:
         dependency-type: "development"
-    open-pull-requests-limit: 20
 
   - package-ecosystem: "github-actions"
     directory: "/"
@@ -26,4 +25,3 @@ updates:
       timezone: "Europe/London"
     cooldown:
       default-days: 7
-    open-pull-requests-limit: 20

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -9,9 +9,7 @@ on:
     - cron: "13 13 * * 3"
 
 permissions:
-  actions: read
   contents: read
-  security-events: write
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
@@ -21,6 +19,10 @@ jobs:
   analyze:
     name: Analyze
     runs-on: ubuntu-latest
+
+    permissions:
+      actions: read
+      security-events: write
 
     strategy:
       fail-fast: false


### PR DESCRIPTION
* Remove `open-pull-requests-limit`.
* Add pre-commit to Dependabot checks.
* Move permissions from workflow to job level.