### PR TITLE
Add code comments to explain `Save draft` button behaviour for draft codelists

### DIFF
--- a/assets/src/scripts/components/Header/ManagementForm.tsx
+++ b/assets/src/scripts/components/Header/ManagementForm.tsx
@@ -68,6 +68,8 @@ export default function ManagementForm({ counts }: ManagementFormProps) {
           </OverlayTrigger>
         )}
         <button
+          // "Save draft" does not save a draft codelist; this POST just
+          // redirects back to the draft codelist (see builder/views.py).
           className="btn btn-outline-primary ml-2"
           name="action"
           type="submit"

--- a/builder/views.py
+++ b/builder/views.py
@@ -64,6 +64,11 @@ def _handle_post(request, draft):
         )
         return redirect(draft)
     elif action == "save-draft":
+        # Note: the "Save draft" button does not save a draft
+        # codelist, we only redirect the user back to the draft codelist.
+        # We do this to avoid users wondering how to save their work.
+        # Updates to draft codelists are saved to the backend when a
+        # user changes the status of a code in the builder, via update_code_statuses().
         messages.add_message(request, messages.INFO, "Your changes have been saved")
         return redirect(draft.codelist)
     elif action == "discard":


### PR DESCRIPTION
The behaviour of the `Save draft` button isn't immediately obvious. Despite its name, it doesn't save the draft codelist; changes are saved as code statuses are updated.

This PR adds comments to clarify the current behaviour and make it easier to understand in future.