### PR TITLE
Update BNF data importer to handle ISP CSV headers

### DIFF
--- a/coding_systems/bnf/import_data.py
+++ b/coding_systems/bnf/import_data.py
@@ -19,6 +19,9 @@ def import_data(
     records = {concept_type: set() for concept_type in TYPES}
     with release_path.open(mode="r", newline="") as f:
         csv_reader = csv.DictReader(f)
+        csv_reader.fieldnames = [
+            header.upper().replace(" ", "_") for header in csv_reader.fieldnames
+        ]
         for row in csv_reader:
             parent_code = None
             for concept_type in TYPES:

--- a/coding_systems/bnf/tests/test_import_data.py
+++ b/coding_systems/bnf/tests/test_import_data.py
@@ -39,19 +39,92 @@ def mock_migrate_coding_system_with_error(*args, **kwargs):
 
 
 @pytest.fixture
-def mock_bnf_data_csv_path(tmp_path):
+def mock_isp_bnf_data_csv_path(tmp_path):
+    """Create a temporary directory containing a mock CSV that includes BNF data in the format previously available from the NHSBSA Information Services Portal (ISP).
+
+    The CSV contains 3 rows and includes 10 concepts:
+    1. Header row using the NHSBSA ISP column name format.
+    2. 7 new concepts.
+    3. 3 new concepts and 4 concepts shared with row 2.
+
+    Returns the path to the CSV file.
+    """
+    mock_isp_bnf_import_data = [
+        [
+            "BNF Chapter",
+            "BNF Chapter Code",
+            "BNF Section",
+            "BNF Section Code",
+            "BNF Paragraph",
+            "BNF Paragraph Code",
+            "BNF Subparagraph",
+            "BNF Subparagraph Code",
+            "BNF Chemical Substance",
+            "BNF Chemical Substance Code",
+            "BNF Product",
+            "BNF Product Code",
+            "BNF Presentation",
+            "BNF Presentation Code",
+        ],
+        [
+            "Gastro-Intestinal System",
+            "01",
+            "Dyspepsia and gastro-oesophageal reflux disease",
+            "0101",
+            "Antacids and simeticone",
+            "010101",
+            "Antacids and simeticone",
+            "0101010",
+            "Other antacid and simeticone preparations",
+            "010101000",
+            "Proprietary compound preparation BNF 0101010",
+            "010101000BB",
+            "Indigestion mixture",
+            "010101000BBAJA0",
+        ],
+        [
+            "Gastro-Intestinal System",
+            "01",
+            "Dyspepsia and gastro-oesophageal reflux disease",
+            "0101",
+            "Antacids and simeticone",
+            "010101",
+            "Antacids and simeticone",
+            "0101010",
+            "Alexitol sodium",
+            "0101010A0",
+            "Alexitol sodium",
+            "0101010A0AA",
+            "Alexitol sodium 360mg tablets",
+            "0101010A0AAAAAA",
+        ],
+    ]
+    csv_dir = tmp_path / "data"
+    csv_dir.mkdir()
+    with open(
+        csv_dir / "data.csv",
+        "w",
+        newline="",
+    ) as csv_file:
+        writer = csv.writer(csv_file)
+        writer.writerows(mock_isp_bnf_import_data)
+    return str(csv_dir / "data.csv")
+
+
+@pytest.fixture
+def mock_odp_bnf_data_csv_path(tmp_path):
     """Create a temporary directory containing a mock CSV that includes BNF data in the format available from the NHSBSA ODP API.
 
-    The CSV contains 4 rows and includes 13 concepts:
+    The CSV contains 3 rows and includes 10 concepts:
     1. Header row using the NHSBSA ODP column name format.
     2. 7 new concepts.
     3. 3 new concepts and 4 concepts shared with row 2.
 
-    Returns the path to the directory containing the CSV.
+    Returns the path to the CSV file.
     """
-    mock_bnf_import_data = [
+    mock_odp_bnf_import_data = [
         [
-            "MONTH_YEAR",
+            "YEAR_MONTH",
             "BNF_CHAPTER",
             "BNF_CHAPTER_CODE",
             "BNF_SECTION",
@@ -110,7 +183,7 @@ def mock_bnf_data_csv_path(tmp_path):
         newline="",
     ) as csv_file:
         writer = csv.writer(csv_file)
-        writer.writerows(mock_bnf_import_data)
+        writer.writerows(mock_odp_bnf_import_data)
     return str(csv_dir / "data.csv")
 
 
@@ -136,25 +209,31 @@ class BNFDynamicDatabaseTestCaseWithTmpPath(DynamicDatabaseTestCaseWithTmpPath):
     # Set this fixture as `autouse`:
     # all the tests currently using this class use this import data fixture.
     @pytest.fixture(autouse=True)
-    def _set_import_data_from_fixture(self, mock_bnf_data_csv_path):
-        self.import_data_path = mock_bnf_data_csv_path
+    def _set_import_data_from_fixture(self, mock_odp_bnf_data_csv_path):
+        self.import_data_path = mock_odp_bnf_data_csv_path
 
 
-class TestImportData(BNFDynamicDatabaseTestCaseWithTmpPath):
+# Use DynamicDatabaseTestCaseWithTmpPath instead of BNFDynamicDatabaseTestCaseWithTmpPath so that we can test with the mock isp-format BNF data fixture
+class TestImportISPData(DynamicDatabaseTestCaseWithTmpPath):
+    """Test importing BNF coding system data using CSV files with the old ISP column header format and dynamic database creation."""
+
     db_aliases = [
-        "bnf_release-1-a_20221001",
+        "bnf_isp-release-1-a_20221001",
     ]
     coding_system_subpath_name = "bnf"
 
+    @pytest.fixture(autouse=True)
+    def _set_import_data_from_fixture(self, mock_isp_bnf_data_csv_path):
+        self.import_data_path = mock_isp_bnf_data_csv_path
+
     @pytest.mark.usefixtures("setup_coding_systems")
-    def test_import_data(self):
-        """Test importing BNF coding system data with dynamic database creation."""
+    def test_import_isp_format_data(self):
         cs_release_count = CodingSystemRelease.objects.count()
 
         # Execute import.
         import_data(
             self.import_data_path,
-            release_name="release 1 A",
+            release_name="isp release 1 A",
             valid_from=date(2022, 10, 1),
             import_ref="Ref",
         )
@@ -165,7 +244,7 @@ class TestImportData(BNFDynamicDatabaseTestCaseWithTmpPath):
 
         # Verify release details.
         assert cs_release.coding_system == "bnf"
-        assert cs_release.release_name == "release 1 A"
+        assert cs_release.release_name == "isp release 1 A"
         assert cs_release.valid_from == date(2022, 10, 1)
         assert cs_release.import_ref == "Ref"
 
@@ -174,7 +253,45 @@ class TestImportData(BNFDynamicDatabaseTestCaseWithTmpPath):
         assert cs_release.database_alias in settings.DATABASES
 
         # Verify imported concepts.
-        assert Concept.objects.using("bnf_release-1-a_20221001").count() == 10
+        assert Concept.objects.using("bnf_isp-release-1-a_20221001").count() == 10
+
+
+class TestImportODPData(BNFDynamicDatabaseTestCaseWithTmpPath):
+    """Test importing BNF coding system data using the mock ODP-header-format CSV file and dynamic database creation."""
+
+    db_aliases = [
+        "bnf_odp-release-1-a_20221001",
+    ]
+    coding_system_subpath_name = "bnf"
+
+    @pytest.mark.usefixtures("setup_coding_systems")
+    def test_import_odp_format_data(self):
+        cs_release_count = CodingSystemRelease.objects.count()
+
+        # Execute import.
+        import_data(
+            self.import_data_path,
+            release_name="odp release 1 A",
+            valid_from=date(2022, 10, 1),
+            import_ref="Ref",
+        )
+
+        # Verify CodingSystemRelease creation.
+        assert CodingSystemRelease.objects.count() == cs_release_count + 1
+        cs_release = CodingSystemRelease.objects.latest("id")
+
+        # Verify release details.
+        assert cs_release.coding_system == "bnf"
+        assert cs_release.release_name == "odp release 1 A"
+        assert cs_release.valid_from == date(2022, 10, 1)
+        assert cs_release.import_ref == "Ref"
+
+        # Verify database file creation and configuration.
+        assert self.expected_db_path.exists()
+        assert cs_release.database_alias in settings.DATABASES
+
+        # Verify imported concepts.
+        assert Concept.objects.using("bnf_odp-release-1-a_20221001").count() == 10
 
 
 class TestImportDataExisting(BNFDynamicDatabaseTestCaseWithTmpPath):
@@ -218,7 +335,7 @@ class TestImportDataExisting(BNFDynamicDatabaseTestCaseWithTmpPath):
         assert not self.expected_db_path.with_suffix(".bu").exists()
 
 
-def test_import_error(coding_systems_tmp_path, mock_bnf_data_csv_path):
+def test_import_error(coding_systems_tmp_path, mock_odp_bnf_data_csv_path):
     cs_release_count = CodingSystemRelease.objects.count()
 
     # raise an exception after the migrate command; i.e after the setup that
@@ -226,7 +343,7 @@ def test_import_error(coding_systems_tmp_path, mock_bnf_data_csv_path):
     with patch("coding_systems.bnf.import_data.csv.DictReader", side_effect=Exception):
         with pytest.raises(Exception):
             import_data(
-                mock_bnf_data_csv_path,
+                mock_odp_bnf_data_csv_path,
                 release_name="release 2",
                 valid_from=date(2022, 10, 1),
                 import_ref="Ref",
@@ -240,7 +357,7 @@ def test_import_error(coding_systems_tmp_path, mock_bnf_data_csv_path):
     ).exists()
 
 
-def test_import_setup_error(coding_systems_tmp_path, mock_bnf_data_csv_path):
+def test_import_setup_error(coding_systems_tmp_path, mock_odp_bnf_data_csv_path):
     cs_release_count = CodingSystemRelease.objects.count()
 
     # raise an exception during the setup that creates the CodingSystemRelease and the new db file
@@ -250,7 +367,7 @@ def test_import_setup_error(coding_systems_tmp_path, mock_bnf_data_csv_path):
     ):
         with pytest.raises(Exception, match="expected exception"):
             import_data(
-                mock_bnf_data_csv_path,
+                mock_odp_bnf_data_csv_path,
                 release_name="release 3",
                 valid_from=date(2022, 10, 1),
                 import_ref="Ref",
@@ -269,7 +386,7 @@ def test_import_setup_error(coding_systems_tmp_path, mock_bnf_data_csv_path):
 
 
 def test_import_setup_error_existing_release(
-    coding_systems_tmp_path, mock_bnf_data_csv_path
+    coding_systems_tmp_path, mock_odp_bnf_data_csv_path
 ):
     # set up an existing CodingSystemRelease and db file
     cs_release = CodingSystemRelease.objects.create(
@@ -294,7 +411,7 @@ def test_import_setup_error_existing_release(
     ):
         with pytest.raises(Exception, match="expected exception"):
             import_data(
-                mock_bnf_data_csv_path,
+                mock_odp_bnf_data_csv_path,
                 release_name="v_error_setup",
                 valid_from=date(2022, 10, 1),
                 import_ref="Ref",


### PR DESCRIPTION
We previously (2f6905e, as part of #3167) updated the BNF data importer to handle the new CSV column header format used by the ODP (e.g. `BNF_CHAPTER_CODE`) . However, the BNF releases from 2024-10-01 to 2025-02-01 are only available as CSVs using the old ISP column header format (e.g. `BNF Chapter Code`).

This update transforms the CSV column headers before processing the data, so that both formats are represented internally in the same way (e.g. `BNF_CHAPTER_CODE`). This allows the importer to support both the old ISP and new ODP CSV header formats while keeping the rest of the import logic unchanged.

<details>
<summary> Local testing </summary>

A new August BNF data CSV was released by the [ODP](https://opendata.nhsbsa.net/dataset/bnf-code-information-current-year). Let's test the updated script by trying to import this locally.

First, check what we have locally:
```
just manage shell

>>> from coding_systems.versioning.models import CodingSystemRelease
>>> for release in (CodingSystemRelease.objects.filter(coding_system="bnf").order_by("-valid_from")):
...     print(release.release_name,release.valid_from,release.state,release.database_alias)
... 
90 (2026-07-01) 2026-07-01 ready bnf_90-2026-07-01_20260701
90 (2026-06-01) 2026-06-01 ready bnf_90-2026-06-01_20260601
90 (2026-05-01) 2026-05-01 ready bnf_90-2026-05-01_20260501
90 (2026-04-01) 2026-04-01 ready bnf_90-2026-04-01_20260401
90 (2026-03-01) 2026-03-01 ready bnf_90-2026-03-01_20260301
90 (2026-02-01) 2026-02-01 ready bnf_90-2026-02-01_20260201
90 (2026-01-01) 2026-01-01 ready bnf_90-2026-01-01_20260101
88 (2025-12-01) 2025-12-01 ready bnf_88-2025-12-01_20251201
88 (2025-11-01) 2025-11-01 ready bnf_88-2025-11-01_20251101
88 (2025-10-01) 2025-10-01 ready bnf_88-2025-10-01_20251001
88 (2025-09-01) 2025-09-01 ready bnf_88-2025-09-01_20250901
88 (2025-08-01) 2025-08-01 ready bnf_88-2025-08-01_20250801
88 (2025-07-01) 2025-07-01 ready bnf_88-2025-07-01_20250701
88 (2025-06-01) 2025-06-01 ready bnf_88-2025-06-01_20250601
88 (2025-05-01) 2025-05-01 ready bnf_88-2025-05-01_20250501
88 (2025-04-01) 2025-04-01 ready bnf_88-2025-04-01_20250401
88 (2025-03-01) 2025-03-01 ready bnf_88-2025-03-01_20250301
88 (2025-02-01) 2025-02-01 ready bnf_88-2025-02-01_20250201
88 (2025-01-01) 2025-01-01 ready bnf_88-2025-01-01_20250101
86 (2024-12-01) 2024-12-01 ready bnf_86-2024-12-01_20241201
86 (2024-11-01) 2024-11-01 ready bnf_86-2024-11-01_20241101
86 (2024-10-01) 2024-10-01 ready bnf_86-2024-10-01_20241001
86 (2024-09-02) 2024-09-02 ready bnf_86-2024-09-02_20240902
86 (2024-05-02) 2024-05-02 ready bnf_86-2024-05-02_20240502
86 (2024-01-01) 2024-01-01 ready bnf_86-2024-01-01_20240101
84 (2023-11-01) 2023-11-01 ready bnf_84-2023-11-01_20231101
84 (2023-09-01) 2023-09-01 ready bnf_84-2023-09-01_20230901
84 (2023-05-02) 2023-05-02 ready bnf_84-2023-05-02_20230502
84 (2023-02-01) 2023-02-01 ready bnf_84-2023-02-01_20230201
82 (2022-11-01) 2022-11-01 ready bnf_82-2022-11-01_20221101
unknown 1900-01-01 ready bnf_unknown_19000101
```

Cool, now try importing the new CSV:

```
python manage.py import_coding_system_data bnf /home/katie/opencodelists-bnf-data/bnf_code_current_202608_version_90.csv --release "90 (2026-08-01)" --valid-from 2026-08-01 --import-ref bnf_codes_202608_version_90.csv
Setting up database...
Operations to perform:
  Apply all migrations: bnf
Running migrations:
  Applying bnf.0001_squashed_0002_20250425... OK
Importing bnf data...
2026-09-07T13:34:27.493289Z [info     ] Loading BNF type               [coding_systems.bnf.import_data] type=Chapter
2026-09-07T13:34:27.564850Z [info     ] Loading BNF type               [coding_systems.bnf.import_data] type=Section
2026-09-07T13:34:28.134332Z [info     ] Loading BNF type               [coding_systems.bnf.import_data] type=Paragraph
2026-09-07T13:34:29.188845Z [info     ] Loading BNF type               [coding_systems.bnf.import_data] type=Subparagraph
2026-09-07T13:34:30.492190Z [info     ] Loading BNF type               [coding_systems.bnf.import_data] type='Chemical Substance'
2026-09-07T13:34:37.827004Z [info     ] Loading BNF type               [coding_systems.bnf.import_data] type=Product
2026-09-07T13:36:11.819832Z [info     ] Loading BNF type               [coding_systems.bnf.import_data] type=Presentation
Found 82 versions compatible with previous release 'bnf_90-2026-07-01_20260701'.
100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 82/82 [00:00<00:00, 94.57it/s]
82 checked; 78 identified as compatible

*** APP RESTART REQUIRED ***
Import complete; run `dokku ps:restart opencodelists` to restart the app
```
Back into the shell to check we have a new `CodingSystemRelease` object:

```
>>> for release in (CodingSystemRelease.objects.filter(coding_system="bnf").order_by("-valid_from")):
...     print(release.release_name,release.valid_from,release.state,release.database_alias)
... 
90 (2026-08-01) 2026-08-01 ready bnf_90-2026-08-01_20260801
90 (2026-07-01) 2026-07-01 ready bnf_90-2026-07-01_20260701
90 (2026-06-01) 2026-06-01 ready bnf_90-2026-06-01_20260601
90 (2026-05-01) 2026-05-01 ready bnf_90-2026-05-01_20260501
90 (2026-04-01) 2026-04-01 ready bnf_90-2026-04-01_20260401
90 (2026-03-01) 2026-03-01 ready bnf_90-2026-03-01_20260301
90 (2026-02-01) 2026-02-01 ready bnf_90-2026-02-01_20260201
90 (2026-01-01) 2026-01-01 ready bnf_90-2026-01-01_20260101
88 (2025-12-01) 2025-12-01 ready bnf_88-2025-12-01_20251201
88 (2025-11-01) 2025-11-01 ready bnf_88-2025-11-01_20251101
88 (2025-10-01) 2025-10-01 ready bnf_88-2025-10-01_20251001
88 (2025-09-01) 2025-09-01 ready bnf_88-2025-09-01_20250901
88 (2025-08-01) 2025-08-01 ready bnf_88-2025-08-01_20250801
88 (2025-07-01) 2025-07-01 ready bnf_88-2025-07-01_20250701
88 (2025-06-01) 2025-06-01 ready bnf_88-2025-06-01_20250601
88 (2025-05-01) 2025-05-01 ready bnf_88-2025-05-01_20250501
88 (2025-04-01) 2025-04-01 ready bnf_88-2025-04-01_20250401
88 (2025-03-01) 2025-03-01 ready bnf_88-2025-03-01_20250301
88 (2025-02-01) 2025-02-01 ready bnf_88-2025-02-01_20250201
88 (2025-01-01) 2025-01-01 ready bnf_88-2025-01-01_20250101
86 (2024-12-01) 2024-12-01 ready bnf_86-2024-12-01_20241201
86 (2024-11-01) 2024-11-01 ready bnf_86-2024-11-01_20241101
86 (2024-10-01) 2024-10-01 ready bnf_86-2024-10-01_20241001
86 (2024-09-02) 2024-09-02 ready bnf_86-2024-09-02_20240902
86 (2024-05-02) 2024-05-02 ready bnf_86-2024-05-02_20240502
86 (2024-01-01) 2024-01-01 ready bnf_86-2024-01-01_20240101
84 (2023-11-01) 2023-11-01 ready bnf_84-2023-11-01_20231101
84 (2023-09-01) 2023-09-01 ready bnf_84-2023-09-01_20230901
84 (2023-05-02) 2023-05-02 ready bnf_84-2023-05-02_20230502
84 (2023-02-01) 2023-02-01 ready bnf_84-2023-02-01_20230201
82 (2022-11-01) 2022-11-01 ready bnf_82-2022-11-01_20221101
unknown 1900-01-01 ready bnf_unknown_19000101
```

*Restart the app*

Try and build a codelist locally with the new release, and check old releases to see new release compatibility:

Draft codelist:
<img width="1174" height="765" alt="image" src="https://github.com/user-attachments/assets/30fe30b4-d602-4abd-abf9-d1c17e6f24bc" />

Under review:
<img width="1174" height="765" alt="image" src="https://github.com/user-attachments/assets/db615d8f-ba84-4aa9-ac16-0a1e83132773" />

Create codelist with uploaded csv:
<img width="1174" height="765" alt="image" src="https://github.com/user-attachments/assets/d1004ab5-f6a5-4096-9c07-2563d93875af" />

Clone the uploaded-csv codelist:
<img width="1174" height="765" alt="image" src="https://github.com/user-attachments/assets/95eb6fde-6b40-4f06-bb50-7d2338f2e640" />

Convert the uploaded codelist to dm+d:
<img width="1174" height="765" alt="image" src="https://github.com/user-attachments/assets/bc9e5227-5e03-4932-af86-901c9a632720" />

Latest compatible release:
<img width="1174" height="765" alt="image" src="https://github.com/user-attachments/assets/0326890a-efb4-4fbe-b1f7-603c71a40a46" />

</details>