### PR TITLE
Add cwd and envFile to OCL debug launcher

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -9,6 +9,8 @@
       "django": true,
       "autoStartBrowser": true,
       "program": "${workspaceFolder}/manage.py",
+      "cwd": "${workspaceFolder}",
+      "envFile": "${workspaceFolder}/.env",
       "justMyCode": true
     },
     {


### PR DESCRIPTION
The "Launch OpenCodelists" debug script worked locally for me, but not for all users as the `.env` file failed to be located due to environment differences. Adding the `cwd` and `envFile` properties explicitly, fixes this.