### PR TITLE
Allow re-inclusion of previously-deleted orphan codes

### DIFF
--- a/builder/actions.py
+++ b/builder/actions.py
@@ -44,7 +44,7 @@ def get_codes_to_keep(codeset_version, potential_codes):
     1. Explicitly included in the codelist
     2. Descendants of included codes
     """
-    # Get all explicitly included codes on the codelist
+    # Get all explicitly and implicitly included codes on the codelist
     all_included_codes = codeset_version.codeset.codes()
 
     # Build a list of codes_to_keep from this search, consisting of any included codes or their descendants
@@ -158,8 +158,22 @@ def update_code_statuses(*, draft, updates):
     new_codeset = draft.codeset.update(updates)
 
     status_to_new_code = defaultdict(list)
+    previous_codes = draft.codeset.all_codes()
     for code, status in new_codeset.code_to_status.items():
         status_to_new_code[status].append(code)
+        # check for re-inclusion of previously-deleted orphan codes
+        if code not in previous_codes and status == "+":
+            codes_to_reinclude = (
+                {code} | draft.hierarchy.descendants(code)
+            ) - previous_codes
+            CodeObj.objects.bulk_create(
+                CodeObj(
+                    version=draft,
+                    code=code_to_reinclude,
+                    status=status if code_to_reinclude == code else "(+)",
+                )
+                for code_to_reinclude in codes_to_reinclude
+            )
 
     for status, codes in status_to_new_code.items():
         draft.code_objs.filter(code__in=codes).update(status=status)

--- a/builder/tests/test_actions.py
+++ b/builder/tests/test_actions.py
@@ -527,3 +527,71 @@ def test_cannot_save_with_incomplete_code_status(
 
     draft.refresh_from_db()
     assert draft.is_draft
+
+
+def test_re_inclusion_of_previously_deleted_orphan(draft_with_some_searches):
+    draft = draft_with_some_searches
+
+    # Double check that codes and statuses are as expected
+    assert dict(draft.code_objs.values_list("code", "status")) == {
+        # Part of arthritis search
+        "439656005": "+",  # Arthritis of elbow
+        "202855006": "(+)",  # Lateral epicondylitis
+        "3723001": "-",  # Arthritis
+        # Orphans
+        "128133004": "+",  # Disorder of elbow
+        "429554009": "(+)",  # Arthropathy of elbow
+        "35185008": "(+)",  # Enthesopathy of elbow region
+        "73583000": "(+)",  # Epicondylitis
+        "239964003": "(+)",  # Soft tissue lesion of elbow region
+        "156659008": "+",  # (Epicondylitis &/or ...
+    }
+
+    # Deselect orphaned disorder of elbow
+    actions.update_code_statuses(draft=draft, updates=[("128133004", "?")])
+    assert dict(draft.code_objs.values_list("code", "status")) == {
+        # Part of arthritis search
+        "439656005": "+",  # Arthritis of elbow
+        "202855006": "(+)",  # Lateral epicondylitis
+        "3723001": "-",  # Arthritis
+        # Orphans
+        "156659008": "+",  # (Epicondylitis &/or ...
+    }
+
+    # Delete arthritis search
+    actions.delete_search(
+        search=draft.searches.get(term="arthritis"),
+    )
+    assert (
+        dict(draft.code_objs.values_list("code", "status"))
+        == {
+            # Orphans
+            "156659008": "+",  # (Epicondylitis &/or ...  kept because included
+            "439656005": "+",  # Arthritis of elbow         kept because included
+            "202855006": "(+)",  # Lateral epicondylitis    kept because descendant of included
+        }
+    )
+
+    # Exclude orphaned code - it should disappear
+    actions.update_code_statuses(draft=draft, updates=[("156659008", "-")])
+    assert (
+        dict(draft.code_objs.values_list("code", "status"))
+        == {
+            # Orphans
+            "439656005": "+",  # Arthritis of elbow         kept because included
+            "202855006": "(+)",  # Lateral epicondylitis    kept because descendant of included
+        }
+    )
+
+    # Re-include previously orphaned code - it should appear with its descendants
+    actions.update_code_statuses(draft=draft, updates=[("35185008", "+")])
+    assert (
+        dict(draft.code_objs.values_list("code", "status"))
+        == {
+            # Orphans
+            "439656005": "+",  # Arthritis of elbow         kept because included
+            "202855006": "(+)",  # Lateral epicondylitis    kept because descendant of included
+            "35185008": "+",  # Enthesopathy of elbow region    kept because included
+            "73583000": "(+)",  # Epicondylitis                   kept because descendant of included
+        }
+    )


### PR DESCRIPTION
Fixes #3206 

Orphan codes are codes without related searches. This may be because the search whence they came has been deleted or because the codelist was originally created by upload of a csv file.

Orphan codes that are not either themselves included or descendants of an included code are deleted to avoid a broken state (see #2639 ). However, the UI is not immediately synchronised with the db state after this deletion and so they persist in the UI.
A user may then request inclusion of these deleted-in-the-db-but-persisting-in-the-ui codes which would then show them as included in the UI but they would still be missing from the db. Upon saving the codelist, these codes and their descendants would disappear from view, in some cases leaving completely empty codelists (see #3206 ).

This PR ensures that any request for inclusion of codes is honoured in the db such that what the user sees in the builder view is what they will get when they click save.