### PR TITLE
Only show release valid_from date if not BNF

### DIFF
--- a/assets/src/scripts/__tests__/components/Layout/Header.test.tsx
+++ b/assets/src/scripts/__tests__/components/Layout/Header.test.tsx
@@ -136,4 +136,27 @@ describe("Header component", () => {
       screen.queryByText(metadata.coding_system_release.valid_from),
     ).not.toBeInTheDocument();
   });
+
+  it("does not append valid_from for BNF coding system releases", () => {
+    const bnfReleaseName = "86 (2024-09-02)";
+    const bnfMetadata = {
+      ...metadata,
+      coding_system_id: "bnf",
+      coding_system_release: {
+        release_name: bnfReleaseName,
+        valid_from: "2024-09-02",
+      },
+    };
+
+    render(
+      <Header isEditable={isEditable} counts={counts} metadata={bnfMetadata} />,
+    );
+
+    const release = screen.getByText(
+      "Coding system release",
+    ).nextElementSibling;
+    expect(release).toHaveTextContent(bnfReleaseName);
+    expect(release).toHaveTextContent("2024-09-02");
+    expect(release?.textContent).toBe(bnfReleaseName);
+  });
 });

--- a/assets/src/scripts/components/Layout/Header.tsx
+++ b/assets/src/scripts/components/Layout/Header.tsx
@@ -12,6 +12,10 @@ export default function Header({
   isEditable: PageData["isEditable"];
   metadata: PageData["metadata"];
 }) {
+  const { coding_system_release: release } = metadata;
+  const showReleaseDate =
+    metadata.coding_system_id !== "bnf" && Boolean(release.valid_from);
+
   return (
     <div className="border-bottom mb-3 pb-3">
       <div className="d-flex flex-row justify-content-between gap-2 mb-2">
@@ -33,10 +37,8 @@ export default function Header({
         <div className="list-group-item py-1 px-2">
           <dt>Coding system release</dt>
           <dd className="mb-0">
-            {metadata.coding_system_release.release_name}{" "}
-            {metadata.coding_system_release.valid_from ? (
-              <>({metadata.coding_system_release.valid_from})</>
-            ) : null}
+            {release.release_name}
+            {showReleaseDate && ` (${release.valid_from})`}
           </dd>
         </div>
 

--- a/codelists/tests/views/test_version.py
+++ b/codelists/tests/views/test_version.py
@@ -92,6 +92,19 @@ def test_medication_banner_not_visible_for_current_coding_system_release(
     assert b"Medication codelists can quickly become outdated" not in rsp.content
 
 
+def test_bnf_compatible_release_does_not_show_valid_from_date(
+    client, create_coding_system_release, bnf_version_asthma
+):
+    compatible_release = create_coding_system_release("bnf")
+    bnf_version_asthma.compatible_releases.add(compatible_release)
+
+    rsp = client.get(bnf_version_asthma.get_absolute_url())
+    soup = BeautifulSoup(rsp.content, "html.parser")
+    label = soup.find("dt", string=re.compile("Latest compatible release"))
+
+    assert label.find_next_sibling("dd").get_text(strip=True) == "test_bnf"
+
+
 def test_medication_banner_for_owner_of_codelist(
     client,
     create_coding_system_release,

--- a/templates/codelists/version.html
+++ b/templates/codelists/version.html
@@ -127,7 +127,10 @@
             </dt>
             <dd class="mb-0">
               {% with release=clv.compatible_releases.last %}
-                {{ release.release_name }} ({{ release.valid_from|date:'Y-m-d'}})
+                {{ release.release_name }}
+                {% if clv.coding_system_id != "bnf" %}
+                  ({{ release.valid_from|date:'Y-m-d' }})
+                {% endif %}
               {% endwith %}
             </dd>
           </div>


### PR DESCRIPTION
As the BNF release_name contains the date it is valid from.

No more double dates like this:
<img width="393" height="66" alt="" src="https://github.com/user-attachments/assets/2e7f5486-08fd-4e83-ae21-9b7a7ea9bd3b" />
